### PR TITLE
Establish portable protocol 1.0 candidate foundations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,227 @@
+name: CI
+
+"on":
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: "1"
+
+jobs:
+  style-and-api:
+    name: style-and-api
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88
+        with:
+          toolchain: stable
+          components: clippy,rustfmt
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Lint all targets
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+      - name: Check public documentation
+        env:
+          RUSTDOCFLAGS: -D warnings
+        run: cargo doc --workspace --all-features --no-deps
+
+  native-test:
+    name: native-test (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88
+        with:
+          toolchain: stable
+
+      - name: Run workspace tests
+        run: cargo test --workspace --all-targets --all-features
+
+      - name: Run documentation tests
+        run: cargo test --workspace --doc --all-features
+
+      - name: Check release profile
+        run: cargo check --workspace --release --all-features
+
+  msrv:
+    name: msrv (1.85.0)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install minimum supported Rust
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88
+        with:
+          toolchain: 1.85.0
+
+      - name: Check every workspace target on MSRV
+        run: cargo check --workspace --all-targets --all-features
+
+      - name: Run tests on MSRV
+        run: cargo test --workspace --all-features
+
+  portable-target:
+    name: portable-target (${{ matrix.target }})
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - aarch64-unknown-none
+          - riscv64gc-unknown-none-elf
+          - wasm32-unknown-unknown
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install stable Rust and target
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88
+        with:
+          toolchain: stable
+          targets: ${{ matrix.target }}
+
+      - name: Check no_std and alloc portable crates
+        run: >-
+          cargo check
+          -p virtio-accel-proto
+          -p virtio-accel-core
+          -p virtio-accel-device
+          -p virtio-accel
+          --target ${{ matrix.target }}
+          --no-default-features
+
+      - name: Check std reference code on Wasm
+        if: matrix.target == 'wasm32-unknown-unknown'
+        run: cargo check --workspace --target wasm32-unknown-unknown --all-features
+
+  feature-sets:
+    name: feature-sets-and-dependencies
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88
+        with:
+          toolchain: stable
+
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 # v2.83.2
+        with:
+          tool: cargo-hack@0.6.45
+          fallback: none
+
+      - name: Check feature powerset
+        run: cargo hack check --workspace --feature-powerset --no-dev-deps
+
+      - name: Check portable dependency features
+        run: bash ci/check-portable-dependencies.sh
+
+  dependency-policy:
+    name: dependency-policy
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Check advisories, licenses, bans, and sources
+        uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
+        with:
+          rust-version: "1.85.0"
+          command: check
+          arguments: --all-features
+
+  fuzz-smoke:
+    name: fuzz-smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Detect fuzz workspace
+        id: fuzz
+        shell: bash
+        run: |
+          if [[ -f fuzz/Cargo.toml ]]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "No fuzz workspace yet; issue #26 will add the first targets."
+          fi
+
+      - name: Install nightly Rust
+        if: steps.fuzz.outputs.present == 'true'
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88
+        with:
+          toolchain: nightly-2026-07-13
+
+      - name: Install cargo-fuzz
+        if: steps.fuzz.outputs.present == 'true'
+        uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 # v2.83.2
+        with:
+          tool: cargo-fuzz@0.13.2
+          fallback: none
+
+      - name: Run bounded smoke iterations
+        if: steps.fuzz.outputs.present == 'true'
+        shell: bash
+        run: |
+          mapfile -t targets < <(cargo fuzz list)
+          if (( ${#targets[@]} == 0 )); then
+            echo "fuzz/Cargo.toml exists but defines no fuzz targets" >&2
+            exit 1
+          fi
+          for target in "${targets[@]}"; do
+            cargo fuzz run "$target" -- -runs=256 -max_total_time=20
+          done

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "memchr"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -24,6 +36,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -80,6 +134,7 @@ name = "virtio-accel-proto"
 version = "0.1.0"
 dependencies = [
  "bitflags",
+ "serde_json",
  "zerocopy",
 ]
 
@@ -102,3 +157,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "virtio-accel"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+rust-version.workspace = true
 description = "Portable Rust foundations for a virtio accelerator device"
 publish = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,11 @@ rust-version = "1.85"
 
 [workspace.dependencies]
 bitflags = { version = "2.13.1", default-features = false }
+serde_json = "1.0.149"
 zerocopy = { version = "0.8.54", default-features = false, features = ["derive"] }
 virtio-accel-core = { path = "crates/virtio-accel-core" }
 virtio-accel-device = { path = "crates/virtio-accel-device" }
+virtio-accel-mock = { path = "crates/virtio-accel-mock" }
 virtio-accel-proto = { path = "crates/virtio-accel-proto" }
 
 [dependencies]
@@ -35,4 +37,4 @@ virtio-accel-device.workspace = true
 virtio-accel-proto.workspace = true
 
 [dev-dependencies]
-virtio-accel-mock = { path = "crates/virtio-accel-mock" }
+virtio-accel-mock.workspace = true

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,176 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2026 MicroPerceptron contributors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ claimed virtio device ID.
 
 ## Workspace
 
-- `virtio-accel-proto`: `no_std`, pointer-free, little-endian draft wire structures.
+- `virtio-accel-proto`: `no_std`, pointer-free, little-endian protocol 1.0 wire structures.
 - `virtio-accel-core`: `no_std` backend lifecycle, memory, program, queue, and event contracts.
 - `virtio-accel-device`: `no_std + alloc` device-owned state, including bounded generational IDs.
 - `virtio-accel-mock`: cross-platform in-memory backend that exercises the complete lifecycle.
@@ -34,20 +34,23 @@ transport adapters (future: rust-vmm, bare metal, tests)
 Neither the wire protocol nor the device-state layer is allowed to leak transport descriptors or
 guest addresses into a provider backend.
 
-## Current draft surface
+## Frozen protocol surface
 
-The protocol defines fixed headers and payloads for device discovery, contexts, buffers, programs,
-queues, submissions, and events. Unknown opcodes remain plain integers until validated, so decoding
-untrusted bytes never creates an invalid Rust enum.
+Portable protocol 1.0 defines fixed headers and payloads for device discovery, contexts, buffers,
+programs, execution queues, submissions, and events. Unknown opcodes, statuses, and event states
+remain raw integers until validated, so decoding untrusted bytes never creates an invalid Rust enum.
 
 Core execution is asynchronous at the ownership boundary: a successful submit returns an event,
 while an indeterminate failure must also return an event that retains the operation's resources.
 Guest-visible object IDs are opaque, kind-tagged, generational, and never reused after generation
 exhaustion.
 
-The [portable protocol foundations](docs/specification.md) define the normative v1 terminology,
-object model, compatibility rules, and mandatory baseline. See
-[docs/architecture.md](docs/architecture.md) for the implementation invariants and
+The [portable protocol foundations](docs/specification.md) define the normative terminology, object
+model, compatibility rules, and mandatory baseline. The exact byte layouts live in
+[docs/wire-abi.md](docs/wire-abi.md), the command-chain rules in
+[docs/virtqueue.md](docs/virtqueue.md), and independent golden artifacts under
+[conformance/v1.0](conformance/v1.0/README.md). See
+[docs/architecture.md](docs/architecture.md) for implementation invariants and
 [docs/portability.md](docs/portability.md) for the enforced target matrix.
 
 ## Development
@@ -58,5 +61,6 @@ cargo clippy --workspace --all-targets --all-features -- -D warnings
 cargo test --workspace --all-targets --all-features
 ```
 
-The protocol is pre-standardization work. Numeric opcodes, feature bits, and payload layouts may
-change until the device model is validated and a virtio specification proposal begins.
+The project remains pre-standardization work and claims no Virtio device ID. Protocol 1.0 numeric
+opcodes, statuses, and payload layouts are nevertheless frozen for independent implementation;
+incompatible changes require a new protocol major version.

--- a/README.md
+++ b/README.md
@@ -34,11 +34,12 @@ transport adapters (future: rust-vmm, bare metal, tests)
 Neither the wire protocol nor the device-state layer is allowed to leak transport descriptors or
 guest addresses into a provider backend.
 
-## Frozen protocol surface
+## Protocol 1.0 candidate surface
 
-Portable protocol 1.0 defines fixed headers and payloads for device discovery, contexts, buffers,
-programs, execution queues, submissions, and events. Unknown opcodes, statuses, and event states
-remain raw integers until validated, so decoding untrusted bytes never creates an invalid Rust enum.
+The portable protocol 1.0 candidate defines fixed headers and payloads for device discovery,
+contexts, buffers, programs, execution queues, submissions, and events. Unknown opcodes, statuses,
+and event states remain raw integers until validated, so decoding untrusted bytes never creates an
+invalid Rust enum.
 
 Core execution is asynchronous at the ownership boundary: a successful submit returns an event,
 while an indeterminate failure must also return an event that retains the operation's resources.
@@ -62,5 +63,13 @@ cargo test --workspace --all-targets --all-features
 ```
 
 The project remains pre-standardization work and claims no Virtio device ID. Protocol 1.0 numeric
-opcodes, statuses, and payload layouts are nevertheless frozen for independent implementation;
+opcodes, statuses, and payload layouts are versioned review inputs for independent implementation.
+They remain pre-release candidates until the final freeze audit in
+[issue #33](https://github.com/MicroPerceptron/virtio-accel/issues/33). Candidate changes must follow
+the coordinated change procedure in [docs/wire-abi.md](docs/wire-abi.md); after the freeze,
 incompatible changes require a new protocol major version.
+
+## License
+
+Licensed under either of [Apache License, Version 2.0](LICENSE-APACHE) or [MIT license](LICENSE-MIT)
+at your option.

--- a/README.md
+++ b/README.md
@@ -45,15 +45,17 @@ while an indeterminate failure must also return an event that retains the operat
 Guest-visible object IDs are opaque, kind-tagged, generational, and never reused after generation
 exhaustion.
 
-See [docs/architecture.md](docs/architecture.md) for the invariants and the next implementation
-boundary.
+The [portable protocol foundations](docs/specification.md) define the normative v1 terminology,
+object model, compatibility rules, and mandatory baseline. See
+[docs/architecture.md](docs/architecture.md) for the implementation invariants and
+[docs/portability.md](docs/portability.md) for the enforced target matrix.
 
 ## Development
 
 ```sh
 cargo fmt --all -- --check
-cargo clippy --workspace --all-targets -- -D warnings
-cargo test --workspace
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo test --workspace --all-targets --all-features
 ```
 
 The protocol is pre-standardization work. Numeric opcodes, feature bits, and payload layouts may

--- a/ci/check-portable-dependencies.sh
+++ b/ci/check-portable-dependencies.sh
@@ -7,7 +7,7 @@ readonly packages=(
 )
 
 for package in "${packages[@]}"; do
-  tree="$(cargo tree -p "$package" -e features --prefix none)"
+  tree="$(cargo tree -p "$package" -e normal,build,features --prefix none)"
   if grep -Eq 'feature "(std|alloc)"' <<<"$tree"; then
     echo "$package unexpectedly enables a std or alloc dependency feature:" >&2
     echo "$tree" >&2

--- a/ci/check-portable-dependencies.sh
+++ b/ci/check-portable-dependencies.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly packages=(
+  virtio-accel-proto
+  virtio-accel-core
+)
+
+for package in "${packages[@]}"; do
+  tree="$(cargo tree -p "$package" -e features --prefix none)"
+  if grep -Eq 'feature "(std|alloc)"' <<<"$tree"; then
+    echo "$package unexpectedly enables a std or alloc dependency feature:" >&2
+    echo "$tree" >&2
+    exit 1
+  fi
+done
+
+echo "portable dependency features are clean"

--- a/conformance/v1.0/README.md
+++ b/conformance/v1.0/README.md
@@ -1,0 +1,16 @@
+# Protocol 1.0 conformance artifacts
+
+This directory contains implementation-independent inputs for the frozen portable wire contract.
+
+- [`layout.json`](layout.json) records protocol constants and every structure size, byte alignment,
+  and field offset.
+- [`vectors.json`](vectors.json) contains canonical hexadecimal bytes for the device configuration,
+  all 15 request opcodes, every success and command-specific response shape, all event states, and
+  reviewed malformed/unknown boundary cases.
+
+The files are deliberately plain JSON with hexadecimal byte strings so implementations do not need
+Rust tooling to consume them.
+
+Ordinary tests parse these checked-in files as inputs. They do not regenerate them. An intentional
+protocol revision must update the normative specification, Rust layout assertions, manifest, and
+vectors in one reviewed change. Incompatible changes require a new versioned directory.

--- a/conformance/v1.0/README.md
+++ b/conformance/v1.0/README.md
@@ -1,6 +1,6 @@
 # Protocol 1.0 conformance artifacts
 
-This directory contains implementation-independent inputs for the frozen portable wire contract.
+This directory contains implementation-independent inputs for the portable protocol 1.0 candidate.
 
 - [`layout.json`](layout.json) records protocol constants and every structure size, byte alignment,
   and field offset.
@@ -12,5 +12,6 @@ The files are deliberately plain JSON with hexadecimal byte strings so implement
 Rust tooling to consume them.
 
 Ordinary tests parse these checked-in files as inputs. They do not regenerate them. An intentional
-protocol revision must update the normative specification, Rust layout assertions, manifest, and
-vectors in one reviewed change. Incompatible changes require a new versioned directory.
+candidate revision must update the normative specification, Rust layout assertions, manifest, and
+vectors in one reviewed change. After the final freeze audit, incompatible changes require a new
+versioned directory.

--- a/conformance/v1.0/layout.json
+++ b/conformance/v1.0/layout.json
@@ -1,0 +1,216 @@
+{
+  "schema": "virtio-accel-layout-1",
+  "protocol": {
+    "major": 1,
+    "minor": 0
+  },
+  "queue": {
+    "command_index": 0,
+    "baseline_count": 1,
+    "hard_max_chain_descriptors": 256,
+    "min_max_request_bytes": 97,
+    "min_max_response_bytes": 92,
+    "hard_max_request_bytes": 16777216,
+    "hard_max_response_bytes": 16777216,
+    "hard_max_bindings": 4096
+  },
+  "features": {
+    "baseline": "0x0000000000000000",
+    "reserved": {
+      "MULTI_QUEUE": "0x0000000000000001",
+      "EVENT_QUEUE": "0x0000000000000002",
+      "EXTERNAL_MEMORY": "0x0000000000000004",
+      "TIMELINE_FENCES": "0x0000000000000008",
+      "SECURE_CONTEXTS": "0x0000000000000010"
+    }
+  },
+  "opcodes": {
+    "GET_DEVICE_INFO": "0x0001",
+    "CREATE_CONTEXT": "0x0100",
+    "DESTROY_CONTEXT": "0x0101",
+    "ALLOCATE_BUFFER": "0x0200",
+    "FREE_BUFFER": "0x0201",
+    "WRITE_BUFFER": "0x0202",
+    "READ_BUFFER": "0x0203",
+    "LOAD_PROGRAM": "0x0300",
+    "UNLOAD_PROGRAM": "0x0301",
+    "CREATE_QUEUE": "0x0400",
+    "DESTROY_QUEUE": "0x0401",
+    "SUBMIT": "0x0500",
+    "POLL_EVENT": "0x0501",
+    "CANCEL_EVENT": "0x0502",
+    "DESTROY_EVENT": "0x0503"
+  },
+  "statuses": {
+    "OK": 0,
+    "UNSUPPORTED": 1,
+    "INCOMPATIBLE": 2,
+    "INVALID_ARGUMENT": 3,
+    "OUT_OF_BOUNDS": 4,
+    "BUSY": 5,
+    "OUT_OF_MEMORY": 6,
+    "RESOURCE_LIMIT": 7,
+    "DEADLINE_EXPIRED": 8,
+    "DEVICE_LOST": 9,
+    "PERMISSION_DENIED": 10,
+    "STALE_OBJECT": 11,
+    "INTERNAL_ERROR": 65535
+  },
+  "event_states": {
+    "PENDING": 0,
+    "COMPLETE": 1,
+    "FAILED": 2,
+    "CANCELLED": 3
+  },
+  "structures": {
+    "WireConfig": {
+      "size": 16,
+      "align": 1,
+      "fields": {
+        "protocol_major": 0,
+        "protocol_minor": 2,
+        "command_queue_count": 4,
+        "max_chain_descriptors": 6,
+        "max_request_bytes": 8,
+        "max_response_bytes": 12
+      }
+    },
+    "RequestHeader": {
+      "size": 16,
+      "align": 1,
+      "fields": {
+        "opcode": 0,
+        "flags": 2,
+        "payload_bytes": 4,
+        "request_id": 8
+      }
+    },
+    "ResponseHeader": {
+      "size": 16,
+      "align": 1,
+      "fields": {
+        "status": 0,
+        "flags": 2,
+        "payload_bytes": 4,
+        "request_id": 8
+      }
+    },
+    "WireDeviceInfo": {
+      "size": 76,
+      "align": 1,
+      "fields": {
+        "uuid": 0,
+        "class": 16,
+        "reserved": 18,
+        "vendor_id": 20,
+        "device_id": 24,
+        "capabilities": 28,
+        "max_contexts": 36,
+        "max_buffers_per_context": 40,
+        "max_programs_per_context": 44,
+        "max_queues_per_context": 48,
+        "max_events_per_context": 52,
+        "max_bindings_per_submission": 56,
+        "max_buffer_bytes": 60,
+        "max_artifact_bytes": 68
+      }
+    },
+    "CreateContextRequest": {
+      "size": 8,
+      "align": 1,
+      "fields": {
+        "flags": 0,
+        "reserved": 4
+      }
+    },
+    "ObjectPayload": {
+      "size": 8,
+      "align": 1,
+      "fields": {
+        "object_id": 0
+      }
+    },
+    "AllocateBufferRequest": {
+      "size": 40,
+      "align": 1,
+      "fields": {
+        "context_id": 0,
+        "bytes": 8,
+        "alignment": 16,
+        "memory_domain": 24,
+        "reserved0": 25,
+        "usage": 32,
+        "reserved1": 36
+      }
+    },
+    "TransferBufferRequest": {
+      "size": 24,
+      "align": 1,
+      "fields": {
+        "buffer_id": 0,
+        "offset": 8,
+        "bytes": 16
+      }
+    },
+    "LoadProgramRequest": {
+      "size": 80,
+      "align": 1,
+      "fields": {
+        "context_id": 0,
+        "format": 8,
+        "flags": 12,
+        "target": 16,
+        "payload_bytes": 64,
+        "resident_bytes": 72
+      }
+    },
+    "CreateQueueRequest": {
+      "size": 16,
+      "align": 1,
+      "fields": {
+        "context_id": 0,
+        "flags": 8,
+        "reserved": 12
+      }
+    },
+    "SubmitRequest": {
+      "size": 32,
+      "align": 1,
+      "fields": {
+        "queue_id": 0,
+        "program_id": 8,
+        "binding_count": 16,
+        "flags": 20,
+        "timeout_ns": 24
+      }
+    },
+    "WireBinding": {
+      "size": 32,
+      "align": 1,
+      "fields": {
+        "buffer_id": 0,
+        "offset": 8,
+        "bytes": 16,
+        "slot": 24,
+        "access": 28,
+        "reserved": 29
+      }
+    },
+    "SubmitResponse": {
+      "size": 8,
+      "align": 1,
+      "fields": {
+        "event_id": 0
+      }
+    },
+    "WireEventState": {
+      "size": 8,
+      "align": 1,
+      "fields": {
+        "state": 0,
+        "error": 2,
+        "reserved": 4
+      }
+    }
+  }
+}

--- a/conformance/v1.0/vectors.json
+++ b/conformance/v1.0/vectors.json
@@ -1,0 +1,301 @@
+{
+  "schema": "virtio-accel-vectors-1",
+  "protocol": "1.0",
+  "note": "Immutable reviewed inputs. Ordinary tests must not regenerate this file.",
+  "frames": [
+    {
+      "name": "config_minimum",
+      "kind": "config",
+      "hex": "0100000001000200610000005c000000"
+    },
+    {
+      "name": "config_maximum",
+      "kind": "config",
+      "hex": "01000000010000010000000100000001"
+    },
+    {
+      "name": "request_get_device_info",
+      "kind": "request",
+      "opcode": "GET_DEVICE_INFO",
+      "hex": "01000000000000000807060504030201"
+    },
+    {
+      "name": "request_create_context",
+      "kind": "request",
+      "opcode": "CREATE_CONTEXT",
+      "hex": "000100000800000008070605040302010000000000000000"
+    },
+    {
+      "name": "request_destroy_context",
+      "kind": "request",
+      "opcode": "DESTROY_CONTEXT",
+      "hex": "010100000800000008070605040302011817161514131211"
+    },
+    {
+      "name": "request_allocate_buffer",
+      "kind": "request",
+      "opcode": "ALLOCATE_BUFFER",
+      "hex": "0002000028000000080706050403020118171615141312110010000000000000400000000000000003000000000000000c00000000000000"
+    },
+    {
+      "name": "request_free_buffer",
+      "kind": "request",
+      "opcode": "FREE_BUFFER",
+      "hex": "010200000800000008070605040302012827262524232221"
+    },
+    {
+      "name": "request_write_buffer",
+      "kind": "request",
+      "opcode": "WRITE_BUFFER",
+      "hex": "020200001c0000000807060504030201282726252423222104000000000000000400000000000000deadbeef"
+    },
+    {
+      "name": "request_read_buffer",
+      "kind": "request",
+      "opcode": "READ_BUFFER",
+      "hex": "03020000180000000807060504030201282726252423222104000000000000000400000000000000"
+    },
+    {
+      "name": "request_load_program",
+      "kind": "request",
+      "opcode": "LOAD_PROGRAM",
+      "hex": "0003000054000000080706050403020118171615141312110100000000000000000000000100000002000000030000000400000005000000060000000700000008000000090000000a0000000b00000004000000000000000010000000000000a1b2c3d4"
+    },
+    {
+      "name": "request_unload_program",
+      "kind": "request",
+      "opcode": "UNLOAD_PROGRAM",
+      "hex": "010300000800000008070605040302013837363534333231"
+    },
+    {
+      "name": "request_create_queue",
+      "kind": "request",
+      "opcode": "CREATE_QUEUE",
+      "hex": "0004000010000000080706050403020118171615141312110000000000000000"
+    },
+    {
+      "name": "request_destroy_queue",
+      "kind": "request",
+      "opcode": "DESTROY_QUEUE",
+      "hex": "010400000800000008070605040302014847464544434241"
+    },
+    {
+      "name": "request_submit",
+      "kind": "request",
+      "opcode": "SUBMIT",
+      "hex": "0005000040000000080706050403020148474645444342413837363534333231010000000000000040420f00000000002827262524232221000000000000000000100000000000000700000003000000"
+    },
+    {
+      "name": "request_poll_event",
+      "kind": "request",
+      "opcode": "POLL_EVENT",
+      "hex": "010500000800000008070605040302015857565554535251"
+    },
+    {
+      "name": "request_cancel_event",
+      "kind": "request",
+      "opcode": "CANCEL_EVENT",
+      "hex": "020500000800000008070605040302015857565554535251"
+    },
+    {
+      "name": "request_destroy_event",
+      "kind": "request",
+      "opcode": "DESTROY_EVENT",
+      "hex": "030500000800000008070605040302015857565554535251"
+    },
+    {
+      "name": "response_get_device_info",
+      "kind": "response",
+      "status": "OK",
+      "hex": "000000004c000000080706050403020176697274696f2d616363656c6d6f636b0100000078563412f0debc9a070000000000000040000000000400000001000010000000001000000001000000000040000000000000000100000000"
+    },
+    {
+      "name": "response_create_context",
+      "kind": "response",
+      "status": "OK",
+      "hex": "000000000800000008070605040302011817161514131211"
+    },
+    {
+      "name": "response_destroy_context",
+      "kind": "response",
+      "status": "OK",
+      "hex": "00000000000000000807060504030201"
+    },
+    {
+      "name": "response_allocate_buffer",
+      "kind": "response",
+      "status": "OK",
+      "hex": "000000000800000008070605040302012827262524232221"
+    },
+    {
+      "name": "response_free_buffer",
+      "kind": "response",
+      "status": "OK",
+      "hex": "00000000000000000807060504030201"
+    },
+    {
+      "name": "response_write_buffer",
+      "kind": "response",
+      "status": "OK",
+      "hex": "00000000000000000807060504030201"
+    },
+    {
+      "name": "response_read_buffer",
+      "kind": "response",
+      "status": "OK",
+      "hex": "00000000040000000807060504030201deadbeef"
+    },
+    {
+      "name": "response_load_program",
+      "kind": "response",
+      "status": "OK",
+      "hex": "000000000800000008070605040302013837363534333231"
+    },
+    {
+      "name": "response_unload_program",
+      "kind": "response",
+      "status": "OK",
+      "hex": "00000000000000000807060504030201"
+    },
+    {
+      "name": "response_create_queue",
+      "kind": "response",
+      "status": "OK",
+      "hex": "000000000800000008070605040302014847464544434241"
+    },
+    {
+      "name": "response_destroy_queue",
+      "kind": "response",
+      "status": "OK",
+      "hex": "00000000000000000807060504030201"
+    },
+    {
+      "name": "response_submit_accepted",
+      "kind": "response",
+      "status": "OK",
+      "hex": "000000000800000008070605040302015857565554535251"
+    },
+    {
+      "name": "response_submit_indeterminate",
+      "kind": "response",
+      "status": "DEVICE_LOST",
+      "hex": "090000000800000008070605040302015857565554535251"
+    },
+    {
+      "name": "response_poll_event_pending",
+      "kind": "response",
+      "status": "OK",
+      "hex": "000000000800000008070605040302010000000000000000"
+    },
+    {
+      "name": "response_poll_event_complete",
+      "kind": "response",
+      "status": "OK",
+      "hex": "000000000800000008070605040302010100000000000000"
+    },
+    {
+      "name": "response_poll_event_failed",
+      "kind": "response",
+      "status": "OK",
+      "hex": "000000000800000008070605040302010200090000000000"
+    },
+    {
+      "name": "response_poll_event_cancelled",
+      "kind": "response",
+      "status": "OK",
+      "hex": "000000000800000008070605040302010300000000000000"
+    },
+    {
+      "name": "response_cancel_event",
+      "kind": "response",
+      "status": "OK",
+      "hex": "00000000000000000807060504030201"
+    },
+    {
+      "name": "response_destroy_event",
+      "kind": "response",
+      "status": "OK",
+      "hex": "00000000000000000807060504030201"
+    },
+    {
+      "name": "response_unknown_opcode",
+      "kind": "response",
+      "status": "UNSUPPORTED",
+      "hex": "01000000000000000807060504030201"
+    }
+  ],
+  "edge_cases": [
+    {
+      "name": "config_descriptor_limit_above_hard_max",
+      "kind": "config",
+      "expected": "ChainDescriptorLimit",
+      "hex": "01000000010001010000100000001000"
+    },
+    {
+      "name": "config_future_minor_compatible",
+      "kind": "config",
+      "expected": "compatible-baseline",
+      "hex": "0100010001000200610000005c000000"
+    },
+    {
+      "name": "config_unknown_major",
+      "kind": "config",
+      "expected": "Version",
+      "hex": "0200000001000200610000005c000000"
+    },
+    {
+      "name": "request_header_truncated",
+      "kind": "request",
+      "expected": "Size",
+      "hex": "010000000000000008070605040302"
+    },
+    {
+      "name": "request_unknown_opcode",
+      "kind": "request",
+      "expected": "UNSUPPORTED",
+      "hex": "adde0000000000000807060504030201"
+    },
+    {
+      "name": "request_reserved_flag",
+      "kind": "request",
+      "expected": "UNSUPPORTED",
+      "hex": "01000100000000000807060504030201"
+    },
+    {
+      "name": "request_trailing_byte",
+      "kind": "request",
+      "expected": "INVALID_ARGUMENT",
+      "hex": "0100000000000000080706050403020100"
+    },
+    {
+      "name": "request_reserved_context_flag",
+      "kind": "request",
+      "expected": "UNSUPPORTED",
+      "hex": "000100000800000008070605040302010100000000000000"
+    },
+    {
+      "name": "request_unknown_memory_domain",
+      "kind": "request",
+      "expected": "INVALID_ARGUMENT",
+      "hex": "00020000280000000807060504030201181716151413121100100000000000004000000000000000ff000000000000000c00000000000000"
+    },
+    {
+      "name": "request_binding_count_overflow",
+      "kind": "request",
+      "expected": "RESOURCE_LIMIT",
+      "hex": "0005000020000000080706050403020148474645444342413837363534333231ffffffff000000000000000000000000"
+    },
+    {
+      "name": "response_unknown_status",
+      "kind": "response",
+      "expected": "opaque-failure",
+      "hex": "34120000000000000807060504030201"
+    },
+    {
+      "name": "response_unknown_event_state",
+      "kind": "response",
+      "expected": "recovery",
+      "hex": "00000000080000000807060504030201ffff000000000000"
+    }
+  ]
+}

--- a/crates/virtio-accel-core/src/lib.rs
+++ b/crates/virtio-accel-core/src/lib.rs
@@ -82,8 +82,10 @@ pub struct DeviceIdentity {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct DeviceLimits {
     pub max_contexts: u32,
-    pub max_queues_per_context: u32,
     pub max_buffers_per_context: u32,
+    pub max_programs_per_context: u32,
+    pub max_queues_per_context: u32,
+    pub max_events_per_context: u32,
     pub max_bindings_per_submission: u32,
     pub max_buffer_bytes: u64,
     pub max_artifact_bytes: u64,

--- a/crates/virtio-accel-core/src/lib.rs
+++ b/crates/virtio-accel-core/src/lib.rs
@@ -57,6 +57,10 @@ impl AcceleratorClass {
 
 bitflags! {
     /// Semantic capabilities exposed by a backend, independent of virtio feature negotiation.
+    ///
+    /// Capabilities describe which accelerator operations the backend can perform. They do not
+    /// change the wire layout. A transport feature bit is required separately whenever enabling a
+    /// capability would change descriptor framing or any other device/driver protocol behavior.
     #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
     pub struct Capabilities: u64 {
         const HOST_VISIBLE_MEMORY = 1 << 0;
@@ -250,6 +254,10 @@ pub struct ArtifactRef<'a> {
 }
 
 bitflags! {
+    /// Flags for an accelerator execution queue.
+    ///
+    /// This queue is a backend object used to submit programs. It is not a virtqueue; the v1
+    /// protocol uses the term *command virtqueue* for the transport queue carrying requests.
     #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
     pub struct QueueFlags: u32 {
         const IN_ORDER = 1 << 0;
@@ -349,6 +357,9 @@ impl<R> ReleaseFailure<R> {
 ///
 /// Destructive methods consume handles. A transport adapter must reject parent destruction while
 /// child objects or in-flight events still exist; it must not use `Drop` timing as protocol state.
+///
+/// [`Self::Queue`] is an accelerator execution queue. It must not be confused with the command
+/// virtqueue used by a transport adapter to deliver protocol requests.
 pub trait Accelerator {
     type Context;
     type Buffer;

--- a/crates/virtio-accel-mock/src/lib.rs
+++ b/crates/virtio-accel-mock/src/lib.rs
@@ -83,8 +83,10 @@ impl Default for MockAccelerator {
                     | Capabilities::EVENT_CANCELLATION,
                 limits: DeviceLimits {
                     max_contexts: 64,
-                    max_queues_per_context: 16,
                     max_buffers_per_context: 1_024,
+                    max_programs_per_context: 256,
+                    max_queues_per_context: 16,
+                    max_events_per_context: 4_096,
                     max_bindings_per_submission: 256,
                     max_buffer_bytes: 1 << 30,
                     max_artifact_bytes: 1 << 30,

--- a/crates/virtio-accel-proto/Cargo.toml
+++ b/crates/virtio-accel-proto/Cargo.toml
@@ -4,9 +4,12 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
-description = "Pointer-free experimental virtio accelerator wire protocol"
+description = "Pointer-free portable virtio accelerator protocol 1.0 ABI"
 publish = false
 
 [dependencies]
 bitflags.workspace = true
 zerocopy.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true

--- a/crates/virtio-accel-proto/src/lib.rs
+++ b/crates/virtio-accel-proto/src/lib.rs
@@ -1,6 +1,7 @@
-//! Pointer-free, little-endian wire structures for the experimental virtio-accel protocol.
+//! Pointer-free, little-endian wire structures for portable virtio-accel protocol 1.0.
 //!
-//! This is a draft ABI. It intentionally does not assign or claim a virtio device ID.
+//! The byte contract is frozen for independent implementation. It intentionally does not assign or
+//! claim a Virtio device ID or standardize provider artifact contents.
 
 #![no_std]
 #![forbid(unsafe_code)]
@@ -13,13 +14,44 @@ pub type Le16 = U16<LE>;
 pub type Le32 = U32<LE>;
 pub type Le64 = U64<LE>;
 
-pub const PROTOCOL_MAJOR: u16 = 0;
-pub const PROTOCOL_MINOR: u16 = 1;
+/// Frozen portable protocol major version.
+pub const PROTOCOL_MAJOR: u16 = 1;
+/// Frozen portable protocol minor version.
+pub const PROTOCOL_MINOR: u16 = 0;
 /// Index of the baseline command virtqueue.
 ///
 /// This transport queue carries protocol requests and responses. It is distinct from an
 /// accelerator execution queue created with [`KnownOpcode::CreateQueue`].
 pub const COMMAND_QUEUE: u16 = 0;
+/// Number of command virtqueues in the baseline device model.
+pub const BASELINE_COMMAND_QUEUES: u16 = 1;
+/// Protocol-wide upper bound for flattened descriptors in one command chain.
+pub const HARD_MAX_CHAIN_DESCRIPTORS: u16 = 256;
+/// Protocol-wide upper bound for one complete request frame, including its header.
+pub const HARD_MAX_REQUEST_BYTES: u32 = 16 * 1024 * 1024;
+/// Protocol-wide upper bound for one complete response frame, including its header.
+pub const HARD_MAX_RESPONSE_BYTES: u32 = 16 * 1024 * 1024;
+/// Protocol-wide upper bound for bindings carried by one submission.
+pub const HARD_MAX_BINDINGS: u32 = 4_096;
+/// Smallest request-frame limit that can carry every baseline opcode.
+pub const MIN_MAX_REQUEST_BYTES: u32 = 97;
+/// Smallest response-frame limit that can carry every baseline response.
+pub const MIN_MAX_RESPONSE_BYTES: u32 = 92;
+
+/// Mask of buffer-usage bits assigned by protocol 1.0.
+pub const KNOWN_BUFFER_USAGE_BITS: u32 = 0x1f;
+/// Request flags accepted by protocol 1.0.
+pub const KNOWN_REQUEST_FLAG_BITS: u16 = 0;
+/// Context flags accepted by protocol 1.0.
+pub const KNOWN_CONTEXT_FLAG_BITS: u32 = 0;
+/// Program-load flags accepted by protocol 1.0.
+pub const KNOWN_PROGRAM_FLAG_BITS: u32 = 0;
+/// Accelerator execution-queue flags accepted by protocol 1.0.
+pub const KNOWN_QUEUE_FLAG_BITS: u32 = 0;
+/// Submission flags accepted by protocol 1.0.
+pub const KNOWN_SUBMIT_FLAG_BITS: u32 = 0;
+/// Former draft assignment retained as a reserved-zero request bit.
+pub const RESERVED_REQUEST_FLAG_NO_WAIT: u16 = 1 << 0;
 
 bitflags! {
     /// Device-specific feature bits. Virtio transport feature bits are deliberately separate.
@@ -33,19 +65,18 @@ bitflags! {
     }
 }
 
-/// Feature set required by every implementation of the current portable baseline.
+/// Feature set required by every implementation of portable protocol 1.0.
 ///
-/// The draft baseline deliberately requires no device-specific feature bits. The commands and
+/// The baseline deliberately requires no device-specific feature bits. The commands and
 /// object lifecycle described by the specification remain available; feature bits are reserved
 /// for behavior that changes transport framing or synchronization.
 pub const BASELINE_FEATURES: FeatureBits = FeatureBits::empty();
 
-/// Draft feature bits that a baseline implementation must leave unadvertised.
+/// Reserved feature bits that a protocol 1.0 implementation must leave unadvertised.
 ///
-/// Defining their numeric positions reserves the namespace without claiming that their semantics
-/// are stable. Advertising any of these bits before its specification and conformance work is
-/// complete is a protocol error.
-pub const UNADVERTISED_DRAFT_FEATURES: FeatureBits = FeatureBits::from_bits_retain(
+/// Defining their numeric positions preserves the reviewed namespace without assigning protocol
+/// semantics. Advertising any of these bits is a protocol error.
+pub const RESERVED_FEATURES: FeatureBits = FeatureBits::from_bits_retain(
     FeatureBits::MULTI_QUEUE.bits()
         | FeatureBits::EVENT_QUEUE.bits()
         | FeatureBits::EXTERNAL_MEMORY.bits()
@@ -56,13 +87,9 @@ pub const UNADVERTISED_DRAFT_FEATURES: FeatureBits = FeatureBits::from_bits_reta
 bitflags! {
     /// Per-request flags.
     ///
-    /// No request flag is part of the mandatory draft baseline. `NO_WAIT` retains its draft
-    /// numeric assignment but must not be sent until issue #9 defines its command-specific
-    /// semantics.
+    /// Protocol 1.0 defines no request flags. Receivers must reject every nonzero raw flag value.
     #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-    pub struct RequestFlags: u16 {
-        const NO_WAIT = 1 << 0;
-    }
+    pub struct RequestFlags: u16 {}
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -131,20 +158,96 @@ impl StatusCode {
     pub const PERMISSION_DENIED: Self = Self(10);
     pub const STALE_OBJECT: Self = Self(11);
     pub const INTERNAL_ERROR: Self = Self(0xffff);
+
+    /// Returns whether this value has assigned protocol 1.0 semantics.
+    pub const fn is_known(self) -> bool {
+        matches!(self.0, 0..=11 | 0xffff)
+    }
+
+    pub const fn is_success(self) -> bool {
+        self.0 == Self::OK.0
+    }
 }
 
-#[derive(Clone, Copy, Debug, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u16)]
+pub enum KnownEventState {
+    Pending = 0,
+    Complete = 1,
+    Failed = 2,
+    Cancelled = 3,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct UnknownEventState(pub u16);
+
+impl TryFrom<u16> for KnownEventState {
+    type Error = UnknownEventState;
+
+    fn try_from(value: u16) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::Pending),
+            1 => Ok(Self::Complete),
+            2 => Ok(Self::Failed),
+            3 => Ok(Self::Cancelled),
+            _ => Err(UnknownEventState(value)),
+        }
+    }
+}
+
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned,
+)]
 #[repr(C)]
 pub struct WireConfig {
     pub protocol_major: Le16,
     pub protocol_minor: Le16,
-    pub max_command_queues: Le16,
-    pub reserved: Le16,
+    pub command_queue_count: Le16,
+    pub max_chain_descriptors: Le16,
     pub max_request_bytes: Le32,
     pub max_response_bytes: Le32,
 }
 
-#[derive(Clone, Copy, Debug, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ConfigError {
+    Version,
+    CommandQueueCount,
+    ChainDescriptorLimit,
+    RequestByteLimit,
+    ResponseByteLimit,
+}
+
+impl WireConfig {
+    /// Validates that this configuration can provide the protocol 1.0 baseline.
+    ///
+    /// A higher minor version is accepted and used with 1.0 behavior until separately negotiated
+    /// extensions are understood.
+    pub fn validate(&self) -> Result<(), ConfigError> {
+        if self.protocol_major.get() != PROTOCOL_MAJOR {
+            return Err(ConfigError::Version);
+        }
+        if self.command_queue_count.get() != BASELINE_COMMAND_QUEUES {
+            return Err(ConfigError::CommandQueueCount);
+        }
+        if !(2..=HARD_MAX_CHAIN_DESCRIPTORS).contains(&self.max_chain_descriptors.get()) {
+            return Err(ConfigError::ChainDescriptorLimit);
+        }
+        if !(MIN_MAX_REQUEST_BYTES..=HARD_MAX_REQUEST_BYTES).contains(&self.max_request_bytes.get())
+        {
+            return Err(ConfigError::RequestByteLimit);
+        }
+        if !(MIN_MAX_RESPONSE_BYTES..=HARD_MAX_RESPONSE_BYTES)
+            .contains(&self.max_response_bytes.get())
+        {
+            return Err(ConfigError::ResponseByteLimit);
+        }
+        Ok(())
+    }
+}
+
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned,
+)]
 #[repr(C)]
 pub struct RequestHeader {
     pub opcode: Le16,
@@ -173,7 +276,9 @@ impl RequestHeader {
     }
 }
 
-#[derive(Clone, Copy, Debug, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned,
+)]
 #[repr(C)]
 pub struct ResponseHeader {
     pub status: Le16,
@@ -193,7 +298,9 @@ impl ResponseHeader {
     }
 }
 
-#[derive(Clone, Copy, Debug, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned,
+)]
 #[repr(C)]
 pub struct WireDeviceInfo {
     pub uuid: [u8; 16],
@@ -203,27 +310,35 @@ pub struct WireDeviceInfo {
     pub device_id: Le32,
     pub capabilities: Le64,
     pub max_contexts: Le32,
-    pub max_queues_per_context: Le32,
     pub max_buffers_per_context: Le32,
+    pub max_programs_per_context: Le32,
+    pub max_queues_per_context: Le32,
+    pub max_events_per_context: Le32,
     pub max_bindings_per_submission: Le32,
     pub max_buffer_bytes: Le64,
     pub max_artifact_bytes: Le64,
 }
 
-#[derive(Clone, Copy, Debug, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned,
+)]
 #[repr(C)]
 pub struct CreateContextRequest {
     pub flags: Le32,
     pub reserved: Le32,
 }
 
-#[derive(Clone, Copy, Debug, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned,
+)]
 #[repr(C)]
 pub struct ObjectPayload {
     pub object_id: Le64,
 }
 
-#[derive(Clone, Copy, Debug, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned,
+)]
 #[repr(C)]
 pub struct AllocateBufferRequest {
     pub context_id: Le64,
@@ -235,7 +350,9 @@ pub struct AllocateBufferRequest {
     pub reserved1: Le32,
 }
 
-#[derive(Clone, Copy, Debug, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned,
+)]
 #[repr(C)]
 pub struct TransferBufferRequest {
     pub buffer_id: Le64,
@@ -243,7 +360,9 @@ pub struct TransferBufferRequest {
     pub bytes: Le64,
 }
 
-#[derive(Clone, Copy, Debug, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned,
+)]
 #[repr(C)]
 pub struct LoadProgramRequest {
     pub context_id: Le64,
@@ -254,7 +373,9 @@ pub struct LoadProgramRequest {
     pub resident_bytes: Le64,
 }
 
-#[derive(Clone, Copy, Debug, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned,
+)]
 #[repr(C)]
 pub struct CreateQueueRequest {
     pub context_id: Le64,
@@ -262,7 +383,9 @@ pub struct CreateQueueRequest {
     pub reserved: Le32,
 }
 
-#[derive(Clone, Copy, Debug, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned,
+)]
 #[repr(C)]
 pub struct SubmitRequest {
     pub queue_id: Le64,
@@ -273,7 +396,9 @@ pub struct SubmitRequest {
     pub timeout_ns: Le64,
 }
 
-#[derive(Clone, Copy, Debug, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned,
+)]
 #[repr(C)]
 pub struct WireBinding {
     pub buffer_id: Le64,
@@ -284,12 +409,29 @@ pub struct WireBinding {
     pub reserved: [u8; 3],
 }
 
-#[derive(Clone, Copy, Debug, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned)]
+/// Event identifier returned for an accepted or indeterminate submission.
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned,
+)]
+#[repr(C)]
+pub struct SubmitResponse {
+    pub event_id: Le64,
+}
+
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, FromBytes, IntoBytes, KnownLayout, Immutable, Unaligned,
+)]
 #[repr(C)]
 pub struct WireEventState {
     pub state: Le16,
     pub error: Le16,
     pub reserved: Le32,
+}
+
+impl WireEventState {
+    pub fn known_state(&self) -> Result<KnownEventState, UnknownEventState> {
+        self.state.get().try_into()
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -310,13 +452,61 @@ pub fn checked_array_bytes<T>(count: u32) -> Result<usize, DecodeError> {
 
 #[cfg(test)]
 mod tests {
+    extern crate std;
+
     use super::*;
+    use core::mem::{align_of, offset_of, size_of};
+    use serde_json::Value;
+    use std::collections::BTreeSet;
     use zerocopy::IntoBytes;
+
+    const REQUEST_ID: u64 = 0x0102_0304_0506_0708;
+
+    fn corpus() -> Value {
+        serde_json::from_str(include_str!("../../../conformance/v1.0/vectors.json")).unwrap()
+    }
+
+    fn layout_manifest() -> Value {
+        serde_json::from_str(include_str!("../../../conformance/v1.0/layout.json")).unwrap()
+    }
+
+    fn decode_hex(hex: &str) -> std::vec::Vec<u8> {
+        assert_eq!(hex.len() % 2, 0);
+        (0..hex.len())
+            .step_by(2)
+            .map(|offset| u8::from_str_radix(&hex[offset..offset + 2], 16).unwrap())
+            .collect()
+    }
+
+    fn vector(group: &str, name: &str) -> std::vec::Vec<u8> {
+        let corpus = corpus();
+        let entry = corpus[group]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|entry| entry["name"] == name)
+            .unwrap_or_else(|| panic!("missing vector {name}"));
+        decode_hex(entry["hex"].as_str().unwrap())
+    }
+
+    fn assert_layout<T>(name: &str, fields: &[(&str, usize)]) {
+        let manifest = layout_manifest();
+        let expected = &manifest["structures"][name];
+        assert_eq!(size_of::<T>() as u64, expected["size"].as_u64().unwrap());
+        assert_eq!(align_of::<T>() as u64, expected["align"].as_u64().unwrap());
+        for (field, offset) in fields {
+            assert_eq!(
+                *offset as u64,
+                expected["fields"][field].as_u64().unwrap(),
+                "{name}.{field}"
+            );
+        }
+    }
 
     #[test]
     fn headers_are_fixed_little_endian_frames() {
-        let header = RequestHeader::new(KnownOpcode::Submit, RequestFlags::NO_WAIT, 32, 7);
-        assert_eq!(core::mem::size_of::<RequestHeader>(), 16);
+        let header = RequestHeader::new(KnownOpcode::Submit, RequestFlags::empty(), 32, 7);
+        assert_eq!(size_of::<RequestHeader>(), 16);
         assert_eq!(header.as_bytes()[..2], 0x0500_u16.to_le_bytes());
         let decoded = read_exact::<RequestHeader>(header.as_bytes()).unwrap();
         assert_eq!(decoded.known_opcode(), Ok(KnownOpcode::Submit));
@@ -324,30 +514,597 @@ mod tests {
     }
 
     #[test]
-    fn wire_layouts_contain_no_native_pointers_or_padding() {
-        assert_eq!(core::mem::size_of::<WireConfig>(), 16);
-        assert_eq!(core::mem::size_of::<ResponseHeader>(), 16);
-        assert_eq!(core::mem::size_of::<WireDeviceInfo>(), 68);
-        assert_eq!(core::mem::size_of::<AllocateBufferRequest>(), 40);
-        assert_eq!(core::mem::size_of::<LoadProgramRequest>(), 80);
-        assert_eq!(core::mem::size_of::<SubmitRequest>(), 32);
-        assert_eq!(core::mem::size_of::<WireBinding>(), 32);
+    fn wire_layouts_match_the_frozen_manifest() {
+        assert_layout::<WireConfig>(
+            "WireConfig",
+            &[
+                ("protocol_major", offset_of!(WireConfig, protocol_major)),
+                ("protocol_minor", offset_of!(WireConfig, protocol_minor)),
+                (
+                    "command_queue_count",
+                    offset_of!(WireConfig, command_queue_count),
+                ),
+                (
+                    "max_chain_descriptors",
+                    offset_of!(WireConfig, max_chain_descriptors),
+                ),
+                (
+                    "max_request_bytes",
+                    offset_of!(WireConfig, max_request_bytes),
+                ),
+                (
+                    "max_response_bytes",
+                    offset_of!(WireConfig, max_response_bytes),
+                ),
+            ],
+        );
+        assert_layout::<RequestHeader>(
+            "RequestHeader",
+            &[
+                ("opcode", offset_of!(RequestHeader, opcode)),
+                ("flags", offset_of!(RequestHeader, flags)),
+                ("payload_bytes", offset_of!(RequestHeader, payload_bytes)),
+                ("request_id", offset_of!(RequestHeader, request_id)),
+            ],
+        );
+        assert_layout::<ResponseHeader>(
+            "ResponseHeader",
+            &[
+                ("status", offset_of!(ResponseHeader, status)),
+                ("flags", offset_of!(ResponseHeader, flags)),
+                ("payload_bytes", offset_of!(ResponseHeader, payload_bytes)),
+                ("request_id", offset_of!(ResponseHeader, request_id)),
+            ],
+        );
+        assert_layout::<WireDeviceInfo>(
+            "WireDeviceInfo",
+            &[
+                ("uuid", offset_of!(WireDeviceInfo, uuid)),
+                ("class", offset_of!(WireDeviceInfo, class)),
+                ("reserved", offset_of!(WireDeviceInfo, reserved)),
+                ("vendor_id", offset_of!(WireDeviceInfo, vendor_id)),
+                ("device_id", offset_of!(WireDeviceInfo, device_id)),
+                ("capabilities", offset_of!(WireDeviceInfo, capabilities)),
+                ("max_contexts", offset_of!(WireDeviceInfo, max_contexts)),
+                (
+                    "max_buffers_per_context",
+                    offset_of!(WireDeviceInfo, max_buffers_per_context),
+                ),
+                (
+                    "max_programs_per_context",
+                    offset_of!(WireDeviceInfo, max_programs_per_context),
+                ),
+                (
+                    "max_queues_per_context",
+                    offset_of!(WireDeviceInfo, max_queues_per_context),
+                ),
+                (
+                    "max_events_per_context",
+                    offset_of!(WireDeviceInfo, max_events_per_context),
+                ),
+                (
+                    "max_bindings_per_submission",
+                    offset_of!(WireDeviceInfo, max_bindings_per_submission),
+                ),
+                (
+                    "max_buffer_bytes",
+                    offset_of!(WireDeviceInfo, max_buffer_bytes),
+                ),
+                (
+                    "max_artifact_bytes",
+                    offset_of!(WireDeviceInfo, max_artifact_bytes),
+                ),
+            ],
+        );
+        assert_layout::<CreateContextRequest>(
+            "CreateContextRequest",
+            &[
+                ("flags", offset_of!(CreateContextRequest, flags)),
+                ("reserved", offset_of!(CreateContextRequest, reserved)),
+            ],
+        );
+        assert_layout::<ObjectPayload>(
+            "ObjectPayload",
+            &[("object_id", offset_of!(ObjectPayload, object_id))],
+        );
+        assert_layout::<AllocateBufferRequest>(
+            "AllocateBufferRequest",
+            &[
+                ("context_id", offset_of!(AllocateBufferRequest, context_id)),
+                ("bytes", offset_of!(AllocateBufferRequest, bytes)),
+                ("alignment", offset_of!(AllocateBufferRequest, alignment)),
+                (
+                    "memory_domain",
+                    offset_of!(AllocateBufferRequest, memory_domain),
+                ),
+                ("reserved0", offset_of!(AllocateBufferRequest, reserved0)),
+                ("usage", offset_of!(AllocateBufferRequest, usage)),
+                ("reserved1", offset_of!(AllocateBufferRequest, reserved1)),
+            ],
+        );
+        assert_layout::<TransferBufferRequest>(
+            "TransferBufferRequest",
+            &[
+                ("buffer_id", offset_of!(TransferBufferRequest, buffer_id)),
+                ("offset", offset_of!(TransferBufferRequest, offset)),
+                ("bytes", offset_of!(TransferBufferRequest, bytes)),
+            ],
+        );
+        assert_layout::<LoadProgramRequest>(
+            "LoadProgramRequest",
+            &[
+                ("context_id", offset_of!(LoadProgramRequest, context_id)),
+                ("format", offset_of!(LoadProgramRequest, format)),
+                ("flags", offset_of!(LoadProgramRequest, flags)),
+                ("target", offset_of!(LoadProgramRequest, target)),
+                (
+                    "payload_bytes",
+                    offset_of!(LoadProgramRequest, payload_bytes),
+                ),
+                (
+                    "resident_bytes",
+                    offset_of!(LoadProgramRequest, resident_bytes),
+                ),
+            ],
+        );
+        assert_layout::<CreateQueueRequest>(
+            "CreateQueueRequest",
+            &[
+                ("context_id", offset_of!(CreateQueueRequest, context_id)),
+                ("flags", offset_of!(CreateQueueRequest, flags)),
+                ("reserved", offset_of!(CreateQueueRequest, reserved)),
+            ],
+        );
+        assert_layout::<SubmitRequest>(
+            "SubmitRequest",
+            &[
+                ("queue_id", offset_of!(SubmitRequest, queue_id)),
+                ("program_id", offset_of!(SubmitRequest, program_id)),
+                ("binding_count", offset_of!(SubmitRequest, binding_count)),
+                ("flags", offset_of!(SubmitRequest, flags)),
+                ("timeout_ns", offset_of!(SubmitRequest, timeout_ns)),
+            ],
+        );
+        assert_layout::<WireBinding>(
+            "WireBinding",
+            &[
+                ("buffer_id", offset_of!(WireBinding, buffer_id)),
+                ("offset", offset_of!(WireBinding, offset)),
+                ("bytes", offset_of!(WireBinding, bytes)),
+                ("slot", offset_of!(WireBinding, slot)),
+                ("access", offset_of!(WireBinding, access)),
+                ("reserved", offset_of!(WireBinding, reserved)),
+            ],
+        );
+        assert_layout::<SubmitResponse>(
+            "SubmitResponse",
+            &[("event_id", offset_of!(SubmitResponse, event_id))],
+        );
+        assert_layout::<WireEventState>(
+            "WireEventState",
+            &[
+                ("state", offset_of!(WireEventState, state)),
+                ("error", offset_of!(WireEventState, error)),
+                ("reserved", offset_of!(WireEventState, reserved)),
+            ],
+        );
     }
 
     #[test]
-    fn unknown_opcodes_remain_rejectable_without_invalid_enums() {
-        let mut bytes = RequestHeader::new(KnownOpcode::GetDeviceInfo, RequestFlags::empty(), 0, 1)
-            .as_bytes()
-            .to_vec();
-        bytes[..2].copy_from_slice(&0xdead_u16.to_le_bytes());
-        let decoded = read_exact::<RequestHeader>(&bytes).unwrap();
+    fn manifest_constants_match_the_frozen_rust_namespace() {
+        let manifest = layout_manifest();
+        assert_eq!(manifest["protocol"]["major"], PROTOCOL_MAJOR);
+        assert_eq!(manifest["protocol"]["minor"], PROTOCOL_MINOR);
+        assert_eq!(manifest["queue"]["command_index"], COMMAND_QUEUE);
+        assert_eq!(manifest["queue"]["baseline_count"], BASELINE_COMMAND_QUEUES);
+        assert_eq!(
+            manifest["queue"]["hard_max_chain_descriptors"],
+            HARD_MAX_CHAIN_DESCRIPTORS
+        );
+        assert_eq!(
+            manifest["queue"]["min_max_request_bytes"],
+            MIN_MAX_REQUEST_BYTES
+        );
+        assert_eq!(
+            manifest["queue"]["min_max_response_bytes"],
+            MIN_MAX_RESPONSE_BYTES
+        );
+        assert_eq!(
+            manifest["queue"]["hard_max_request_bytes"],
+            HARD_MAX_REQUEST_BYTES
+        );
+        assert_eq!(
+            manifest["queue"]["hard_max_response_bytes"],
+            HARD_MAX_RESPONSE_BYTES
+        );
+        assert_eq!(manifest["queue"]["hard_max_bindings"], HARD_MAX_BINDINGS);
+        assert_eq!(
+            MIN_MAX_REQUEST_BYTES as usize,
+            size_of::<RequestHeader>() + size_of::<LoadProgramRequest>() + 1
+        );
+        assert_eq!(
+            MIN_MAX_RESPONSE_BYTES as usize,
+            size_of::<ResponseHeader>() + size_of::<WireDeviceInfo>()
+        );
+
+        let opcodes = &manifest["opcodes"];
+        for (name, value) in [
+            ("GET_DEVICE_INFO", KnownOpcode::GetDeviceInfo as u16),
+            ("CREATE_CONTEXT", KnownOpcode::CreateContext as u16),
+            ("DESTROY_CONTEXT", KnownOpcode::DestroyContext as u16),
+            ("ALLOCATE_BUFFER", KnownOpcode::AllocateBuffer as u16),
+            ("FREE_BUFFER", KnownOpcode::FreeBuffer as u16),
+            ("WRITE_BUFFER", KnownOpcode::WriteBuffer as u16),
+            ("READ_BUFFER", KnownOpcode::ReadBuffer as u16),
+            ("LOAD_PROGRAM", KnownOpcode::LoadProgram as u16),
+            ("UNLOAD_PROGRAM", KnownOpcode::UnloadProgram as u16),
+            ("CREATE_QUEUE", KnownOpcode::CreateQueue as u16),
+            ("DESTROY_QUEUE", KnownOpcode::DestroyQueue as u16),
+            ("SUBMIT", KnownOpcode::Submit as u16),
+            ("POLL_EVENT", KnownOpcode::PollEvent as u16),
+            ("CANCEL_EVENT", KnownOpcode::CancelEvent as u16),
+            ("DESTROY_EVENT", KnownOpcode::DestroyEvent as u16),
+        ] {
+            assert_eq!(opcodes[name], std::format!("0x{value:04x}"));
+        }
+
+        let statuses = &manifest["statuses"];
+        for (name, value) in [
+            ("OK", StatusCode::OK.0),
+            ("UNSUPPORTED", StatusCode::UNSUPPORTED.0),
+            ("INCOMPATIBLE", StatusCode::INCOMPATIBLE.0),
+            ("INVALID_ARGUMENT", StatusCode::INVALID_ARGUMENT.0),
+            ("OUT_OF_BOUNDS", StatusCode::OUT_OF_BOUNDS.0),
+            ("BUSY", StatusCode::BUSY.0),
+            ("OUT_OF_MEMORY", StatusCode::OUT_OF_MEMORY.0),
+            ("RESOURCE_LIMIT", StatusCode::RESOURCE_LIMIT.0),
+            ("DEADLINE_EXPIRED", StatusCode::DEADLINE_EXPIRED.0),
+            ("DEVICE_LOST", StatusCode::DEVICE_LOST.0),
+            ("PERMISSION_DENIED", StatusCode::PERMISSION_DENIED.0),
+            ("STALE_OBJECT", StatusCode::STALE_OBJECT.0),
+            ("INTERNAL_ERROR", StatusCode::INTERNAL_ERROR.0),
+        ] {
+            assert_eq!(statuses[name], value);
+        }
+
+        let states = &manifest["event_states"];
+        for (name, value) in [
+            ("PENDING", KnownEventState::Pending as u16),
+            ("COMPLETE", KnownEventState::Complete as u16),
+            ("FAILED", KnownEventState::Failed as u16),
+            ("CANCELLED", KnownEventState::Cancelled as u16),
+        ] {
+            assert_eq!(states[name], value);
+        }
+
+        let features = &manifest["features"];
+        assert_eq!(features["baseline"], "0x0000000000000000");
+        for (name, value) in [
+            ("MULTI_QUEUE", FeatureBits::MULTI_QUEUE.bits()),
+            ("EVENT_QUEUE", FeatureBits::EVENT_QUEUE.bits()),
+            ("EXTERNAL_MEMORY", FeatureBits::EXTERNAL_MEMORY.bits()),
+            ("TIMELINE_FENCES", FeatureBits::TIMELINE_FENCES.bits()),
+            ("SECURE_CONTEXTS", FeatureBits::SECURE_CONTEXTS.bits()),
+        ] {
+            assert_eq!(features["reserved"][name], std::format!("0x{value:016x}"));
+        }
+    }
+
+    #[test]
+    fn canonical_frames_have_exact_header_lengths_and_known_namespaces() {
+        let corpus = corpus();
+        let frames = corpus["frames"].as_array().unwrap();
+        let mut request_count = 0;
+        let mut response_count = 0;
+        let mut request_opcodes = BTreeSet::new();
+        let mut response_names = BTreeSet::new();
+
+        for frame in frames {
+            let bytes = decode_hex(frame["hex"].as_str().unwrap());
+            match frame["kind"].as_str().unwrap() {
+                "config" => {
+                    let config = read_exact::<WireConfig>(&bytes).unwrap();
+                    config.validate().unwrap();
+                }
+                "request" => {
+                    request_count += 1;
+                    let header =
+                        read_exact::<RequestHeader>(&bytes[..size_of::<RequestHeader>()]).unwrap();
+                    assert!(header.known_opcode().is_ok(), "{}", frame["name"]);
+                    let opcode_name = frame["opcode"].as_str().unwrap();
+                    assert_eq!(
+                        layout_manifest()["opcodes"][opcode_name],
+                        std::format!("0x{:04x}", header.opcode.get())
+                    );
+                    assert!(request_opcodes.insert(header.opcode.get()));
+                    assert_eq!(header.flags.get(), KNOWN_REQUEST_FLAG_BITS);
+                    assert_ne!(header.request_id.get(), 0);
+                    assert_eq!(
+                        bytes.len(),
+                        size_of::<RequestHeader>() + header.payload_bytes.get() as usize,
+                        "{}",
+                        frame["name"]
+                    );
+                }
+                "response" => {
+                    response_count += 1;
+                    assert!(response_names.insert(frame["name"].as_str().unwrap()));
+                    let header =
+                        read_exact::<ResponseHeader>(&bytes[..size_of::<ResponseHeader>()])
+                            .unwrap();
+                    assert!(
+                        StatusCode(header.status.get()).is_known(),
+                        "{}",
+                        frame["name"]
+                    );
+                    let status_name = frame["status"].as_str().unwrap();
+                    assert_eq!(
+                        layout_manifest()["statuses"][status_name],
+                        header.status.get()
+                    );
+                    assert_eq!(header.flags.get(), 0);
+                    assert_eq!(header.request_id.get(), REQUEST_ID);
+                    assert_eq!(
+                        bytes.len(),
+                        size_of::<ResponseHeader>() + header.payload_bytes.get() as usize,
+                        "{}",
+                        frame["name"]
+                    );
+                }
+                other => panic!("unknown frame kind {other}"),
+            }
+        }
+
+        assert_eq!(request_count, 15);
+        assert_eq!(request_opcodes.len(), 15);
+        assert_eq!(response_count, 20);
+        for name in [
+            "response_get_device_info",
+            "response_create_context",
+            "response_destroy_context",
+            "response_allocate_buffer",
+            "response_free_buffer",
+            "response_write_buffer",
+            "response_read_buffer",
+            "response_load_program",
+            "response_unload_program",
+            "response_create_queue",
+            "response_destroy_queue",
+            "response_submit_accepted",
+            "response_submit_indeterminate",
+            "response_poll_event_pending",
+            "response_poll_event_complete",
+            "response_poll_event_failed",
+            "response_poll_event_cancelled",
+            "response_cancel_event",
+            "response_destroy_event",
+            "response_unknown_opcode",
+        ] {
+            assert!(response_names.contains(name), "missing {name}");
+        }
+    }
+
+    #[test]
+    fn canonical_struct_encodings_match_reviewed_vectors() {
+        let minimum_config = WireConfig {
+            protocol_major: Le16::new(PROTOCOL_MAJOR),
+            protocol_minor: Le16::new(PROTOCOL_MINOR),
+            command_queue_count: Le16::new(BASELINE_COMMAND_QUEUES),
+            max_chain_descriptors: Le16::new(2),
+            max_request_bytes: Le32::new(MIN_MAX_REQUEST_BYTES),
+            max_response_bytes: Le32::new(MIN_MAX_RESPONSE_BYTES),
+        };
+        assert_eq!(
+            minimum_config.as_bytes(),
+            vector("frames", "config_minimum")
+        );
+
+        let get_info = RequestHeader::new(
+            KnownOpcode::GetDeviceInfo,
+            RequestFlags::empty(),
+            0,
+            REQUEST_ID,
+        );
+        assert_eq!(
+            get_info.as_bytes(),
+            vector("frames", "request_get_device_info")
+        );
+
+        let create_context = CreateContextRequest {
+            flags: Le32::new(0),
+            reserved: Le32::new(0),
+        };
+        assert_eq!(
+            create_context.as_bytes(),
+            &vector("frames", "request_create_context")[16..]
+        );
+
+        let context = ObjectPayload {
+            object_id: Le64::new(0x1112_1314_1516_1718),
+        };
+        assert_eq!(
+            context.as_bytes(),
+            &vector("frames", "request_destroy_context")[16..]
+        );
+
+        let allocate = AllocateBufferRequest {
+            context_id: context.object_id,
+            bytes: Le64::new(4_096),
+            alignment: Le64::new(64),
+            memory_domain: 3,
+            reserved0: [0; 7],
+            usage: Le32::new(0x0c),
+            reserved1: Le32::new(0),
+        };
+        assert_eq!(
+            allocate.as_bytes(),
+            &vector("frames", "request_allocate_buffer")[16..]
+        );
+
+        let transfer = TransferBufferRequest {
+            buffer_id: Le64::new(0x2122_2324_2526_2728),
+            offset: Le64::new(4),
+            bytes: Le64::new(4),
+        };
+        assert_eq!(
+            transfer.as_bytes(),
+            &vector("frames", "request_read_buffer")[16..]
+        );
+
+        let load_program = LoadProgramRequest {
+            context_id: context.object_id,
+            format: Le32::new(1),
+            flags: Le32::new(0),
+            target: core::array::from_fn(|index| Le32::new(index as u32)),
+            payload_bytes: Le64::new(4),
+            resident_bytes: Le64::new(4_096),
+        };
+        assert_eq!(
+            load_program.as_bytes(),
+            &vector("frames", "request_load_program")[16..96]
+        );
+
+        let create_queue = CreateQueueRequest {
+            context_id: context.object_id,
+            flags: Le32::new(0),
+            reserved: Le32::new(0),
+        };
+        assert_eq!(
+            create_queue.as_bytes(),
+            &vector("frames", "request_create_queue")[16..]
+        );
+
+        let submit = SubmitRequest {
+            queue_id: Le64::new(0x4142_4344_4546_4748),
+            program_id: Le64::new(0x3132_3334_3536_3738),
+            binding_count: Le32::new(1),
+            flags: Le32::new(0),
+            timeout_ns: Le64::new(1_000_000),
+        };
+        assert_eq!(
+            submit.as_bytes(),
+            &vector("frames", "request_submit")[16..48]
+        );
+
+        let binding = WireBinding {
+            buffer_id: transfer.buffer_id,
+            offset: Le64::new(0),
+            bytes: Le64::new(4_096),
+            slot: Le32::new(7),
+            access: 3,
+            reserved: [0; 3],
+        };
+        assert_eq!(
+            binding.as_bytes(),
+            &vector("frames", "request_submit")[48..]
+        );
+
+        let device_info = WireDeviceInfo {
+            uuid: *b"virtio-accelmock",
+            class: Le16::new(1),
+            reserved: Le16::new(0),
+            vendor_id: Le32::new(0x1234_5678),
+            device_id: Le32::new(0x9abc_def0),
+            capabilities: Le64::new(7),
+            max_contexts: Le32::new(64),
+            max_buffers_per_context: Le32::new(1_024),
+            max_programs_per_context: Le32::new(256),
+            max_queues_per_context: Le32::new(16),
+            max_events_per_context: Le32::new(4_096),
+            max_bindings_per_submission: Le32::new(256),
+            max_buffer_bytes: Le64::new(1 << 30),
+            max_artifact_bytes: Le64::new(16 * 1024 * 1024),
+        };
+        assert_eq!(
+            device_info.as_bytes(),
+            &vector("frames", "response_get_device_info")[16..]
+        );
+
+        let submit_response = SubmitResponse {
+            event_id: Le64::new(0x5152_5354_5556_5758),
+        };
+        assert_eq!(
+            submit_response.as_bytes(),
+            &vector("frames", "response_submit_accepted")[16..]
+        );
+
+        let failed_event = WireEventState {
+            state: Le16::new(KnownEventState::Failed as u16),
+            error: Le16::new(StatusCode::DEVICE_LOST.0),
+            reserved: Le32::new(0),
+        };
+        assert_eq!(
+            failed_event.as_bytes(),
+            &vector("frames", "response_poll_event_failed")[16..]
+        );
+    }
+
+    #[test]
+    fn edge_vectors_preserve_unknown_values_without_invalid_enums() {
+        let truncated = vector("edge_cases", "request_header_truncated");
+        assert_eq!(
+            read_exact::<RequestHeader>(&truncated),
+            Err(DecodeError::Size)
+        );
+
+        let unknown_opcode = vector("edge_cases", "request_unknown_opcode");
+        let decoded = read_exact::<RequestHeader>(&unknown_opcode).unwrap();
         assert_eq!(decoded.known_opcode(), Err(UnknownOpcode(0xdead)));
+
+        let unknown_status = vector("edge_cases", "response_unknown_status");
+        let response = read_exact::<ResponseHeader>(&unknown_status).unwrap();
+        let status = StatusCode(response.status.get());
+        assert_eq!(status, StatusCode(0x1234));
+        assert!(!status.is_known());
+        assert!(!status.is_success());
+
+        let unknown_event = vector("edge_cases", "response_unknown_event_state");
+        let event = read_exact::<WireEventState>(&unknown_event[16..]).unwrap();
+        assert_eq!(event.known_state(), Err(UnknownEventState(0xffff)));
     }
 
     #[test]
-    fn draft_features_are_reserved_but_not_baseline_requirements() {
+    fn edge_vectors_cover_limits_reserved_bits_and_exact_lengths() {
+        let invalid_config = vector("edge_cases", "config_descriptor_limit_above_hard_max");
+        assert_eq!(
+            read_exact::<WireConfig>(&invalid_config)
+                .unwrap()
+                .validate(),
+            Err(ConfigError::ChainDescriptorLimit)
+        );
+
+        let future_minor = vector("edge_cases", "config_future_minor_compatible");
+        let config = read_exact::<WireConfig>(&future_minor).unwrap();
+        assert!(config.protocol_minor.get() > PROTOCOL_MINOR);
+        assert_eq!(config.validate(), Ok(()));
+
+        let unknown_major = vector("edge_cases", "config_unknown_major");
+        assert_eq!(
+            read_exact::<WireConfig>(&unknown_major).unwrap().validate(),
+            Err(ConfigError::Version)
+        );
+
+        let reserved_flag = vector("edge_cases", "request_reserved_flag");
+        let header = read_exact::<RequestHeader>(&reserved_flag).unwrap();
+        assert_eq!(header.flags.get(), RESERVED_REQUEST_FLAG_NO_WAIT);
+        assert!(RequestFlags::from_bits(header.flags.get()).is_none());
+
+        let trailing = vector("edge_cases", "request_trailing_byte");
+        let header = read_exact::<RequestHeader>(&trailing[..16]).unwrap();
+        assert_ne!(
+            trailing.len(),
+            size_of::<RequestHeader>() + header.payload_bytes.get() as usize
+        );
+
+        let excessive_bindings = vector("edge_cases", "request_binding_count_overflow");
+        let submit = read_exact::<SubmitRequest>(&excessive_bindings[16..]).unwrap();
+        assert!(submit.binding_count.get() > HARD_MAX_BINDINGS);
+    }
+
+    #[test]
+    fn reserved_features_are_not_baseline_requirements() {
         assert!(BASELINE_FEATURES.is_empty());
-        assert!(!UNADVERTISED_DRAFT_FEATURES.is_empty());
-        assert!(!BASELINE_FEATURES.intersects(UNADVERTISED_DRAFT_FEATURES));
+        assert!(!RESERVED_FEATURES.is_empty());
+        assert!(!BASELINE_FEATURES.intersects(RESERVED_FEATURES));
     }
 }

--- a/crates/virtio-accel-proto/src/lib.rs
+++ b/crates/virtio-accel-proto/src/lib.rs
@@ -15,6 +15,10 @@ pub type Le64 = U64<LE>;
 
 pub const PROTOCOL_MAJOR: u16 = 0;
 pub const PROTOCOL_MINOR: u16 = 1;
+/// Index of the baseline command virtqueue.
+///
+/// This transport queue carries protocol requests and responses. It is distinct from an
+/// accelerator execution queue created with [`KnownOpcode::CreateQueue`].
 pub const COMMAND_QUEUE: u16 = 0;
 
 bitflags! {
@@ -29,7 +33,32 @@ bitflags! {
     }
 }
 
+/// Feature set required by every implementation of the current portable baseline.
+///
+/// The draft baseline deliberately requires no device-specific feature bits. The commands and
+/// object lifecycle described by the specification remain available; feature bits are reserved
+/// for behavior that changes transport framing or synchronization.
+pub const BASELINE_FEATURES: FeatureBits = FeatureBits::empty();
+
+/// Draft feature bits that a baseline implementation must leave unadvertised.
+///
+/// Defining their numeric positions reserves the namespace without claiming that their semantics
+/// are stable. Advertising any of these bits before its specification and conformance work is
+/// complete is a protocol error.
+pub const UNADVERTISED_DRAFT_FEATURES: FeatureBits = FeatureBits::from_bits_retain(
+    FeatureBits::MULTI_QUEUE.bits()
+        | FeatureBits::EVENT_QUEUE.bits()
+        | FeatureBits::EXTERNAL_MEMORY.bits()
+        | FeatureBits::TIMELINE_FENCES.bits()
+        | FeatureBits::SECURE_CONTEXTS.bits(),
+);
+
 bitflags! {
+    /// Per-request flags.
+    ///
+    /// No request flag is part of the mandatory draft baseline. `NO_WAIT` retains its draft
+    /// numeric assignment but must not be sent until issue #9 defines its command-specific
+    /// semantics.
     #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
     pub struct RequestFlags: u16 {
         const NO_WAIT = 1 << 0;
@@ -313,5 +342,12 @@ mod tests {
         bytes[..2].copy_from_slice(&0xdead_u16.to_le_bytes());
         let decoded = read_exact::<RequestHeader>(&bytes).unwrap();
         assert_eq!(decoded.known_opcode(), Err(UnknownOpcode(0xdead)));
+    }
+
+    #[test]
+    fn draft_features_are_reserved_but_not_baseline_requirements() {
+        assert!(BASELINE_FEATURES.is_empty());
+        assert!(!UNADVERTISED_DRAFT_FEATURES.is_empty());
+        assert!(!BASELINE_FEATURES.intersects(UNADVERTISED_DRAFT_FEATURES));
     }
 }

--- a/crates/virtio-accel-proto/src/lib.rs
+++ b/crates/virtio-accel-proto/src/lib.rs
@@ -1,7 +1,8 @@
 //! Pointer-free, little-endian wire structures for portable virtio-accel protocol 1.0.
 //!
-//! The byte contract is frozen for independent implementation. It intentionally does not assign or
-//! claim a Virtio device ID or standardize provider artifact contents.
+//! The versioned byte contract is a candidate for independent implementation and final audit. It
+//! intentionally does not assign or claim a Virtio device ID or standardize provider artifact
+//! contents.
 
 #![no_std]
 #![forbid(unsafe_code)]
@@ -14,9 +15,9 @@ pub type Le16 = U16<LE>;
 pub type Le32 = U32<LE>;
 pub type Le64 = U64<LE>;
 
-/// Frozen portable protocol major version.
+/// Candidate portable protocol major version.
 pub const PROTOCOL_MAJOR: u16 = 1;
-/// Frozen portable protocol minor version.
+/// Candidate portable protocol minor version.
 pub const PROTOCOL_MINOR: u16 = 0;
 /// Index of the baseline command virtqueue.
 ///
@@ -514,7 +515,7 @@ mod tests {
     }
 
     #[test]
-    fn wire_layouts_match_the_frozen_manifest() {
+    fn wire_layouts_match_the_versioned_manifest() {
         assert_layout::<WireConfig>(
             "WireConfig",
             &[
@@ -691,7 +692,7 @@ mod tests {
     }
 
     #[test]
-    fn manifest_constants_match_the_frozen_rust_namespace() {
+    fn manifest_constants_match_the_candidate_rust_namespace() {
         let manifest = layout_manifest();
         assert_eq!(manifest["protocol"]["major"], PROTOCOL_MAJOR);
         assert_eq!(manifest["protocol"]["minor"], PROTOCOL_MINOR);

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,40 @@
+[graph]
+targets = [
+    "aarch64-unknown-none",
+    "riscv64gc-unknown-none-elf",
+    "wasm32-unknown-unknown",
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
+    "aarch64-apple-darwin",
+]
+all-features = true
+
+[advisories]
+yanked = "deny"
+unmaintained = "workspace"
+unsound = "all"
+
+[licenses]
+allow = [
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "MIT",
+    "Unicode-3.0",
+]
+confidence-threshold = 0.93
+
+[bans]
+multiple-versions = "deny"
+wildcards = "deny"
+allow-wildcard-paths = true
+highlight = "all"
+
+[bans.workspace-dependencies]
+duplicates = "deny"
+include-path-dependencies = true
+unused = "deny"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,6 +9,10 @@ they do not own accelerator semantics.
 The draft does not yet assign a virtio device ID. It also does not standardize vendor executable
 formats: artifact format identifiers and target words remain opaque to the transport.
 
+The normative terminology, object model, and compatibility rules live in
+[specification.md](specification.md). This document explains the implementation boundaries that
+preserve those rules.
+
 ## Load-bearing invariants
 
 ### Wire safety
@@ -61,14 +65,17 @@ and threat-model pass.
 
 ## Queue model
 
-Queue zero is the baseline bidirectional command queue. One descriptor chain contains device-readable
-request bytes and device-writable response bytes. Completion may be out of submission order, keyed by
-the request ID.
+Command virtqueue zero is the baseline bidirectional transport queue. One descriptor chain contains
+device-readable request bytes and device-writable response bytes. Completion may be out of
+submission order, keyed by the request ID.
 
 The baseline `SUBMIT` command returns an event object; `POLL_EVENT` provides portable progress without
 requiring unsolicited device writes. Optional multi-queue and event-queue features are reserved for
 later validation. Split and packed virtqueue mechanics belong to transport adapters, not the command
 engine.
+
+An accelerator execution queue is a separate context-scoped backend object. It never denotes a
+Virtio queue index.
 
 ## Performance posture
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,12 +6,13 @@ The portable layers define the semantics that must agree across every guest tran
 machine monitor, host operating system, and hardware provider. Platform integrations are adapters;
 they do not own accelerator semantics.
 
-The draft does not yet assign a virtio device ID. It also does not standardize vendor executable
+Protocol 1.0 does not assign a Virtio device ID. It also does not standardize vendor executable
 formats: artifact format identifiers and target words remain opaque to the transport.
 
 The normative terminology, object model, and compatibility rules live in
-[specification.md](specification.md). This document explains the implementation boundaries that
-preserve those rules.
+[specification.md](specification.md), with exact layouts in [wire-abi.md](wire-abi.md) and command
+queue rules in [virtqueue.md](virtqueue.md). This document explains the implementation boundaries
+that preserve those rules.
 
 ## Load-bearing invariants
 

--- a/docs/portability.md
+++ b/docs/portability.md
@@ -40,9 +40,10 @@ CI runs `cargo hack check --feature-powerset --no-dev-deps` across the workspace
 additive: disabling default features may remove convenience behavior but must not select a different
 protocol interpretation.
 
-The portable dependency guard inspects resolved target features for `virtio-accel-proto` and
-`virtio-accel-core`. A dependency’s host-side derive macro may use `std`, but the target graph for
-these crates must not enable a dependency feature named `std` or `alloc`.
+The portable dependency guard inspects normal and build target features for `virtio-accel-proto`
+and `virtio-accel-core`; test-only development dependencies are intentionally outside the target
+runtime graph. A dependency’s host-side derive macro may use `std`, but the target graph for these
+crates must not enable a dependency feature named `std` or `alloc`.
 
 ## Dependency policy
 

--- a/docs/portability.md
+++ b/docs/portability.md
@@ -1,0 +1,89 @@
+# Portability and continuous integration
+
+The portable v1 promise is enforced by `.github/workflows/ci.yml`. This file is the source of truth
+for required checks; the table below explains why each job exists.
+
+The minimum supported Rust version (MSRV) is 1.85.0. Rust 1.85 is the first release supporting the
+Rust 2024 edition selected by the workspace. Every package inherits the same `rust-version`.
+
+## CI matrix
+
+| Job | Toolchain and targets | Contract enforced |
+|---|---|---|
+| `style-and-api` | Current stable on Ubuntu | Formatting, Clippy with warnings denied, and warning-free public docs |
+| `native-test` | Current stable on Ubuntu, macOS, and Windows | All workspace unit, integration, target, feature, and documentation tests plus release-profile checking |
+| `msrv` | Rust 1.85.0 on Ubuntu | Every workspace target and test continues to compile at the declared MSRV |
+| `portable-target` | Stable `aarch64-unknown-none`, `riscv64gc-unknown-none-elf`, and `wasm32-unknown-unknown` | `proto` and `core` remain `no_std`; device/facade layers require at most `alloc`; Wasm also checks the std reference crates |
+| `feature-sets-and-dependencies` | Stable on Ubuntu | Every Cargo feature combination plus a guard against `std`/`alloc` feature leakage into `proto` and `core` |
+| `dependency-policy` | Cargo-deny with Rust 1.85.0 | Advisories, yanked crates, duplicate versions, wildcard requirements, licenses, and dependency sources |
+| `fuzz-smoke` | Nightly on Ubuntu when `fuzz/Cargo.toml` exists | Every fuzz target gets bounded smoke iterations; issue #26 activates the job by adding the fuzz workspace |
+
+The native jobs intentionally use GitHub-hosted `*-latest` images so runner security and supported
+host versions advance without changing the project’s semantic target list. Release evidence records
+the concrete runner versions used for the release.
+
+## Crate portability tiers
+
+| Tier | Crates | Allowed runtime surface |
+|---|---|---|
+| `core-only` | `virtio-accel-proto`, `virtio-accel-core` | `core`; proc-macros may execute with `std` on the build host, but target dependencies may not enable `std` or `alloc` |
+| `alloc-portable` | `virtio-accel-device`, `virtio-accel` | `core + alloc`; no OS, filesystem, sockets, threads, or host synchronization |
+| `std-reference` | `virtio-accel-mock` | Portable `std`; no host-OS or vendor-specific API |
+
+Future reference guest and queue crates belong to `alloc-portable`. Concrete VMM, kernel, OS, and
+vendor adapters are outside the portable-v1 milestone and must not become default dependencies of a
+portable crate.
+
+## Cargo feature policy
+
+CI runs `cargo hack check --feature-powerset --no-dev-deps` across the workspace. Features must be
+additive: disabling default features may remove convenience behavior but must not select a different
+protocol interpretation.
+
+The portable dependency guard inspects resolved target features for `virtio-accel-proto` and
+`virtio-accel-core`. A dependency’s host-side derive macro may use `std`, but the target graph for
+these crates must not enable a dependency feature named `std` or `alloc`.
+
+## Dependency policy
+
+`deny.toml` permits only crates.io dependencies and the workspace’s path dependencies. It rejects:
+
+- known advisories and yanked releases;
+- unmaintained direct workspace dependencies;
+- unsound dependencies;
+- multiple resolved versions of the same crate;
+- wildcard version requirements; and
+- licenses outside Apache-2.0, BSD-2-Clause, MIT, and Unicode-3.0.
+
+GitHub Actions are pinned to immutable commit SHAs with their human-readable release versions kept
+in comments. Standalone CI tools are pinned too: `cargo-hack` 0.6.45, `cargo-fuzz` 0.13.2 on
+`nightly-2026-07-13`, and `cargo-deny` 0.20.2 (bundled by the pinned cargo-deny action).
+
+## Local verification
+
+The host-independent checks can be reproduced with:
+
+```sh
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps
+cargo test --workspace --all-targets --all-features
+cargo test --workspace --doc --all-features
+cargo +1.85.0 check --workspace --all-targets --all-features
+cargo hack check --workspace --feature-powerset --no-dev-deps
+bash ci/check-portable-dependencies.sh
+cargo deny --all-features check
+```
+
+Target checks require the corresponding Rust standard libraries:
+
+```sh
+rustup target add aarch64-unknown-none riscv64gc-unknown-none-elf wasm32-unknown-unknown
+cargo check \
+  -p virtio-accel-proto \
+  -p virtio-accel-core \
+  -p virtio-accel-device \
+  -p virtio-accel \
+  --target aarch64-unknown-none \
+  --no-default-features
+```

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -1,6 +1,7 @@
 # virtio-accel portable protocol foundations
 
-Status: frozen portable protocol 1.0. Implementation conformance remains in progress.
+Status: portable protocol 1.0 candidate. Implementation conformance and the final freeze audit
+remain in progress.
 
 This document defines the portable semantic foundation for `virtio-accel`. It does not assign a
 Virtio device ID and is not an OASIS Virtio specification. The transport model is intended to remain
@@ -8,8 +9,8 @@ compatible with the general facilities defined by the
 [Virtio specification](https://docs.oasis-open.org/virtio/virtio/v1.3/virtio-v1.3.html).
 
 Sections 1 through 11, [wire-abi.md](wire-abi.md), and [virtqueue.md](virtqueue.md) are normative for
-portable protocol 1.0. Appendix A maps the current Rust surface to the terms in this document and is
-non-normative implementation guidance.
+the portable protocol 1.0 candidate. Appendix A maps the current Rust surface to the terms in this
+document and is non-normative implementation guidance.
 
 ## 1. Normative language
 
@@ -257,11 +258,16 @@ Unknown request, context, execution-queue, submission, buffer-usage, or binding-
 
 ## 6. Versioning and compatibility
 
-### 6.1 Frozen version
+### 6.1 Candidate version
 
-This specification freezes protocol version `1.0`. Implementations **MUST** expose major `1` and
-minor `0` in device-specific configuration and **MUST NOT** claim protocol 1.0 conformance unless
-they satisfy the normative wire, queue, lifecycle, and compatibility requirements.
+This specification assigns version `1.0` to the candidate exercised by the conformance artifacts.
+Candidate implementations **MUST** expose major `1` and minor `0` in device-specific configuration
+and **MUST NOT** claim candidate protocol 1.0 conformance unless they satisfy the normative wire,
+queue, lifecycle, and compatibility requirements.
+
+Protocol 1.0 does not become a stable compatibility promise until the final audit tracked by issue
+#33. Before that audit, an intentional candidate revision **MUST** follow the coordinated procedure
+in [wire-abi.md](wire-abi.md) and **MUST NOT** be described as a frozen or stable release.
 
 ### 6.2 Stable major versions
 
@@ -359,16 +365,18 @@ Portable crates **MUST NOT** select an operating system, VMM, kernel, vendor API
 Platform adapters depend inward on the portable layers. A portable layer **MUST NOT** conditionally
 expose different semantics by host OS.
 
-## 11. Tracked semantic freezes
+## 11. Tracked completion work
 
-This document, [wire-abi.md](wire-abi.md), and [virtqueue.md](virtqueue.md) freeze the driver/device
-protocol. The following implementation and provider details remain explicitly tracked rather than
-silently decided here:
+This document, [wire-abi.md](wire-abi.md), and [virtqueue.md](virtqueue.md) define the current
+driver/device protocol candidate. The following implementation, provider, and verification details
+remain explicitly tracked rather than silently decided here:
 
-- issue #21 freezes the complete backend capability, memory-domain, execution-queue, blocking,
-  concurrency, and release semantics without changing the 1.0 wire contract;
+- issue #21 completes the backend capability, memory-domain, execution-queue, blocking,
+  concurrency, and release semantics before the wire contract freezes;
 - issue #25 turns the trust assumptions into enforceable resource and threat-model limits; and
-- issue #32 defines post-1.0 semver and wire-evolution policy.
+- issue #32 defines post-1.0 semver and wire-evolution policy; and
+- issue #33 performs the final protocol and API audit, including independent clean-room review,
+  before freezing protocol 1.0.
 
 No implementation **MAY** advertise a reserved optional feature merely because a Rust constant
 records its numeric position.
@@ -399,9 +407,9 @@ model or is identified as an implementation helper.
 | `ReleaseFailure` | Rejected versus indeterminate resource-release boundary |
 | `Accelerator` | Accelerator backend contract |
 | `Le16`, `Le32`, `Le64` | Wire implementation aliases; not semantic API |
-| `PROTOCOL_MAJOR`, `PROTOCOL_MINOR` | Frozen protocol version 1.0 |
+| `PROTOCOL_MAJOR`, `PROTOCOL_MINOR` | Candidate protocol version 1.0 |
 | `COMMAND_QUEUE` | Baseline command virtqueue index |
-| `BASELINE_COMMAND_QUEUES`, `HARD_MAX_*`, `MIN_MAX_*` | Frozen queue, frame, binding, and configuration bounds |
+| `BASELINE_COMMAND_QUEUES`, `HARD_MAX_*`, `MIN_MAX_*` | Candidate queue, frame, binding, and configuration bounds |
 | `KNOWN_*_BITS`, `RESERVED_REQUEST_FLAG_NO_WAIT` | Assigned and reserved-zero flag namespaces |
 | `FeatureBits` | Device-specific Virtio transport features |
 | `BASELINE_FEATURES` | Mandatory feature set, currently empty |

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -1,15 +1,15 @@
 # virtio-accel portable protocol foundations
 
-Status: normative design draft. Current draft protocol version: 0.1. Target first stable protocol
-version: 1.0.
+Status: frozen portable protocol 1.0. Implementation conformance remains in progress.
 
 This document defines the portable semantic foundation for `virtio-accel`. It does not assign a
 Virtio device ID and is not an OASIS Virtio specification. The transport model is intended to remain
 compatible with the general facilities defined by the
 [Virtio specification](https://docs.oasis-open.org/virtio/virtio/v1.3/virtio-v1.3.html).
 
-Sections 1 through 11 are normative for the portable v1 design. Appendix A maps the current Rust
-surface to the terms in this document and is non-normative implementation guidance.
+Sections 1 through 11, [wire-abi.md](wire-abi.md), and [virtqueue.md](virtqueue.md) are normative for
+portable protocol 1.0. Appendix A maps the current Rust surface to the terms in this document and is
+non-normative implementation guidance.
 
 ## 1. Normative language
 
@@ -222,13 +222,13 @@ changing the event.
 
 ### 5.2 Transport feature bits
 
-Transport feature bits alter driver/device protocol behavior. The mandatory draft baseline has no
+Transport feature bits alter driver/device protocol behavior. The mandatory baseline has no
 device-specific transport features: `BASELINE_FEATURES` is empty.
 
-The currently assigned draft bits `MULTI_QUEUE`, `EVENT_QUEUE`, `EXTERNAL_MEMORY`,
+The currently reserved bits `MULTI_QUEUE`, `EVENT_QUEUE`, `EXTERNAL_MEMORY`,
 `TIMELINE_FENCES`, and `SECURE_CONTEXTS` reserve numeric positions only. A baseline device **MUST NOT**
-advertise them and a baseline driver **MUST NOT** accept them. Advertising one before its normative
-semantics and conformance tests are complete is a protocol error.
+advertise them and a baseline driver **MUST NOT** accept them. Protocol 1.0 assigns no semantics to
+these positions.
 
 Unknown device-specific feature bits **MUST NOT** be accepted by a driver. A device **MUST NOT**
 offer a feature it cannot honor if accepted.
@@ -242,28 +242,26 @@ If enabling a backend capability would require different descriptor direction, a
 new synchronization, or changed lifetime rules, the device **MUST** also negotiate an appropriate
 transport feature.
 
-The exact v1 meanings of host-visible memory, device-local memory, secure contexts, and execution
-queue flags are frozen by issues #21 and #9. Until then, the reference implementation **MUST NOT**
-translate an underspecified capability into additional wire behavior.
+The exact backend meanings of host-visible memory, device-local memory, secure contexts, and
+execution-queue flags are tracked by issue #21. Protocol 1.0 accepts only the wire values explicitly
+listed in [wire-abi.md](wire-abi.md); the reference implementation **MUST NOT** translate an
+underspecified capability into additional wire behavior.
 
 ### 5.4 Request and object flags
 
-All request-header flags are zero in the mandatory draft baseline. `NO_WAIT` retains a draft numeric
-assignment but is unadvertised and **MUST NOT** be sent until its command-specific semantics are
-defined by issue #9.
+All request-header flags are zero in protocol 1.0. The former draft `NO_WAIT` position, bit zero, is
+reserved and **MUST** be zero.
 
 Unknown request, context, execution-queue, submission, buffer-usage, or binding-access flag bits
 **MUST** be rejected before backend invocation. Reserved fields **MUST** be zero.
 
 ## 6. Versioning and compatibility
 
-### 6.1 Draft version
+### 6.1 Frozen version
 
-Protocol major zero is pre-stable. The current `0.1` wire values may change incompatibly while the
-v1 issues remain open. Implementations **MUST NOT** claim stable interoperability from a major-zero
-version.
-
-The first frozen release will use protocol version `1.0`.
+This specification freezes protocol version `1.0`. Implementations **MUST** expose major `1` and
+minor `0` in device-specific configuration and **MUST NOT** claim protocol 1.0 conformance unless
+they satisfy the normative wire, queue, lifecycle, and compatibility requirements.
 
 ### 6.2 Stable major versions
 
@@ -363,20 +361,17 @@ expose different semantics by host OS.
 
 ## 11. Tracked semantic freezes
 
-This document resolves the shared vocabulary and compatibility model. The following details remain
-explicitly tracked rather than silently decided here:
+This document, [wire-abi.md](wire-abi.md), and [virtqueue.md](virtqueue.md) freeze the driver/device
+protocol. The following implementation and provider details remain explicitly tracked rather than
+silently decided here:
 
-- issue #9 freezes every numeric ABI value, payload, status, request flag, and exact capability
-  mapping;
-- issue #10 freezes descriptor-chain framing, used length, ordering, notification, and reset
-  behavior;
 - issue #21 freezes the complete backend capability, memory-domain, execution-queue, blocking,
-  concurrency, and release semantics;
+  concurrency, and release semantics without changing the 1.0 wire contract;
 - issue #25 turns the trust assumptions into enforceable resource and threat-model limits; and
 - issue #32 defines post-1.0 semver and wire-evolution policy.
 
-No implementation **MAY** advertise an underspecified optional feature merely because a draft Rust
-constant already exists.
+No implementation **MAY** advertise a reserved optional feature merely because a Rust constant
+records its numeric position.
 
 ## Appendix A: Rust surface mapping
 
@@ -389,9 +384,9 @@ model or is identified as an implementation helper.
 | `AcceleratorClass` | Extensible device class in device identity |
 | `Capabilities` | Semantic backend capabilities; not Virtio feature bits |
 | `DeviceIdentity` | Device instance identity |
-| `DeviceLimits` | Semantic limits enforced before backend invocation |
+| `DeviceLimits` | Context, buffer, program, execution-queue, event, binding, and byte limits enforced before backend invocation |
 | `DeviceInfo` | Device identity, semantic capabilities, and limits |
-| `ContextFlags`, `ContextDesc` | Context creation intent; nonzero draft flags remain subject to #9/#21 |
+| `ContextFlags`, `ContextDesc` | Context creation intent; protocol 1.0 accepts only empty context flags |
 | `MemoryDomain` | Requested buffer placement class |
 | `BufferUsage`, `BufferDesc`, `BufferRange` | Buffer allocation intent and checked byte range |
 | `AccessMode` | Binding read/write intent |
@@ -404,15 +399,17 @@ model or is identified as an implementation helper.
 | `ReleaseFailure` | Rejected versus indeterminate resource-release boundary |
 | `Accelerator` | Accelerator backend contract |
 | `Le16`, `Le32`, `Le64` | Wire implementation aliases; not semantic API |
-| `PROTOCOL_MAJOR`, `PROTOCOL_MINOR` | Draft/stable compatibility version |
+| `PROTOCOL_MAJOR`, `PROTOCOL_MINOR` | Frozen protocol version 1.0 |
 | `COMMAND_QUEUE` | Baseline command virtqueue index |
+| `BASELINE_COMMAND_QUEUES`, `HARD_MAX_*`, `MIN_MAX_*` | Frozen queue, frame, binding, and configuration bounds |
+| `KNOWN_*_BITS`, `RESERVED_REQUEST_FLAG_NO_WAIT` | Assigned and reserved-zero flag namespaces |
 | `FeatureBits` | Device-specific Virtio transport features |
 | `BASELINE_FEATURES` | Mandatory feature set, currently empty |
-| `UNADVERTISED_DRAFT_FEATURES` | Reserved namespace that must not be advertised |
-| `RequestFlags` | Per-request wire flags; zero in the mandatory draft baseline |
+| `RESERVED_FEATURES` | Reserved namespace that must not be advertised |
+| `RequestFlags` | Per-request wire flags; empty in protocol 1.0 |
 | `KnownOpcode`, `UnknownOpcode` | Validated command namespace and opaque unknown opcode |
 | `StatusCode` | Extensible response status namespace |
-| `WireConfig` | Device-specific configuration fields |
+| `WireConfig`, `ConfigError` | Device-specific configuration and executable validity rules |
 | `RequestHeader`, `ResponseHeader` | Request and response frame headers |
 | `WireDeviceInfo` | Device-information response payload |
 | `CreateContextRequest` | Context-create request payload |
@@ -422,7 +419,8 @@ model or is identified as an implementation helper.
 | `LoadProgramRequest` | Program-load request prefix |
 | `CreateQueueRequest` | Accelerator execution-queue-create payload |
 | `SubmitRequest`, `WireBinding` | Submission prefix and binding array entry |
-| `WireEventState` | Event-poll response payload |
+| `SubmitResponse` | Event ownership payload for accepted or indeterminate submission |
+| `WireEventState`, `KnownEventState`, `UnknownEventState` | Event-poll response payload and extensible raw state handling |
 | `DecodeError`, `read_exact`, `checked_array_bytes` | Protocol decoding helpers; implementation-only |
 | `ObjectKind`, `ObjectId` | Device-private typed object identity |
 | `ObjectTable`, `ObjectTableError` | Device implementation state; encoding is not wire ABI |

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -1,0 +1,430 @@
+# virtio-accel portable protocol foundations
+
+Status: normative design draft. Current draft protocol version: 0.1. Target first stable protocol
+version: 1.0.
+
+This document defines the portable semantic foundation for `virtio-accel`. It does not assign a
+Virtio device ID and is not an OASIS Virtio specification. The transport model is intended to remain
+compatible with the general facilities defined by the
+[Virtio specification](https://docs.oasis-open.org/virtio/virtio/v1.3/virtio-v1.3.html).
+
+Sections 1 through 11 are normative for the portable v1 design. Appendix A maps the current Rust
+surface to the terms in this document and is non-normative implementation guidance.
+
+## 1. Normative language
+
+The key words **MUST**, **MUST NOT**, **REQUIRED**, **SHOULD**, **SHOULD NOT**, **MAY**, and
+**OPTIONAL** are to be interpreted as described by RFC 2119 and RFC 8174 when, and only when, they
+appear in bold capitals.
+
+Explanatory paragraphs beginning with “Rationale” are non-normative.
+
+## 2. Scope
+
+The portable v1 contract defines:
+
+- device discovery and protocol compatibility;
+- contexts and context-scoped resource ownership;
+- buffers and bounded byte transfers;
+- opaque program artifacts;
+- accelerator execution queues;
+- submissions, bindings, relative timeouts, and asynchronous events;
+- cancellation when supported;
+- explicit destruction, reset, and failure recovery; and
+- a single baseline command virtqueue carrying request and response frames.
+
+The portable v1 contract deliberately does not define:
+
+- a standardized accelerator graph, compiler IR, or executable format;
+- an OASIS device ID or standards submission;
+- PCI, MMIO, vhost-user, QEMU, kernel, DRM, VFIO, or hypervisor integration;
+- operating-system or vendor accelerator APIs;
+- DMA-BUF, platform shared handles, zero-copy external memory, cache-coherency protocols, or
+  timeline fences;
+- packed virtqueues; or
+- process, thread, executor, or async-runtime policy.
+
+Adding an integration listed above **MUST NOT** change the portable object lifecycle by convention.
+If it changes driver/device-visible behavior, it requires a negotiated feature or a new protocol
+version.
+
+## 3. Roles and boundaries
+
+### 3.1 Driver
+
+The **driver** is the request initiator. It discovers the device, validates protocol compatibility,
+negotiates Virtio features, constructs request frames, publishes descriptor chains, validates
+responses, and owns guest-side request tracking.
+
+The driver **MUST** treat all device-written bytes as untrusted.
+
+### 3.2 Device
+
+The **device** owns the guest-visible protocol state. It validates descriptor direction and frame
+bytes, maps opaque object IDs to live resources, enforces limits and context isolation, invokes an
+accelerator backend, writes responses, and performs reset.
+
+The device **MUST** treat all driver-written bytes, lengths, counts, object IDs, flags, and timing as
+untrusted.
+
+### 3.3 Transport adapter
+
+A **transport adapter** maps a concrete Virtio implementation to portable readable/writable regions,
+queue notification, used-length reporting, and reset operations.
+
+A transport adapter **MUST NOT** expose guest addresses, descriptor objects, host mappings, or
+transport-specific synchronization types to the accelerator backend.
+
+### 3.4 Command engine
+
+The **command engine** is the transport-neutral device state machine. It decodes one validated
+request, performs object and quota checks, invokes the backend, updates ownership state, and produces
+one response.
+
+The command engine **MUST NOT** depend on an operating system, VMM, kernel, guest-memory crate, vendor
+API, or compiler API.
+
+### 3.5 Accelerator backend
+
+The **accelerator backend** implements device-local execution semantics using provider-owned native
+handles. It is represented by `virtio_accel_core::Accelerator`.
+
+A backend **MUST NOT** receive wire structures, object IDs, guest addresses, or virtqueue
+descriptors. It receives validated semantic values and provider-owned handles.
+
+## 4. Terminology and object model
+
+### 4.1 Device instance
+
+A **device instance** is one initialized protocol endpoint and its backend. It owns:
+
+- one device identity and set of semantic capabilities;
+- advertised limits;
+- one object-ID namespace;
+- zero or more contexts; and
+- one reset epoch.
+
+Object IDs are meaningful only within the device instance and reset epoch that created them.
+
+### 4.2 Command virtqueue
+
+The **command virtqueue** is the Virtio transport queue that carries request and response frames.
+Queue index zero is the only command virtqueue in the mandatory baseline.
+
+The command virtqueue is not an accelerator execution queue.
+
+### 4.3 Context
+
+A **context** is the isolation and ownership parent for buffers, programs, accelerator execution
+queues, and the events created by its submissions.
+
+A device **MUST** reject an operation that combines objects from different contexts before invoking
+the backend. A context **MUST NOT** be destroyed while any child object or in-flight reference
+remains live.
+
+### 4.4 Buffer
+
+A **buffer** is a bounded backend allocation with:
+
+- a nonzero byte length;
+- a nonzero power-of-two alignment;
+- a memory domain; and
+- declared usage flags.
+
+The buffer’s guest-visible object ID is not an address. Every transfer and binding range **MUST** fit
+within the buffer without integer overflow.
+
+### 4.5 Program
+
+A **program** is a resident backend object created from an opaque artifact format, opaque target
+identity, payload, and declared resident-byte requirement.
+
+The transport **MUST NOT** interpret vendor artifact contents. Artifact-format adapters own their
+validation beyond the portable envelope fields.
+
+### 4.6 Accelerator execution queue
+
+An **accelerator execution queue** is a context-scoped backend object used to submit programs for
+execution. It is created by the protocol `CreateQueue` command and represented by
+`Accelerator::Queue`.
+
+It is unrelated to a Virtio queue index. Documentation and APIs **SHOULD** use “execution queue”
+whenever omitting “accelerator” would make the distinction unclear.
+
+### 4.7 Binding
+
+A **binding** associates one program slot with a nonempty buffer range and an intended access mode
+for one submission.
+
+Binding slot numbers **MUST** be unique within a submission. A binding does not transfer ownership
+of its buffer, but the device **MUST** retain the buffer until the resulting event is safely
+reclaimed.
+
+### 4.8 Submission
+
+A **submission** is an attempt to admit one program, execution queue, binding list, and relative
+timeout to the backend.
+
+Admission has an explicit acceptance boundary:
+
+- **rejected** means the backend guarantees that execution was not accepted and no operation
+  resources were retained;
+- **accepted** returns an event; and
+- **indeterminate** means acceptance cannot be established and therefore also returns an event that
+  owns the retained resources.
+
+The command engine **MUST NOT** convert an indeterminate submission into an ordinary error.
+
+### 4.9 Event
+
+An **event** is the ownership and completion token for one accepted or indeterminate submission. Its
+state is pending, complete, failed, or cancelled.
+
+An event **MUST** retain its execution queue, program, buffers, and per-invocation backend state until
+it is terminal and successfully destroyed. A pending event **MUST NOT** be destroyed.
+
+### 4.10 Request and response
+
+A **request** is one driver-readable command frame identified by a request ID. A **response** is the
+corresponding device-written frame with the same request ID.
+
+Request IDs correlate command completion only. They are not object IDs or execution event IDs.
+
+### 4.11 Reset
+
+A **reset** stops admission, disposes or quarantines in-flight state according to its known ownership,
+invalidates every guest-visible object ID, advances the device epoch, resets command queues, and
+returns the device to its initial negotiation state.
+
+No object ID created before reset may resolve after reset.
+
+## 5. Baseline capabilities and feature policy
+
+### 5.1 Mandatory baseline
+
+The portable v1 baseline **MUST** provide:
+
+- command virtqueue zero;
+- fixed-width little-endian request and response headers;
+- device information;
+- context creation and destruction;
+- buffer allocation, destruction, and bounded read/write transfer;
+- opaque program loading and destruction;
+- accelerator execution queue creation and destruction;
+- submission with bounded bindings and relative timeout;
+- event polling and destruction;
+- stale-object and cross-context rejection; and
+- whole-device reset.
+
+The command opcode for cancellation is part of the baseline namespace. If the backend does not
+advertise semantic event-cancellation capability, the device **MUST** return `UNSUPPORTED` without
+changing the event.
+
+### 5.2 Transport feature bits
+
+Transport feature bits alter driver/device protocol behavior. The mandatory draft baseline has no
+device-specific transport features: `BASELINE_FEATURES` is empty.
+
+The currently assigned draft bits `MULTI_QUEUE`, `EVENT_QUEUE`, `EXTERNAL_MEMORY`,
+`TIMELINE_FENCES`, and `SECURE_CONTEXTS` reserve numeric positions only. A baseline device **MUST NOT**
+advertise them and a baseline driver **MUST NOT** accept them. Advertising one before its normative
+semantics and conformance tests are complete is a protocol error.
+
+Unknown device-specific feature bits **MUST NOT** be accepted by a driver. A device **MUST NOT**
+offer a feature it cannot honor if accepted.
+
+### 5.3 Semantic backend capabilities
+
+Backend `Capabilities` report whether a semantic operation or resource class is supported. They do
+not independently change wire framing.
+
+If enabling a backend capability would require different descriptor direction, additional queues,
+new synchronization, or changed lifetime rules, the device **MUST** also negotiate an appropriate
+transport feature.
+
+The exact v1 meanings of host-visible memory, device-local memory, secure contexts, and execution
+queue flags are frozen by issues #21 and #9. Until then, the reference implementation **MUST NOT**
+translate an underspecified capability into additional wire behavior.
+
+### 5.4 Request and object flags
+
+All request-header flags are zero in the mandatory draft baseline. `NO_WAIT` retains a draft numeric
+assignment but is unadvertised and **MUST NOT** be sent until its command-specific semantics are
+defined by issue #9.
+
+Unknown request, context, execution-queue, submission, buffer-usage, or binding-access flag bits
+**MUST** be rejected before backend invocation. Reserved fields **MUST** be zero.
+
+## 6. Versioning and compatibility
+
+### 6.1 Draft version
+
+Protocol major zero is pre-stable. The current `0.1` wire values may change incompatibly while the
+v1 issues remain open. Implementations **MUST NOT** claim stable interoperability from a major-zero
+version.
+
+The first frozen release will use protocol version `1.0`.
+
+### 6.2 Stable major versions
+
+For protocol major one and later:
+
+- a driver **MUST** reject a device with an unsupported major version;
+- a device minor version is backward compatible with all earlier minor versions of the same major;
+- a driver **MUST NOT** use behavior newer than the device minor version it observed; and
+- feature negotiation remains required even when both endpoints know a feature’s numeric bit.
+
+A major version changes when compatibility cannot be preserved through a new opcode, a new
+negotiated feature, or a previously reserved value.
+
+### 6.3 Extending existing frames
+
+The config space does not communicate the driver’s supported minor version back to the device.
+Therefore a minor version alone **MUST NOT** append fields to an existing response that an older
+driver would receive.
+
+Within a stable major version, an existing request or response payload length is immutable unless a
+negotiated feature explicitly selects a different layout. Extensions **SHOULD** use a new opcode or
+feature-gated payload.
+
+Without such a feature, a receiver **MUST** require the exact payload length for the opcode and
+**MUST** reject trailing bytes. It **MUST NOT** silently reinterpret or ignore an unknown tail.
+
+### 6.4 Unknown numeric values
+
+- An unknown opcode produces `UNSUPPORTED` and no semantic state change.
+- An unknown request or object flag bit produces `UNSUPPORTED` and no backend call.
+- An unknown object ID or zero object ID produces the specified invalid/stale-object failure.
+- An unknown response status is an opaque failure. A driver **MUST NOT** treat it as success or
+  construct an invalid Rust enum value.
+- Unknown accelerator classes and provider-owned artifact formats remain representable as opaque
+  numeric values, but using them may produce `UNSUPPORTED` or `INCOMPATIBLE`.
+
+## 7. Ownership and destruction
+
+The device owns the mapping from opaque object IDs to backend handles. The mapping **MUST** reject:
+
+- zero IDs;
+- stale generations;
+- wrong resource kinds;
+- IDs from another context; and
+- IDs invalidated by reset.
+
+Object-ID encoding is implementation-private. Drivers **MUST NOT** infer slot, kind, generation, or
+address information from an ID.
+
+Destructive backend calls consume handles and have an explicit release boundary:
+
+- a rejected release returns the still-live handle and the device **MUST** restore it for retry;
+- a successful release removes the object permanently; and
+- an indeterminate release invalidates the guest ID and requires recovery. The device **MUST NOT**
+  reuse or free the handle based on an assumption.
+
+`Drop` may provide defensive cleanup inside an implementation but **MUST NOT** be used as
+guest-visible protocol state.
+
+## 8. Time and progress
+
+Wire timeouts are relative nanosecond durations measured from backend admission. Zero means
+infinite. Absolute guest timestamps **MUST NOT** be compared with a host clock because their
+monotonic epochs are unrelated.
+
+Polling an event **MUST** be nonblocking and bounded. The portable contract creates no background
+thread and selects no async executor.
+
+A timeout before admission is rejected. A timeout or communication failure after admission that
+cannot prove rejection is indeterminate and **MUST** retain an event.
+
+## 9. Errors
+
+The portable status namespace distinguishes unsupported behavior, incompatibility, invalid
+arguments, out-of-bounds access, busy resources, host allocation failure, configured resource-limit
+exhaustion, deadline expiration, device loss, permission failure, stale objects, and internal
+errors.
+
+A device **MUST** map errors deterministically and **MUST NOT** expose uninitialized response bytes.
+Provider-specific `External` domains and codes are not part of the baseline wire ABI; absent a
+future negotiated diagnostic extension, they map to `INTERNAL_ERROR`.
+
+An error response **MUST NOT** imply that a backend operation was rejected when acceptance was
+indeterminate.
+
+## 10. Portability requirements
+
+Portable crates **MUST NOT** select an operating system, VMM, kernel, vendor API, or global runtime.
+
+- `virtio-accel-proto` and `virtio-accel-core` require neither `std` nor `alloc`.
+- `virtio-accel-device` and the future reference guest/queue layers may require `alloc` but not
+  `std`.
+- reference host tooling and mock backends may require `std`.
+
+Platform adapters depend inward on the portable layers. A portable layer **MUST NOT** conditionally
+expose different semantics by host OS.
+
+## 11. Tracked semantic freezes
+
+This document resolves the shared vocabulary and compatibility model. The following details remain
+explicitly tracked rather than silently decided here:
+
+- issue #9 freezes every numeric ABI value, payload, status, request flag, and exact capability
+  mapping;
+- issue #10 freezes descriptor-chain framing, used length, ordering, notification, and reset
+  behavior;
+- issue #21 freezes the complete backend capability, memory-domain, execution-queue, blocking,
+  concurrency, and release semantics;
+- issue #25 turns the trust assumptions into enforceable resource and threat-model limits; and
+- issue #32 defines post-1.0 semver and wire-evolution policy.
+
+No implementation **MAY** advertise an underspecified optional feature merely because a draft Rust
+constant already exists.
+
+## Appendix A: Rust surface mapping
+
+This appendix is non-normative. It ensures every current public concept has an explicit place in the
+model or is identified as an implementation helper.
+
+| Rust concept | Protocol term or classification |
+|---|---|
+| `BackendError` | Backend failure taxonomy translated by the command engine into portable status |
+| `AcceleratorClass` | Extensible device class in device identity |
+| `Capabilities` | Semantic backend capabilities; not Virtio feature bits |
+| `DeviceIdentity` | Device instance identity |
+| `DeviceLimits` | Semantic limits enforced before backend invocation |
+| `DeviceInfo` | Device identity, semantic capabilities, and limits |
+| `ContextFlags`, `ContextDesc` | Context creation intent; nonzero draft flags remain subject to #9/#21 |
+| `MemoryDomain` | Requested buffer placement class |
+| `BufferUsage`, `BufferDesc`, `BufferRange` | Buffer allocation intent and checked byte range |
+| `AccessMode` | Binding read/write intent |
+| `ArtifactFormat`, `TargetIdentity`, `ArtifactRef` | Opaque program artifact description |
+| `QueueFlags`, `QueueDesc` | Accelerator execution-queue creation intent, not a Virtio queue |
+| `Timeout` | Relative admission timeout; zero on wire means infinite |
+| `BindingRef`, `validate_bindings` | Validated semantic binding and implementation helper |
+| `EventState` | Event completion state |
+| `SubmitFailure` | Rejected versus indeterminate submission acceptance boundary |
+| `ReleaseFailure` | Rejected versus indeterminate resource-release boundary |
+| `Accelerator` | Accelerator backend contract |
+| `Le16`, `Le32`, `Le64` | Wire implementation aliases; not semantic API |
+| `PROTOCOL_MAJOR`, `PROTOCOL_MINOR` | Draft/stable compatibility version |
+| `COMMAND_QUEUE` | Baseline command virtqueue index |
+| `FeatureBits` | Device-specific Virtio transport features |
+| `BASELINE_FEATURES` | Mandatory feature set, currently empty |
+| `UNADVERTISED_DRAFT_FEATURES` | Reserved namespace that must not be advertised |
+| `RequestFlags` | Per-request wire flags; zero in the mandatory draft baseline |
+| `KnownOpcode`, `UnknownOpcode` | Validated command namespace and opaque unknown opcode |
+| `StatusCode` | Extensible response status namespace |
+| `WireConfig` | Device-specific configuration fields |
+| `RequestHeader`, `ResponseHeader` | Request and response frame headers |
+| `WireDeviceInfo` | Device-information response payload |
+| `CreateContextRequest` | Context-create request payload |
+| `ObjectPayload` | One opaque object ID in a request or response |
+| `AllocateBufferRequest` | Buffer-allocation request payload |
+| `TransferBufferRequest` | Bounded buffer-transfer request prefix |
+| `LoadProgramRequest` | Program-load request prefix |
+| `CreateQueueRequest` | Accelerator execution-queue-create payload |
+| `SubmitRequest`, `WireBinding` | Submission prefix and binding array entry |
+| `WireEventState` | Event-poll response payload |
+| `DecodeError`, `read_exact`, `checked_array_bytes` | Protocol decoding helpers; implementation-only |
+| `ObjectKind`, `ObjectId` | Device-private typed object identity |
+| `ObjectTable`, `ObjectTableError` | Device implementation state; encoding is not wire ABI |
+| `status_from_backend_error`, `status_from_object_table_error` | Device implementation mapping helpers |
+| `MockAccelerator` and mock handle types | Reference/test implementation, not normative protocol |

--- a/docs/virtqueue.md
+++ b/docs/virtqueue.md
@@ -1,0 +1,254 @@
+# virtio-accel protocol 1.0 command-virtqueue contract
+
+This document defines how protocol 1.0 request and response frames inhabit Virtio descriptor
+chains. It is normative together with [specification.md](specification.md) and
+[wire-abi.md](wire-abi.md).
+
+The portable reference path targets a split virtqueue. It relies only on ordered readable and
+writable byte regions plus queue publication/completion operations, so future transport adapters do
+not need to expose guest addresses or transport-specific descriptor types to the command engine.
+
+## 1. Relationship to the base Virtio specification
+
+The [Virtio 1.3 specification](https://docs.oasis-open.org/virtio/virtio/v1.3/virtio-v1.3.html)
+continues to supply the base rules, including descriptor-loop prohibition, negotiated indirect
+descriptors, queue publication barriers, notification suppression, and transport reset. This
+document adds device-specific framing requirements.
+
+Protocol 1.0 defines command virtqueue index zero. It defines no device-specific multi-queue feature.
+The reference device **MUST NOT** offer `VIRTIO_F_RING_PACKED`, `VIRTIO_F_IN_ORDER`,
+`VIRTIO_F_RING_RESET`, `VIRTIO_F_INDIRECT_DESC`, or `VIRTIO_F_EVENT_IDX`. It uses direct split-ring
+descriptors and the basic available/used notification-suppression flags. A future adapter may
+support one of these base Virtio features only when it preserves the device-specific rules here and
+adds corresponding conformance evidence. Whole-device reset remains mandatory.
+
+## 2. Flattened chain model
+
+For validation, a transport adapter presents one available descriptor head as:
+
+- an ordered list of device-readable byte regions;
+- followed by an ordered list of device-writable byte regions; and
+- the original queue head token used for completion.
+
+A future adapter may flatten a valid indirect descriptor table when `VIRTIO_F_INDIRECT_DESC` was
+negotiated. The configured `max_chain_descriptors` then applies after flattening and includes both
+readable and writable descriptors. The protocol 1.0 reference profile rejects indirect
+descriptors because it does not negotiate that feature.
+
+The command engine sees region lengths and byte access only. It **MUST NOT** receive guest physical
+addresses, descriptor indices, indirect-table addresses, ring pointers, or notification objects.
+
+## 3. Descriptor-chain validity
+
+A protocol 1.0 command chain is valid only when all of the following hold:
+
+1. The chain is acyclic and structurally valid under the base Virtio specification.
+2. Its flattened descriptor count is 2 through configured `max_chain_descriptors`.
+3. Every descriptor length is nonzero.
+4. At least one device-readable descriptor precedes at least one device-writable descriptor.
+5. No device-readable descriptor follows a device-writable descriptor.
+6. The readable total is representable, no greater than configured `max_request_bytes`, and exactly
+   one complete request frame.
+7. The writable total is representable and large enough for the command’s maximum possible
+   response shape.
+
+Cross-region reads and writes concatenate regions without inserting padding. Header or payload
+fields may cross descriptor boundaries at any byte.
+
+The transport adapter **MUST** validate the descriptor topology and map every readable and required
+writable byte before the command engine performs semantic validation or invokes a backend.
+
+## 4. One command per chain
+
+Exactly one request frame occupies the complete readable portion of a chain. The first readable byte
+is request-header byte zero. The readable total **MUST** equal:
+
+```text
+16 + request_header.payload_bytes
+```
+
+No bytes before the header, between fixed and variable payload portions, or after the declared
+payload are permitted.
+
+The response begins at writable byte zero. Writable capacity beyond the actual response remains
+untouched and is not included in used length.
+
+## 5. Validation order and failure atomicity
+
+The device validates a chain in this order:
+
+1. descriptor topology, direction, count, nonzero lengths, addressability, and total-length
+   arithmetic;
+2. availability of a complete 16-byte request header and 16-byte writable response header;
+3. configured request limit and exact `payload_bytes` equality;
+4. opcode and request-header flags;
+5. command-specific fixed length, variable counts, reserved fields, scalar namespaces, object
+   relationships, and required writable capacity;
+6. quotas and semantic preconditions; and
+7. backend invocation.
+
+No failure in steps 1 through 5 may mutate device semantic state or invoke the backend.
+
+If descriptor topology is invalid, the request header is truncated, or writable capacity is less
+than 16 bytes, the device returns the descriptor head used with used length zero and writes no
+bytes.
+
+If the request header is valid enough to recover `request_id`, and writable capacity is at least 16,
+later validation failures produce a complete error response header. The used length is 16.
+
+Required success capacity is checked before semantic mutation. A short success buffer therefore
+produces used length zero, no response bytes, and no semantic state change; it is not converted to a
+smaller protocol error because the driver failed the response-buffer contract.
+
+## 6. Response writing and used length
+
+The device **MUST** commit a response atomically from the protocol’s point of view:
+
+- every byte counted as used is initialized;
+- the response header’s `payload_bytes` equals the bytes written after it;
+- no byte beyond `16 + payload_bytes` is written; and
+- the split-ring used element length equals `16 + payload_bytes`.
+
+Used length counts device-written bytes only. It never includes readable request bytes.
+
+Response bytes may span writable descriptors. A device **MUST** write them as if to one concatenated
+byte sequence.
+
+An unexpected mapping or write failure after the preflight succeeds indicates broken transport or
+memory state. If semantic mutation has not occurred, the chain may complete with used length zero.
+If mutation or uncertain backend acceptance has occurred, the device **MUST** set
+`DEVICE_NEEDS_RESET`, quarantine retained resources, and avoid a response that falsely claims
+rejection.
+
+## 7. Command and execution ordering
+
+The baseline command queue permits out-of-order command completion. The device **MUST** consume
+available heads in available-ring order, but may dispatch their semantic work concurrently and
+return them used in a different order as work completes. Drivers therefore track both descriptor
+heads and nonzero request IDs.
+
+Request-ID uniqueness lasts until the corresponding chain is returned used. A driver **MUST NOT**
+infer ordering from numeric request IDs.
+
+Command completion and accelerator execution completion are distinct:
+
+- `SUBMIT` command completion reports admission and returns an event ID;
+- the accelerator operation may remain pending after the command chain is used; and
+- `POLL_EVENT` observes execution completion independently of command ordering.
+
+Implementations may serialize command execution, but they **MUST NOT** promise in-order completion
+as protocol behavior.
+
+## 8. Backpressure and queue fullness
+
+Queue capacity is transport state, not a protocol error response.
+
+- A driver with no free descriptor head or insufficient writable buffers **MUST** retain the command
+  locally and report backpressure to its caller.
+- It **MUST NOT** publish a partial command or reuse descriptors still owned by the device.
+- A device may defer consumption or completion without busy-looping.
+- Resource limits discovered after a valid chain is consumed produce `RESOURCE_LIMIT`; descriptor
+  scarcity before publication does not.
+
+The reference guest API should represent pre-publication backpressure separately from protocol
+statuses so callers can retry without constructing a new semantic command.
+
+## 9. Notifications
+
+Available and used notifications follow the base Virtio split-ring suppression rules. Suppressing a
+notification changes neither command visibility nor completion semantics.
+
+- The driver publishes descriptors and the available-ring entry before deciding whether to notify.
+- The device publishes the used element and used index before deciding whether to notify.
+- Both sides must recheck queue state when required by the base specification to avoid lost wakeups.
+
+The device-specific protocol defines no polling interval, thread, executor, or interrupt affinity.
+
+## 10. Malformed chains
+
+The following are isolated command-chain failures and do not by themselves require device reset:
+
+- descriptor loops or an invalid indirect table caught before byte access;
+- too many, zero-length, missing-readable, missing-writable, or interleaved-direction descriptors;
+- truncated headers or payloads;
+- oversized frames;
+- exact-length or reserved-zero violations;
+- unknown opcodes, flags, or scalar values; and
+- insufficient writable capacity detected before semantic mutation.
+
+The device completes a structurally recoverable malformed chain according to section 5 and
+continues with later available chains.
+
+Repeated malformed input may be rate-limited by the transport or device integration, but rate
+limiting **MUST NOT** change object ownership or fabricate successful responses.
+
+## 11. Device reset and split-ring disposition
+
+Protocol 1.0 uses whole-device reset. The reference device does not negotiate independent
+`VIRTIO_F_RING_RESET`.
+
+When reset begins, the device:
+
+1. stops fetching new available chains;
+2. stops publishing used entries and notifications;
+3. prevents new backend admission;
+4. resolves, cancels, or quarantines already-started operations according to known ownership;
+5. invalidates all object IDs and request tracking from the old reset epoch; and
+6. resets command-queue available/used state as required by the base transport.
+
+Descriptor chains that were available or in progress when reset began are not completed after reset.
+Once the driver has observed reset completion, it may reclaim all queue memory and descriptors under
+the base Virtio reset rule. It **MUST NOT** expect response bytes or used entries for those chains.
+
+After reinitialization, request IDs may be reused, all object IDs from the prior epoch are stale, and
+the queue starts from its base initial state. No late backend completion from the old epoch may write
+guest memory or a new used ring.
+
+## 12. `DEVICE_NEEDS_RESET`
+
+Ordinary hostile input does not set `DEVICE_NEEDS_RESET`. The device sets it when continued protocol
+operation cannot preserve ownership or response truth, including:
+
+- indeterminate provider release that invalidates a guest object but leaves backend ownership
+  unknown;
+- inability to report or retain an indeterminate accepted submission;
+- response-write failure after semantic mutation;
+- internal state corruption or accounting contradiction; or
+- backend device loss that prevents bounded recovery.
+
+After observing `DEVICE_NEEDS_RESET`, the driver **SHOULD** stop submitting commands and perform
+whole-device reset. The device may finish responses whose ownership and output remain provably safe,
+but it **MUST NOT** accept new semantic work.
+
+## 13. Protocol conformance cases
+
+The portable conformance suite uses these stable case identifiers:
+
+| ID | Required assertion |
+|---|---|
+| `VQ-001` | One readable and one writable descriptor carries a valid command |
+| `VQ-002` | Header and every fixed payload decode across every possible byte split |
+| `VQ-003` | Multiple readable and writable segments concatenate without padding |
+| `VQ-004` | Missing readable or writable region completes with used length zero |
+| `VQ-005` | Readable descriptor after a writable descriptor is rejected before backend invocation |
+| `VQ-006` | Zero-length, looping, excessive, or invalid-indirect chains are rejected |
+| `VQ-007` | Truncated request header writes nothing and reports used length zero |
+| `VQ-008` | Valid header plus malformed payload writes exactly a 16-byte error response |
+| `VQ-009` | Unknown opcode returns `UNSUPPORTED` without semantic mutation |
+| `VQ-010` | Nonzero request, command, or reserved flags are rejected |
+| `VQ-011` | Trailing readable bytes are rejected |
+| `VQ-012` | Short command-specific response capacity is detected before mutation and writes nothing |
+| `VQ-013` | Success and error used lengths equal exact initialized response bytes |
+| `VQ-014` | Distinct requests can complete out of publication order and retain correct request IDs |
+| `VQ-015` | `SUBMIT` command completion is independent of event completion |
+| `VQ-016` | Queue-full pre-publication behavior is retryable backpressure, not a protocol status |
+| `VQ-017` | Notification suppression does not lose available or used work |
+| `VQ-018` | Reset produces no late used entries or guest writes from the old epoch |
+| `VQ-019` | Reset invalidates every old object ID and permits request-ID reuse |
+| `VQ-020` | Post-mutation output failure or indeterminate release sets `DEVICE_NEEDS_RESET` |
+
+The byte vectors under [`conformance/v1.0`](../conformance/v1.0/) cover protocol frames. Queue-model
+implementations consume the case identifiers above so the same behavioral scenarios can be reused
+by the in-memory split ring and future platform transports. Executable region/queue ports are
+tracked by issue #17, the split-ring assertions by #18, guest compatibility behavior by #19, and
+full-path assertions by #20.

--- a/docs/wire-abi.md
+++ b/docs/wire-abi.md
@@ -1,0 +1,330 @@
+# virtio-accel protocol 1.0 wire ABI
+
+This document freezes the byte-level portable protocol used by the command virtqueue. It is
+normative together with [specification.md](specification.md) and [virtqueue.md](virtqueue.md).
+Structure names refer to the Rust implementation for convenience; implementations in other
+languages depend only on the byte layouts and rules below.
+
+All multibyte integers are unsigned little-endian values unless a field explicitly says otherwise.
+Every structure has byte alignment one and contains no implicit padding. Offsets and sizes are
+listed in the checked-in [layout manifest](../conformance/v1.0/layout.json).
+
+## 1. Global limits
+
+| Constant | Value | Requirement |
+|---|---:|---|
+| Protocol version | 1.0 | Configuration **MUST** report major 1 and minor 0 |
+| Baseline command queues | 1 | Only command virtqueue index 0 exists |
+| Hard maximum chain descriptors | 256 | The advertised maximum **MUST** be 2 through 256 |
+| Hard maximum request frame | 16 MiB | Includes the 16-byte request header |
+| Hard maximum response frame | 16 MiB | Includes the 16-byte response header |
+| Hard maximum submission bindings | 4096 | The semantic advertised limit may be smaller |
+
+The device-specific configuration limits are additional negotiated bounds. A device **MUST NOT**
+advertise a limit above a hard maximum. A driver **MUST** reject invalid configuration rather than
+allocating from it.
+
+Every count-to-byte conversion **MUST** use checked multiplication and addition. A value that
+overflows the implementation address space or the fixed-width containing field is invalid.
+
+## 2. Device-specific configuration
+
+`WireConfig` is 16 bytes:
+
+| Offset | Bytes | Field | Protocol 1.0 rule |
+|---:|---:|---|---|
+| 0 | 2 | `protocol_major` | **MUST** be 1 |
+| 2 | 2 | `protocol_minor` | A conforming 1.0 device reports 0; a 1.0 driver **MUST** accept a higher minor and use only 1.0 behavior |
+| 4 | 2 | `command_queue_count` | **MUST** be 1 |
+| 6 | 2 | `max_chain_descriptors` | **MUST** be 2 through 256 and no greater than the configured queue size |
+| 8 | 4 | `max_request_bytes` | **MUST** be 97 through 16 MiB |
+| 12 | 4 | `max_response_bytes` | **MUST** be 92 through 16 MiB |
+
+The minimum request limit admits a one-byte program artifact. The minimum response limit admits the
+complete device-information response.
+
+The 16 bytes above are the protocol 1.0 configuration prefix. A future minor version may append
+configuration only when a 1.0 driver can safely ignore it and the extension does not alter baseline
+behavior without feature negotiation. A 1.0 driver reads and validates the prefix and does not
+require the entire transport-specific configuration region to be exactly 16 bytes.
+
+The baseline device-specific feature set is empty. Feature-bit positions 0 through 4 are reserved
+for multi-queue, event-queue, external-memory, timeline-fence, and secure-context proposals. A
+protocol 1.0 device **MUST NOT** advertise them and a protocol 1.0 driver **MUST NOT** accept them.
+
+## 3. Request and response frames
+
+### 3.1 Request header
+
+Every request begins with the 16-byte `RequestHeader`:
+
+| Offset | Bytes | Field | Rule |
+|---:|---:|---|---|
+| 0 | 2 | `opcode` | Raw opcode from section 5 |
+| 2 | 2 | `flags` | **MUST** be zero |
+| 4 | 4 | `payload_bytes` | Exact number of readable bytes after this header |
+| 8 | 8 | `request_id` | Nonzero and unique among requests outstanding on this device instance |
+
+Bit zero of `flags`, formerly drafted as `NO_WAIT`, is reserved and has no 1.0 semantics.
+
+The readable byte count **MUST** equal `16 + payload_bytes` exactly. There is no tolerated trailing
+extension area. An unknown opcode remains a raw integer long enough to produce `UNSUPPORTED`; it
+**MUST NOT** be materialized as an invalid language enum.
+
+A request ID may be reused only after the corresponding descriptor chain has been returned used or
+after the driver has completed a device reset. Request IDs correlate command completion; they do not
+identify accelerator events.
+
+### 3.2 Response header
+
+Every written response begins with the 16-byte `ResponseHeader`:
+
+| Offset | Bytes | Field | Rule |
+|---:|---:|---|---|
+| 0 | 2 | `status` | Raw status from section 6 |
+| 2 | 2 | `flags` | **MUST** be zero |
+| 4 | 4 | `payload_bytes` | Exact number of bytes written after this header |
+| 8 | 8 | `request_id` | Exact request ID from the corresponding valid request header |
+
+The driver **MUST** validate that the response request ID matches the request associated with the
+used descriptor head. An unknown status is an opaque failure, never success.
+
+Except for an indeterminate `SUBMIT`, every non-`OK` response has an empty payload. An indeterminate
+`SUBMIT` has the original mapped failure status and an eight-byte `SubmitResponse`; possession of
+that event ID prevents premature resource release.
+
+## 4. Common value namespaces
+
+### 4.1 Object IDs
+
+An object ID is an opaque nonzero `u64`. Zero is invalid. Its encoding is device-private and no bit
+has driver-visible meaning.
+
+### 4.2 Memory domains
+
+| Value | Meaning |
+|---:|---|
+| 1 | Host-preferred memory |
+| 2 | Device-preferred memory |
+| 3 | Shared/coherent memory class |
+
+All other values produce `INVALID_ARGUMENT`. These values express placement intent only and do not
+create a host mapping or external-memory handle.
+
+### 4.3 Buffer usage bits
+
+| Bit | Value | Meaning |
+|---:|---:|---|
+| 0 | `0x00000001` | Transfer source |
+| 1 | `0x00000002` | Transfer destination |
+| 2 | `0x00000004` | Program input |
+| 3 | `0x00000008` | Program output |
+| 4 | `0x00000010` | Mutable program state |
+
+At least one usage bit **MUST** be set. Unknown bits produce `UNSUPPORTED`.
+
+### 4.4 Binding access
+
+| Value | Meaning |
+|---:|---|
+| 1 | Read |
+| 2 | Write |
+| 3 | Read and write |
+
+All other values produce `INVALID_ARGUMENT`.
+
+### 4.5 Event states
+
+| Value | State | `error` field |
+|---:|---|---|
+| 0 | Pending | `OK` |
+| 1 | Complete | `OK` |
+| 2 | Failed | Non-`OK` status explaining execution failure |
+| 3 | Cancelled | `OK` |
+
+Unknown event states make the response invalid to a 1.0 driver. A driver **MUST** retain the event
+and request recovery rather than guessing that the event is terminal.
+
+## 5. Opcodes and payloads
+
+The request payload length is exact. A fixed prefix followed by variable bytes has no alignment
+padding between the prefix and tail.
+
+| Opcode | Value | Request payload | `OK` response payload | Maximum required writable capacity |
+|---|---:|---|---|---:|
+| `GET_DEVICE_INFO` | `0x0001` | Empty | `WireDeviceInfo` | 92 |
+| `CREATE_CONTEXT` | `0x0100` | `CreateContextRequest` | `ObjectPayload` context ID | 24 |
+| `DESTROY_CONTEXT` | `0x0101` | `ObjectPayload` context ID | Empty | 16 |
+| `ALLOCATE_BUFFER` | `0x0200` | `AllocateBufferRequest` | `ObjectPayload` buffer ID | 24 |
+| `FREE_BUFFER` | `0x0201` | `ObjectPayload` buffer ID | Empty | 16 |
+| `WRITE_BUFFER` | `0x0202` | `TransferBufferRequest` + data | Empty | 16 |
+| `READ_BUFFER` | `0x0203` | `TransferBufferRequest` | Exactly `bytes` data | `16 + bytes` |
+| `LOAD_PROGRAM` | `0x0300` | `LoadProgramRequest` + artifact | `ObjectPayload` program ID | 24 |
+| `UNLOAD_PROGRAM` | `0x0301` | `ObjectPayload` program ID | Empty | 16 |
+| `CREATE_QUEUE` | `0x0400` | `CreateQueueRequest` | `ObjectPayload` execution-queue ID | 24 |
+| `DESTROY_QUEUE` | `0x0401` | `ObjectPayload` execution-queue ID | Empty | 16 |
+| `SUBMIT` | `0x0500` | `SubmitRequest` + `WireBinding[]` | `SubmitResponse` event ID | 24 |
+| `POLL_EVENT` | `0x0501` | `ObjectPayload` event ID | `WireEventState` | 24 |
+| `CANCEL_EVENT` | `0x0502` | `ObjectPayload` event ID | Empty | 16 |
+| `DESTROY_EVENT` | `0x0503` | `ObjectPayload` event ID | Empty | 16 |
+
+The maximum required writable capacity is validated before any semantic mutation or backend call.
+Protocol 1.0 has no object-list payload: every destruction or event operation names exactly one
+object ID. The binding array is the only variable-count structured array in a baseline request.
+
+### 5.1 `WireDeviceInfo`
+
+`WireDeviceInfo` is 76 bytes:
+
+| Field | Rule |
+|---|---|
+| `uuid[16]` | Stable identity for this accelerator device |
+| `class` | Extensible raw class; 0 other, 1 NPU, 2 GPU, 3 DSP |
+| `reserved` | Zero |
+| `vendor_id`, `device_id` | Provider identity; zero means unspecified |
+| `capabilities` | Assigned semantic capability bits only |
+| `max_contexts` | Nonzero device-wide live-context limit |
+| `max_buffers_per_context` | Nonzero live-buffer limit |
+| `max_programs_per_context` | Nonzero live-program limit |
+| `max_queues_per_context` | Nonzero live execution-queue limit |
+| `max_events_per_context` | Nonzero live-event/in-flight-submission limit |
+| `max_bindings_per_submission` | 1 through 4096 |
+| `max_buffer_bytes` | Nonzero maximum allocation size |
+| `max_artifact_bytes` | Nonzero maximum artifact tail size, additionally bounded by the request-frame limit |
+
+Capability bits are semantic reports, not Virtio feature bits. A capability **MUST NOT** alter wire
+framing without a separately negotiated feature. Unknown capability bits are ignored for operation
+selection and preserved by diagnostic tooling.
+
+### 5.2 Context
+
+`CreateContextRequest` is eight bytes: `flags: u32` followed by `reserved: u32`. Both fields **MUST**
+be zero in protocol 1.0.
+
+Context destruction uses an eight-byte `ObjectPayload`.
+
+### 5.3 Buffers
+
+`AllocateBufferRequest` is 40 bytes:
+
+| Field | Rule |
+|---|---|
+| `context_id` | Live context |
+| `bytes` | Nonzero and no greater than `max_buffer_bytes` |
+| `alignment` | Nonzero power of two |
+| `memory_domain` | Assigned value from section 4.2 |
+| `reserved0[7]` | All zero |
+| `usage` | Nonempty subset of assigned usage bits |
+| `reserved1` | Zero |
+
+`TransferBufferRequest` is 24 bytes containing `buffer_id`, `offset`, and `bytes`. `bytes` **MUST**
+be nonzero. `offset + bytes` **MUST NOT** overflow and **MUST** fit in the buffer.
+
+For `WRITE_BUFFER`, the request payload length **MUST** be `24 + bytes`, and bytes following the
+prefix are copied to the buffer. For `READ_BUFFER`, the request payload is exactly 24 bytes and the
+success response payload contains exactly `bytes` bytes. Transfers must also fit the configured
+request or response frame maximum.
+
+### 5.4 Programs
+
+`LoadProgramRequest` is an 80-byte prefix:
+
+| Field | Rule |
+|---|---|
+| `context_id` | Live context |
+| `format` | Nonzero provider-owned format ID |
+| `flags` | Zero |
+| `target[12]` | Opaque format-owned target words |
+| `payload_bytes` | Nonzero, equals the exact artifact tail length |
+| `resident_bytes` | Nonzero declared resident-memory charge |
+
+`80 + payload_bytes` **MUST** fit the request payload and configured frame limit.
+
+### 5.5 Execution queues
+
+`CreateQueueRequest` is 16 bytes: `context_id: u64`, `flags: u32`, and `reserved: u32`. Both flag and
+reserved words **MUST** be zero in protocol 1.0.
+
+### 5.6 Submission and events
+
+`SubmitRequest` is a 32-byte prefix containing `queue_id`, `program_id`, `binding_count`, `flags`,
+and `timeout_ns`.
+
+- `binding_count` **MUST** be 1 through both advertised `max_bindings_per_submission` and 4096.
+- `flags` **MUST** be zero.
+- `timeout_ns` is relative to backend admission; zero means infinite.
+- The payload length **MUST** be `32 + binding_count * 32`.
+
+Each 32-byte `WireBinding` contains `buffer_id`, `offset`, `bytes`, `slot`, `access`, and three
+reserved-zero bytes. Buffer ranges are nonempty and checked for overflow. Slots are unique within
+the submission. Every object belongs to the same context.
+
+`SubmitResponse` is an eight-byte event ID. It is returned with `OK` after accepted admission and
+with the mapped non-`OK` status when admission is indeterminate. A rejected submission has an empty
+error payload.
+
+`WireEventState` is eight bytes: `state: u16`, `error: u16`, and `reserved: u32`. Reserved bytes are
+zero and the state/error combinations are exactly those in section 4.5.
+
+## 6. Status namespace
+
+| Value | Name | Meaning |
+|---:|---|---|
+| 0 | `OK` | Command completed successfully |
+| 1 | `UNSUPPORTED` | Opcode, flag, feature, capability, or operation is not supported |
+| 2 | `INCOMPATIBLE` | Known artifact, target, object, or capability combination is incompatible |
+| 3 | `INVALID_ARGUMENT` | Malformed value, reserved field, length mismatch, zero required value, or duplicate slot |
+| 4 | `OUT_OF_BOUNDS` | Checked byte range does not fit its object |
+| 5 | `BUSY` | Object is live, referenced, pending, or otherwise retryable |
+| 6 | `OUT_OF_MEMORY` | Host/provider allocation failed |
+| 7 | `RESOURCE_LIMIT` | Configured count or byte limit would be exceeded |
+| 8 | `DEADLINE_EXPIRED` | Operation expired according to the relative timeout contract |
+| 9 | `DEVICE_LOST` | Backend/device state cannot continue normally |
+| 10 | `PERMISSION_DENIED` | Isolation or provider policy denied the operation |
+| 11 | `STALE_OBJECT` | Nonzero object ID is stale, wrong-kind, reset-invalidated, or not valid in this context |
+| 65535 | `INTERNAL_ERROR` | Unclassified implementation/provider failure |
+
+Unknown status values are opaque non-success failures. Provider-specific error domains do not cross
+the 1.0 wire boundary; absent a future diagnostic feature, they map to `INTERNAL_ERROR`.
+
+Malformed input is classified before backend invocation:
+
+- unknown opcode or nonzero/unknown flags: `UNSUPPORTED`;
+- fixed-length mismatch, trailing bytes, reserved nonzero, invalid scalar, zero required value, or
+  arithmetic overflow: `INVALID_ARGUMENT`;
+- frame, binding, object, or configured quota exceeded: `RESOURCE_LIMIT`;
+- valid object ID with wrong generation, kind, reset epoch, or context: `STALE_OBJECT`; and
+- valid byte range outside the selected object: `OUT_OF_BOUNDS`.
+
+## 7. Response atomicity
+
+Before backend invocation, the device **MUST** validate the complete readable frame and enough
+writable capacity for every possible response shape of that command. It **MUST** initialize every
+response byte it reports used.
+
+Ordinary protocol errors have no semantic state change. If an unexpected transport write failure
+occurs after semantic mutation, or a release becomes indeterminate, the device **MUST** enter
+recovery and expose the Virtio `DEVICE_NEEDS_RESET` condition. It **MUST NOT** report an ordinary
+rejected response that would let the driver free resources whose ownership is uncertain.
+
+## 8. Frozen compatibility artifacts
+
+Protocol constants, layouts, and canonical bytes are checked in under
+[`conformance/v1.0`](../conformance/v1.0/). They are review inputs, not test-generated output.
+Changing any assigned value, field, size, or vector requires a protocol-major change unless the
+change uses a previously reserved value under the compatibility rules in
+[specification.md](specification.md).
+
+## 9. Freeze-change procedure
+
+A proposed wire change **MUST** be classified before code is merged:
+
+1. An erratum that changes no accepted or emitted bytes may clarify the 1.0 documents and tests.
+2. A compatible extension uses a previously reserved number plus explicit feature or new-opcode
+   negotiation, preserves every 1.0 frame, and receives a new minor-version conformance directory.
+3. Any changed assigned number, existing payload length, field meaning, required response, or
+   ownership interpretation requires a new protocol major version and a new conformance directory.
+
+The same reviewed change **MUST** update the normative documents, Rust constants/layout assertions,
+machine layout manifest, canonical vectors, and compatibility tests. Protocol version directories
+are never regenerated opportunistically from current Rust types.

--- a/docs/wire-abi.md
+++ b/docs/wire-abi.md
@@ -1,6 +1,6 @@
 # virtio-accel protocol 1.0 wire ABI
 
-This document freezes the byte-level portable protocol used by the command virtqueue. It is
+This document defines the protocol 1.0 candidate byte contract used by the command virtqueue. It is
 normative together with [specification.md](specification.md) and [virtqueue.md](virtqueue.md).
 Structure names refer to the Rust implementation for convenience; implementations in other
 languages depend only on the byte layouts and rules below.
@@ -307,23 +307,29 @@ occurs after semantic mutation, or a release becomes indeterminate, the device *
 recovery and expose the Virtio `DEVICE_NEEDS_RESET` condition. It **MUST NOT** report an ordinary
 rejected response that would let the driver free resources whose ownership is uncertain.
 
-## 8. Frozen compatibility artifacts
+## 8. Versioned compatibility artifacts
 
 Protocol constants, layouts, and canonical bytes are checked in under
 [`conformance/v1.0`](../conformance/v1.0/). They are review inputs, not test-generated output.
-Changing any assigned value, field, size, or vector requires a protocol-major change unless the
-change uses a previously reserved value under the compatibility rules in
+Before the final freeze audit, changing any assigned value, field, size, or vector requires one
+coordinated candidate revision under section 9. After the freeze, such a change requires a
+protocol-major change unless it uses a previously reserved value under the compatibility rules in
 [specification.md](specification.md).
 
-## 9. Freeze-change procedure
+## 9. Candidate and post-freeze change procedure
 
 A proposed wire change **MUST** be classified before code is merged:
 
-1. An erratum that changes no accepted or emitted bytes may clarify the 1.0 documents and tests.
-2. A compatible extension uses a previously reserved number plus explicit feature or new-opcode
+1. Before the final freeze audit, a candidate revision may change assigned bytes only when the same
+   reviewed change updates the normative documents, Rust layout assertions, manifest, vectors, and
+   compatibility tests and records the rationale for independent reviewers.
+2. After the freeze, an erratum that changes no accepted or emitted bytes may clarify the 1.0
+   documents and tests.
+3. A compatible extension uses a previously reserved number plus explicit feature or new-opcode
    negotiation, preserves every 1.0 frame, and receives a new minor-version conformance directory.
-3. Any changed assigned number, existing payload length, field meaning, required response, or
-   ownership interpretation requires a new protocol major version and a new conformance directory.
+4. After the freeze, any changed assigned number, existing payload length, field meaning, required
+   response, or ownership interpretation requires a new protocol major version and a new
+   conformance directory.
 
 The same reviewed change **MUST** update the normative documents, Rust constants/layout assertions,
 machine layout manifest, canonical vectors, and compatibility tests. Protocol version directories


### PR DESCRIPTION
## What changed

- Defines the normative portable protocol candidate: roles, object model, ownership, reset, compatibility, mandatory baseline, and explicit non-goals.
- Assigns candidate protocol 1.0 configuration, feature/opcode/status/event namespaces, request and response payloads, limits, validation rules, and wire-evolution procedure.
- Specifies the direct split-virtqueue reference profile, including framing, descriptor direction, scatter/gather behavior, used length, ordering, backpressure, notification, reset, and recovery.
- Adds implementation-independent protocol 1.0 layout and byte-vector JSON artifacts, with tests that consume them as versioned inputs.
- Adds program and live-event quotas before `WireDeviceInfo` stabilizes.
- Establishes cross-platform CI for stable/MSRV, Linux/macOS/Windows, Wasm, representative bare-metal targets, feature powersets, dependency policy, release builds, docs, and future fuzz smoke tests.
- Adds the declared Apache-2.0 and MIT license texts.

## Why

The driver/device byte contract must be precise before the command engine and queue implementations encode accidental assumptions. This establishes a clean-room implementable protocol boundary without selecting a VMM, host OS, kernel API, vendor runtime, or Virtio device ID.

The wire values are versioned as a protocol 1.0 candidate, not yet a stable compatibility promise. Candidate changes require a coordinated update across the normative specification, Rust assertions, manifest, vectors, and tests. The final freeze remains tracked by #33 after implementation evidence and independent review.

Children #8-#11 and cross-platform foundation issue #30 are complete. Epic #2 has been reopened so its clean-room interoperability exit criterion remains visible until the final audit rather than being treated as already proven.

## Impact

- Protocol constants report candidate version 1.0 instead of draft 0.1.
- Request flags are empty in 1.0; the former `NO_WAIT` bit is reserved-zero.
- Optional device-specific feature positions remain reserved and unadvertised.
- `WireConfig` carries the chain-descriptor bound.
- `WireDeviceInfo` adds program and live-event quotas and remains 76 bytes.
- Accepted and indeterminate submissions have an explicit eight-byte event response payload.
- Existing portable crates retain their `no_std` / `alloc` boundaries.
- No protocol bytes, layouts, or vectors changed in the merge-readiness correction commit `0b0d4af`.

## Validation

Local verification passes:

- formatting, Clippy with warnings denied, and rustdoc warnings denied;
- native unit, documentation, and release-profile checks;
- Rust 1.85.0 MSRV checks and tests;
- Wasm, AArch64 bare-metal, RISC-V bare-metal, x86_64 Linux, Windows MSVC, and Apple targets;
- Cargo feature powersets and portable dependency-feature leakage detection;
- cargo-deny advisories, licenses, bans, and sources policy; and
- actionlint for the workflow.

The prior hosted CI run [29480583325](https://github.com/MicroPerceptron/virtio-accel/actions/runs/29480583325) passed every job. The pushed merge-readiness correction is being revalidated by the PR checks.
