### PR TITLE
Prove protocol interoperability with an independent Rust codec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
 
+      - name: Check normative requirement ledger
+        run: python3 ci/check-normative-requirements.py --check
+
       - name: Lint all targets
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,7 @@ jobs:
       - name: Check no_std and alloc portable crates
         run: >-
           cargo check
+          -p virtio-accel-cleanroom
           -p virtio-accel-proto
           -p virtio-accel-core
           -p virtio-accel-device

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "virtio-accel-cleanroom"
+version = "0.1.0"
+dependencies = [
+ "serde_json",
+]
+
+[[package]]
 name = "virtio-accel-core"
 version = "0.1.0"
 dependencies = [
@@ -135,6 +142,7 @@ version = "0.1.0"
 dependencies = [
  "bitflags",
  "serde_json",
+ "virtio-accel-cleanroom",
  "zerocopy",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 
 [workspace]
 members = [
+    "conformance/rust-clean-room",
     "crates/virtio-accel-core",
     "crates/virtio-accel-device",
     "crates/virtio-accel-mock",
@@ -27,6 +28,7 @@ bitflags = { version = "2.13.1", default-features = false }
 serde_json = "1.0.149"
 zerocopy = { version = "0.8.54", default-features = false, features = ["derive"] }
 virtio-accel-core = { path = "crates/virtio-accel-core" }
+virtio-accel-cleanroom = { path = "conformance/rust-clean-room" }
 virtio-accel-device = { path = "crates/virtio-accel-device" }
 virtio-accel-mock = { path = "crates/virtio-accel-mock" }
 virtio-accel-proto = { path = "crates/virtio-accel-proto" }

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ claimed virtio device ID.
 - `virtio-accel-core`: `no_std` backend lifecycle, memory, program, queue, and event contracts.
 - `virtio-accel-device`: `no_std + alloc` device-owned state, including bounded generational IDs.
 - `virtio-accel-mock`: cross-platform in-memory backend that exercises the complete lifecycle.
+- `virtio-accel-cleanroom`: dependency-free `no_std` conformance codec implemented without shared
+  protocol types.
 - `virtio-accel`: small `no_std` facade re-exporting the portable layers.
 
 The crate dependency direction is:
@@ -53,6 +55,10 @@ model, compatibility rules, and mandatory baseline. The exact byte layouts live 
 [conformance/v1.0](conformance/v1.0/README.md). See
 [docs/architecture.md](docs/architecture.md) for implementation invariants and
 [docs/portability.md](docs/portability.md) for the enforced target matrix.
+
+The primary `zerocopy` ABI and the manual clean-room codec both decode and re-encode every canonical
+frame. Their bridge test exchanges bytes only, providing an independent implementation check
+without making the conformance codec a production dependency.
 
 ## Development
 

--- a/ci/check-normative-requirements.py
+++ b/ci/check-normative-requirements.py
@@ -1,0 +1,436 @@
+#!/usr/bin/env python3
+"""Generate or verify the protocol's normative-requirement ledger."""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import hashlib
+import json
+import pathlib
+import re
+import sys
+from typing import Final
+
+ROOT: Final = pathlib.Path(__file__).resolve().parents[1]
+LEDGER: Final = ROOT / "conformance" / "v1.0" / "requirements.json"
+SOURCES: Final = (
+    ("SPEC", "docs/specification.md"),
+    ("WIRE", "docs/wire-abi.md"),
+    ("VIRTQ", "docs/virtqueue.md"),
+)
+KEYWORD: Final = re.compile(
+    r"\*\*(MUST NOT|SHOULD NOT|MUST|SHOULD|MAY|REQUIRED|OPTIONAL)\*\*"
+)
+SECTION: Final = re.compile(r"^##\s+(\d+)(?:\.|\s)")
+
+
+@dataclasses.dataclass(frozen=True)
+class Coverage:
+    status: str
+    evidence: tuple[str, ...]
+    issues: tuple[str, ...]
+    rationale: str
+
+
+def coverage(
+    status: str,
+    evidence: tuple[str, ...] = (),
+    issues: tuple[str, ...] = (),
+    rationale: str = "",
+) -> Coverage:
+    return Coverage(status, evidence, issues, rationale)
+
+
+COVERAGE: Final[dict[tuple[str, int], Coverage]] = {
+    ("SPEC", 1): coverage(
+        "definition",
+        rationale="Defines RFC 2119 and RFC 8174 terminology; it imposes no implementation behavior.",
+    ),
+    ("SPEC", 2): coverage(
+        "mixed",
+        ("ci/check-portable-dependencies.sh", "docs/architecture.md"),
+        ("#17", "#20", "#21"),
+        "Portable dependency direction is enforced now; concrete transport and provider boundaries are tracked.",
+    ),
+    ("SPEC", 3): coverage(
+        "mixed",
+        ("ci/check-portable-dependencies.sh", "docs/architecture.md"),
+        ("#17", "#20", "#21"),
+        "Layer dependencies are enforceable now; runtime adapter boundaries require their implementations.",
+    ),
+    ("SPEC", 4): coverage(
+        "mixed",
+        (
+            "crates/virtio-accel-core/src/lib.rs",
+            "crates/virtio-accel-device/src/object_table.rs",
+            "crates/virtio-accel-mock/src/lib.rs",
+        ),
+        ("#20", "#21"),
+        "Core ownership types and lifecycle tests exist; the command engine and complete backend policy remain tracked.",
+    ),
+    ("SPEC", 5): coverage(
+        "mixed",
+        (
+            "conformance/rust-clean-room/tests/vectors.rs",
+            "crates/virtio-accel-proto/src/lib.rs",
+        ),
+        ("#20", "#32"),
+        "Namespaces and reserved values are executable; runtime negotiation and future evolution remain tracked.",
+    ),
+    ("SPEC", 6): coverage(
+        "mixed",
+        (
+            "conformance/rust-clean-room/tests/vectors.rs",
+            "conformance/v1.0/layout.json",
+            "conformance/v1.0/vectors.json",
+        ),
+        ("#32", "#33"),
+        "Version and exact-length behavior is executable; release governance and the final freeze remain tracked.",
+    ),
+    ("SPEC", 7): coverage(
+        "mixed",
+        (
+            "crates/virtio-accel-core/src/lib.rs",
+            "crates/virtio-accel-device/src/object_table.rs",
+            "crates/virtio-accel-mock/src/lib.rs",
+        ),
+        ("#20", "#21"),
+        "Handle and generational-ID invariants are tested; end-to-end release recovery remains tracked.",
+    ),
+    ("SPEC", 8): coverage(
+        "mixed",
+        ("crates/virtio-accel-core/src/lib.rs",),
+        ("#20", "#21"),
+        "Relative timeout semantics are tested; bounded polling and admission behavior require the command engine.",
+    ),
+    ("SPEC", 9): coverage(
+        "mixed",
+        (
+            "conformance/rust-clean-room/tests/vectors.rs",
+            "crates/virtio-accel-core/src/lib.rs",
+        ),
+        ("#20", "#21"),
+        "Wire error shapes and ownership-aware failures are executable; backend-to-device recovery is tracked.",
+    ),
+    ("SPEC", 10): coverage(
+        "executable",
+        (
+            ".github/workflows/ci.yml",
+            "ci/check-portable-dependencies.sh",
+            "docs/portability.md",
+        ),
+        rationale="The target matrix and dependency guards directly enforce the portable-layer restrictions.",
+    ),
+    ("SPEC", 11): coverage(
+        "mixed",
+        ("ci/check-normative-requirements.py",),
+        ("#21", "#25", "#32", "#33"),
+        "The ledger prevents silent requirements; the section's named completion work remains explicitly tracked.",
+    ),
+    ("WIRE", 1): coverage(
+        "executable",
+        (
+            "conformance/rust-clean-room/src/lib.rs",
+            "conformance/rust-clean-room/tests/vectors.rs",
+            "crates/virtio-accel-proto/src/lib.rs",
+        ),
+        rationale="Both codecs use checked arithmetic and independently enforce the global limits.",
+    ),
+    ("WIRE", 2): coverage(
+        "executable",
+        (
+            "conformance/rust-clean-room/tests/vectors.rs",
+            "crates/virtio-accel-proto/src/lib.rs",
+        ),
+        rationale="Configuration limits, version compatibility, queue-size bounds, and features are tested.",
+    ),
+    ("WIRE", 3): coverage(
+        "executable",
+        (
+            "conformance/rust-clean-room/tests/vectors.rs",
+            "crates/virtio-accel-proto/src/lib.rs",
+        ),
+        rationale="Headers, exact lengths, flags, request correlation, and unknown numeric values are tested.",
+    ),
+    ("WIRE", 4): coverage(
+        "executable",
+        (
+            "conformance/rust-clean-room/src/lib.rs",
+            "conformance/rust-clean-room/tests/vectors.rs",
+        ),
+        rationale="The independent semantic codec validates object IDs, domains, usage, access, and event states.",
+    ),
+    ("WIRE", 5): coverage(
+        "mixed",
+        (
+            "conformance/rust-clean-room/tests/vectors.rs",
+            "crates/virtio-accel-proto/tests/semantic_interop.rs",
+        ),
+        ("#20", "#25"),
+        "Every payload layout and scalar invariant is cross-decoded; live-object and advertised-quota checks are tracked.",
+    ),
+    ("WIRE", 6): coverage(
+        "mixed",
+        (
+            "conformance/rust-clean-room/tests/vectors.rs",
+            "crates/virtio-accel-core/src/lib.rs",
+        ),
+        ("#20", "#21"),
+        "Malformed input classifications and opaque statuses are executable; provider error mapping is tracked.",
+    ),
+    ("WIRE", 7): coverage(
+        "tracked",
+        ("conformance/v1.0/vectors.json",),
+        ("#18", "#20"),
+        "Error shapes are fixed, while writable preflight and post-mutation response atomicity require queue execution.",
+    ),
+    ("WIRE", 8): coverage(
+        "executable",
+        (
+            "conformance/v1.0/layout.json",
+            "conformance/v1.0/vectors.json",
+            "crates/virtio-accel-proto/src/lib.rs",
+        ),
+        rationale="Checked-in artifacts are immutable test inputs and drift is detected by both codec suites.",
+    ),
+    ("WIRE", 9): coverage(
+        "mixed",
+        ("ci/check-normative-requirements.py",),
+        ("#32", "#33"),
+        "Coordinated documentation and evidence are machine-checked; final release policy and freeze remain tracked.",
+    ),
+    ("VIRTQ", 1): coverage(
+        "tracked",
+        ("docs/virtqueue.md",),
+        ("#17", "#18"),
+        "The negotiated reference profile is specified; transport feature enforcement requires the queue adapter.",
+    ),
+    ("VIRTQ", 2): coverage(
+        "tracked",
+        ("docs/virtqueue.md",),
+        ("#17", "#18"),
+        "The flattened region contract is specified and assigned to the region-port and split-ring implementations.",
+    ),
+    ("VIRTQ", 3): coverage(
+        "tracked",
+        ("docs/virtqueue.md",),
+        ("#17", "#18"),
+        "Topology and mapping rules have stable VQ cases but require executable descriptor-chain ports.",
+    ),
+    ("VIRTQ", 4): coverage(
+        "tracked",
+        ("conformance/rust-clean-room/tests/vectors.rs",),
+        ("#17", "#18"),
+        "Frame exactness is executable; cross-region presentation requires the region adapter and split-ring model.",
+    ),
+    ("VIRTQ", 5): coverage(
+        "tracked",
+        ("conformance/rust-clean-room/tests/vectors.rs",),
+        ("#18", "#20"),
+        "Semantic validation classifications are executable; ordering and failure atomicity require queue execution.",
+    ),
+    ("VIRTQ", 6): coverage(
+        "tracked",
+        ("conformance/rust-clean-room/tests/vectors.rs",),
+        ("#18", "#20"),
+        "Response bytes and lengths are defined; scatter writes and post-mutation failure require queue execution.",
+    ),
+    ("VIRTQ", 7): coverage(
+        "tracked",
+        ("docs/virtqueue.md",),
+        ("#18", "#20"),
+        "Stable VQ ordering cases exist; concurrent publication and completion behavior awaits the queue model.",
+    ),
+    ("VIRTQ", 8): coverage(
+        "tracked",
+        ("docs/virtqueue.md",),
+        ("#19", "#20"),
+        "Backpressure semantics are specified and assigned to the guest and full-path implementations.",
+    ),
+    ("VIRTQ", 9): coverage(
+        "tracked",
+        ("docs/virtqueue.md",),
+        ("#18", "#19"),
+        "Notification invariants are specified and assigned to split-ring and guest implementations.",
+    ),
+    ("VIRTQ", 10): coverage(
+        "tracked",
+        ("conformance/rust-clean-room/tests/vectors.rs",),
+        ("#18", "#20"),
+        "Malformed frame behavior is executable; malformed descriptor-chain isolation requires queue execution.",
+    ),
+    ("VIRTQ", 11): coverage(
+        "tracked",
+        ("docs/virtqueue.md",),
+        ("#18", "#19", "#20"),
+        "Reset cases are stable, while descriptor reclamation and late-completion exclusion require full implementations.",
+    ),
+    ("VIRTQ", 12): coverage(
+        "tracked",
+        ("crates/virtio-accel-core/src/lib.rs",),
+        ("#20", "#25"),
+        "Ownership-aware failure types exist; DEVICE_NEEDS_RESET transitions require the command engine and threat limits.",
+    ),
+}
+
+
+def section_number(heading: str) -> int:
+    match = SECTION.match(heading)
+    if match is None:
+        raise ValueError(f"normative keyword occurs outside a numbered section: {heading!r}")
+    return int(match.group(1))
+
+
+def requirement_id(
+    source_code: str,
+    line_number: int,
+    section: str,
+    statement: str,
+    keyword: str,
+    ordinal: int,
+) -> str:
+    material = "\0".join(
+        (source_code, str(line_number), section, statement, keyword, str(ordinal))
+    )
+    digest = hashlib.sha256(material.encode()).hexdigest()[:12].upper()
+    return f"REQ-{source_code}-{digest}"
+
+
+def generate() -> dict[str, object]:
+    requirements: list[dict[str, object]] = []
+
+    for source_code, relative_source in SOURCES:
+        source = ROOT / relative_source
+        heading = ""
+        for line_number, raw_line in enumerate(source.read_text().splitlines(), start=1):
+            if raw_line.startswith("## "):
+                heading = raw_line
+            statement = raw_line.strip()
+            matches = tuple(KEYWORD.finditer(raw_line))
+            if not matches:
+                continue
+            number = section_number(heading)
+            assigned = COVERAGE.get((source_code, number))
+            if assigned is None:
+                raise ValueError(
+                    f"no coverage mapping for {relative_source}:{line_number} ({heading})"
+                )
+            if not assigned.rationale:
+                raise ValueError(f"coverage rationale is empty for {source_code} section {number}")
+            if assigned.status not in {"definition", "executable", "mixed", "tracked"}:
+                raise ValueError(f"invalid coverage status {assigned.status!r}")
+            if assigned.status != "definition" and not (
+                assigned.evidence or assigned.issues
+            ):
+                raise ValueError(
+                    f"{source_code} section {number} has neither evidence nor issues"
+                )
+            for evidence in assigned.evidence:
+                if not (ROOT / evidence).exists():
+                    raise ValueError(
+                        f"coverage evidence does not exist for {source_code} "
+                        f"section {number}: {evidence}"
+                    )
+            for issue in assigned.issues:
+                if re.fullmatch(r"#[1-9][0-9]*", issue) is None:
+                    raise ValueError(
+                        f"invalid tracked issue for {source_code} section {number}: {issue}"
+                    )
+
+            for ordinal, match in enumerate(matches, start=1):
+                keyword = match.group(1)
+                requirements.append(
+                    {
+                        "id": requirement_id(
+                            source_code,
+                            line_number,
+                            heading,
+                            statement,
+                            keyword,
+                            ordinal,
+                        ),
+                        "source": relative_source,
+                        "line": line_number,
+                        "section": heading.removeprefix("## "),
+                        "keyword": keyword,
+                        "statement": statement,
+                        "coverage": {
+                            "status": assigned.status,
+                            "evidence": list(assigned.evidence),
+                            "issues": list(assigned.issues),
+                            "rationale": assigned.rationale,
+                        },
+                    }
+                )
+
+    identifiers = [entry["id"] for entry in requirements]
+    if len(identifiers) != len(set(identifiers)):
+        raise ValueError("requirement IDs are not unique")
+
+    return {
+        "schema": "virtio-accel-normative-requirements-1",
+        "generated_by": "ci/check-normative-requirements.py",
+        "requirement_count": len(requirements),
+        "requirements": requirements,
+    }
+
+
+def render(ledger: dict[str, object]) -> str:
+    return json.dumps(ledger, indent=2, sort_keys=False) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    action = parser.add_mutually_exclusive_group(required=True)
+    action.add_argument("--check", action="store_true")
+    action.add_argument("--write", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        expected = render(generate())
+    except ValueError as error:
+        print(f"normative requirement generation failed: {error}", file=sys.stderr)
+        return 1
+
+    if args.write:
+        LEDGER.write_text(expected)
+        print(f"wrote {LEDGER.relative_to(ROOT)}")
+        return 0
+
+    if not LEDGER.exists():
+        print(f"missing {LEDGER.relative_to(ROOT)}; run with --write", file=sys.stderr)
+        return 1
+    actual = LEDGER.read_text()
+    if actual != expected:
+        try:
+            actual_data = json.loads(actual)
+            expected_data = json.loads(expected)
+            actual_ids = {
+                entry["id"] for entry in actual_data.get("requirements", [])
+            }
+            expected_ids = {
+                entry["id"] for entry in expected_data.get("requirements", [])
+            }
+            added = sorted(expected_ids - actual_ids)
+            removed = sorted(actual_ids - expected_ids)
+            if added:
+                print(f"uncatalogued normative requirements: {', '.join(added)}", file=sys.stderr)
+            if removed:
+                print(f"stale normative requirements: {', '.join(removed)}", file=sys.stderr)
+        except (json.JSONDecodeError, KeyError, TypeError):
+            pass
+        print(
+            "normative requirement ledger is stale; review the change and run "
+            "python3 ci/check-normative-requirements.py --write",
+            file=sys.stderr,
+        )
+        return 1
+
+    count = json.loads(actual)["requirement_count"]
+    print(f"normative requirement ledger is complete ({count} entries)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/check-portable-dependencies.sh
+++ b/ci/check-portable-dependencies.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 readonly packages=(
+  virtio-accel-cleanroom
   virtio-accel-proto
   virtio-accel-core
 )
@@ -14,5 +15,13 @@ for package in "${packages[@]}"; do
     exit 1
   fi
 done
+
+cleanroom_tree="$(cargo tree -p virtio-accel-cleanroom -e normal,build --depth 1 --prefix none)"
+cleanroom_dependencies="$(sed '1d' <<<"$cleanroom_tree")"
+if [[ -n "$cleanroom_dependencies" ]]; then
+  echo "virtio-accel-cleanroom must remain independent of every normal/build dependency:" >&2
+  echo "$cleanroom_tree" >&2
+  exit 1
+fi
 
 echo "portable dependency features are clean"

--- a/conformance/rust-clean-room/Cargo.toml
+++ b/conformance/rust-clean-room/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "virtio-accel-cleanroom"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+description = "Independent manual codec for virtio-accel protocol conformance"
+publish = false
+
+[dev-dependencies]
+serde_json.workspace = true

--- a/conformance/rust-clean-room/src/lib.rs
+++ b/conformance/rust-clean-room/src/lib.rs
@@ -1,0 +1,1115 @@
+//! Independent, dependency-free codec for the virtio-accel protocol 1.0 candidate.
+//!
+//! This crate intentionally does not depend on `virtio-accel-proto`, `zerocopy`, or any shared
+//! wire type. It implements the normative byte contract with explicit little-endian reads and
+//! writes so conformance tests can exercise interoperability through bytes alone.
+
+#![no_std]
+#![forbid(unsafe_code)]
+
+use core::convert::TryFrom;
+
+pub const PROTOCOL_MAJOR: u16 = 1;
+pub const PROTOCOL_MINOR: u16 = 0;
+pub const REQUEST_HEADER_BYTES: usize = 16;
+pub const RESPONSE_HEADER_BYTES: usize = 16;
+pub const HARD_MAX_CHAIN_DESCRIPTORS: u16 = 256;
+pub const HARD_MAX_REQUEST_BYTES: u32 = 16 * 1024 * 1024;
+pub const HARD_MAX_RESPONSE_BYTES: u32 = 16 * 1024 * 1024;
+pub const HARD_MAX_BINDINGS: u32 = 4_096;
+pub const MIN_MAX_REQUEST_BYTES: u32 = 97;
+pub const MIN_MAX_RESPONSE_BYTES: u32 = 92;
+pub const KNOWN_BUFFER_USAGE_BITS: u32 = 0x1f;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Error {
+    Size,
+    Version,
+    CommandQueueCount,
+    ChainDescriptorLimit,
+    RequestByteLimit,
+    ResponseByteLimit,
+    Unsupported,
+    InvalidArgument,
+    ResourceLimit,
+    RecoveryRequired,
+    OutputTooSmall,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Config {
+    pub protocol_major: u16,
+    pub protocol_minor: u16,
+    pub command_queue_count: u16,
+    pub max_chain_descriptors: u16,
+    pub max_request_bytes: u32,
+    pub max_response_bytes: u32,
+}
+
+impl Config {
+    pub const ENCODED_BYTES: usize = 16;
+
+    pub fn validate(self, queue_size: u16) -> Result<(), Error> {
+        if self.protocol_major != PROTOCOL_MAJOR {
+            return Err(Error::Version);
+        }
+        if self.command_queue_count != 1 {
+            return Err(Error::CommandQueueCount);
+        }
+        if !(2..=HARD_MAX_CHAIN_DESCRIPTORS).contains(&self.max_chain_descriptors)
+            || self.max_chain_descriptors > queue_size
+        {
+            return Err(Error::ChainDescriptorLimit);
+        }
+        if !(MIN_MAX_REQUEST_BYTES..=HARD_MAX_REQUEST_BYTES).contains(&self.max_request_bytes) {
+            return Err(Error::RequestByteLimit);
+        }
+        if !(MIN_MAX_RESPONSE_BYTES..=HARD_MAX_RESPONSE_BYTES).contains(&self.max_response_bytes) {
+            return Err(Error::ResponseByteLimit);
+        }
+        Ok(())
+    }
+
+    pub fn encode(self, queue_size: u16, output: &mut [u8]) -> Result<usize, Error> {
+        self.validate(queue_size)?;
+        require_output(output, Self::ENCODED_BYTES)?;
+        write_u16(output, 0, self.protocol_major)?;
+        write_u16(output, 2, self.protocol_minor)?;
+        write_u16(output, 4, self.command_queue_count)?;
+        write_u16(output, 6, self.max_chain_descriptors)?;
+        write_u32(output, 8, self.max_request_bytes)?;
+        write_u32(output, 12, self.max_response_bytes)?;
+        Ok(Self::ENCODED_BYTES)
+    }
+}
+
+pub fn decode_config(bytes: &[u8], queue_size: u16) -> Result<Config, Error> {
+    if bytes.len() != Config::ENCODED_BYTES {
+        return Err(Error::Size);
+    }
+    let config = Config {
+        protocol_major: read_u16(bytes, 0)?,
+        protocol_minor: read_u16(bytes, 2)?,
+        command_queue_count: read_u16(bytes, 4)?,
+        max_chain_descriptors: read_u16(bytes, 6)?,
+        max_request_bytes: read_u32(bytes, 8)?,
+        max_response_bytes: read_u32(bytes, 12)?,
+    };
+    config.validate(queue_size)?;
+    Ok(config)
+}
+
+pub fn validate_features(features: u64) -> Result<(), Error> {
+    if features == 0 {
+        Ok(())
+    } else {
+        Err(Error::Unsupported)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u16)]
+pub enum Opcode {
+    GetDeviceInfo = 0x0001,
+    CreateContext = 0x0100,
+    DestroyContext = 0x0101,
+    AllocateBuffer = 0x0200,
+    FreeBuffer = 0x0201,
+    WriteBuffer = 0x0202,
+    ReadBuffer = 0x0203,
+    LoadProgram = 0x0300,
+    UnloadProgram = 0x0301,
+    CreateQueue = 0x0400,
+    DestroyQueue = 0x0401,
+    Submit = 0x0500,
+    PollEvent = 0x0501,
+    CancelEvent = 0x0502,
+    DestroyEvent = 0x0503,
+}
+
+impl TryFrom<u16> for Opcode {
+    type Error = Error;
+
+    fn try_from(value: u16) -> Result<Self, Self::Error> {
+        match value {
+            0x0001 => Ok(Self::GetDeviceInfo),
+            0x0100 => Ok(Self::CreateContext),
+            0x0101 => Ok(Self::DestroyContext),
+            0x0200 => Ok(Self::AllocateBuffer),
+            0x0201 => Ok(Self::FreeBuffer),
+            0x0202 => Ok(Self::WriteBuffer),
+            0x0203 => Ok(Self::ReadBuffer),
+            0x0300 => Ok(Self::LoadProgram),
+            0x0301 => Ok(Self::UnloadProgram),
+            0x0400 => Ok(Self::CreateQueue),
+            0x0401 => Ok(Self::DestroyQueue),
+            0x0500 => Ok(Self::Submit),
+            0x0501 => Ok(Self::PollEvent),
+            0x0502 => Ok(Self::CancelEvent),
+            0x0503 => Ok(Self::DestroyEvent),
+            _ => Err(Error::Unsupported),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct AllocateBuffer {
+    pub context_id: u64,
+    pub bytes: u64,
+    pub alignment: u64,
+    pub memory_domain: u8,
+    pub usage: u32,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TransferBuffer {
+    pub buffer_id: u64,
+    pub offset: u64,
+    pub bytes: u64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct LoadProgram<'a> {
+    pub context_id: u64,
+    pub format: u32,
+    pub target: [u32; 12],
+    pub resident_bytes: u64,
+    pub artifact: &'a [u8],
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Binding {
+    pub buffer_id: u64,
+    pub offset: u64,
+    pub bytes: u64,
+    pub slot: u32,
+    pub access: u8,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Bindings<'a> {
+    Encoded { bytes: &'a [u8], count: u32 },
+    Values(&'a [Binding]),
+}
+
+impl<'a> Bindings<'a> {
+    pub fn count(self) -> Result<u32, Error> {
+        match self {
+            Self::Encoded { count, .. } => Ok(count),
+            Self::Values(values) => u32::try_from(values.len()).map_err(|_| Error::ResourceLimit),
+        }
+    }
+
+    pub fn get(self, index: u32) -> Result<Binding, Error> {
+        match self {
+            Self::Encoded { bytes, count } => {
+                if index >= count {
+                    return Err(Error::InvalidArgument);
+                }
+                let offset = usize::try_from(index)
+                    .map_err(|_| Error::ResourceLimit)?
+                    .checked_mul(32)
+                    .ok_or(Error::ResourceLimit)?;
+                decode_binding(bytes, offset)
+            }
+            Self::Values(values) => values
+                .get(usize::try_from(index).map_err(|_| Error::ResourceLimit)?)
+                .copied()
+                .ok_or(Error::InvalidArgument),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Submit<'a> {
+    pub queue_id: u64,
+    pub program_id: u64,
+    pub timeout_ns: u64,
+    pub bindings: Bindings<'a>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RequestBody<'a> {
+    GetDeviceInfo,
+    CreateContext,
+    DestroyContext {
+        context_id: u64,
+    },
+    AllocateBuffer(AllocateBuffer),
+    FreeBuffer {
+        buffer_id: u64,
+    },
+    WriteBuffer {
+        transfer: TransferBuffer,
+        data: &'a [u8],
+    },
+    ReadBuffer(TransferBuffer),
+    LoadProgram(LoadProgram<'a>),
+    UnloadProgram {
+        program_id: u64,
+    },
+    CreateQueue {
+        context_id: u64,
+    },
+    DestroyQueue {
+        queue_id: u64,
+    },
+    Submit(Submit<'a>),
+    PollEvent {
+        event_id: u64,
+    },
+    CancelEvent {
+        event_id: u64,
+    },
+    DestroyEvent {
+        event_id: u64,
+    },
+}
+
+impl RequestBody<'_> {
+    pub const fn opcode(&self) -> Opcode {
+        match self {
+            Self::GetDeviceInfo => Opcode::GetDeviceInfo,
+            Self::CreateContext => Opcode::CreateContext,
+            Self::DestroyContext { .. } => Opcode::DestroyContext,
+            Self::AllocateBuffer(_) => Opcode::AllocateBuffer,
+            Self::FreeBuffer { .. } => Opcode::FreeBuffer,
+            Self::WriteBuffer { .. } => Opcode::WriteBuffer,
+            Self::ReadBuffer(_) => Opcode::ReadBuffer,
+            Self::LoadProgram(_) => Opcode::LoadProgram,
+            Self::UnloadProgram { .. } => Opcode::UnloadProgram,
+            Self::CreateQueue { .. } => Opcode::CreateQueue,
+            Self::DestroyQueue { .. } => Opcode::DestroyQueue,
+            Self::Submit(_) => Opcode::Submit,
+            Self::PollEvent { .. } => Opcode::PollEvent,
+            Self::CancelEvent { .. } => Opcode::CancelEvent,
+            Self::DestroyEvent { .. } => Opcode::DestroyEvent,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Request<'a> {
+    pub request_id: u64,
+    pub body: RequestBody<'a>,
+}
+
+impl Request<'_> {
+    pub fn encoded_len(&self) -> Result<usize, Error> {
+        let payload = request_payload_len(&self.body)?;
+        let total = REQUEST_HEADER_BYTES
+            .checked_add(payload)
+            .ok_or(Error::ResourceLimit)?;
+        if total > HARD_MAX_REQUEST_BYTES as usize {
+            return Err(Error::ResourceLimit);
+        }
+        Ok(total)
+    }
+
+    pub fn encode(&self, output: &mut [u8]) -> Result<usize, Error> {
+        if self.request_id == 0 {
+            return Err(Error::InvalidArgument);
+        }
+        let payload_len = request_payload_len(&self.body)?;
+        let total = REQUEST_HEADER_BYTES
+            .checked_add(payload_len)
+            .ok_or(Error::ResourceLimit)?;
+        let payload_u32 = u32::try_from(payload_len).map_err(|_| Error::ResourceLimit)?;
+        if total > HARD_MAX_REQUEST_BYTES as usize {
+            return Err(Error::ResourceLimit);
+        }
+        require_output(output, total)?;
+        write_u16(output, 0, self.body.opcode() as u16)?;
+        write_u16(output, 2, 0)?;
+        write_u32(output, 4, payload_u32)?;
+        write_u64(output, 8, self.request_id)?;
+        encode_request_body(&self.body, &mut output[REQUEST_HEADER_BYTES..total])?;
+        Ok(total)
+    }
+}
+
+pub fn decode_request(bytes: &[u8]) -> Result<Request<'_>, Error> {
+    if bytes.len() < REQUEST_HEADER_BYTES {
+        return Err(Error::Size);
+    }
+    let opcode = Opcode::try_from(read_u16(bytes, 0)?)?;
+    if read_u16(bytes, 2)? != 0 {
+        return Err(Error::Unsupported);
+    }
+    let payload_len = usize::try_from(read_u32(bytes, 4)?).map_err(|_| Error::ResourceLimit)?;
+    let total = REQUEST_HEADER_BYTES
+        .checked_add(payload_len)
+        .ok_or(Error::ResourceLimit)?;
+    if total != bytes.len() {
+        return Err(Error::InvalidArgument);
+    }
+    if total > HARD_MAX_REQUEST_BYTES as usize {
+        return Err(Error::ResourceLimit);
+    }
+    let request_id = read_u64(bytes, 8)?;
+    if request_id == 0 {
+        return Err(Error::InvalidArgument);
+    }
+    let payload = &bytes[REQUEST_HEADER_BYTES..];
+    let body = decode_request_body(opcode, payload)?;
+    if request_payload_len(&body)? != payload_len {
+        return Err(Error::InvalidArgument);
+    }
+    Ok(Request { request_id, body })
+}
+
+fn decode_request_body(opcode: Opcode, payload: &[u8]) -> Result<RequestBody<'_>, Error> {
+    match opcode {
+        Opcode::GetDeviceInfo => {
+            require_exact(payload, 0)?;
+            Ok(RequestBody::GetDeviceInfo)
+        }
+        Opcode::CreateContext => {
+            require_exact(payload, 8)?;
+            if read_u32(payload, 0)? != 0 {
+                return Err(Error::Unsupported);
+            }
+            if read_u32(payload, 4)? != 0 {
+                return Err(Error::InvalidArgument);
+            }
+            Ok(RequestBody::CreateContext)
+        }
+        Opcode::DestroyContext => Ok(RequestBody::DestroyContext {
+            context_id: decode_object(payload)?,
+        }),
+        Opcode::AllocateBuffer => {
+            require_exact(payload, 40)?;
+            if payload[25..32].iter().any(|byte| *byte != 0) || read_u32(payload, 36)? != 0 {
+                return Err(Error::InvalidArgument);
+            }
+            Ok(RequestBody::AllocateBuffer(AllocateBuffer {
+                context_id: read_u64(payload, 0)?,
+                bytes: read_u64(payload, 8)?,
+                alignment: read_u64(payload, 16)?,
+                memory_domain: payload[24],
+                usage: read_u32(payload, 32)?,
+            }))
+        }
+        Opcode::FreeBuffer => Ok(RequestBody::FreeBuffer {
+            buffer_id: decode_object(payload)?,
+        }),
+        Opcode::WriteBuffer => {
+            if payload.len() < 24 {
+                return Err(Error::InvalidArgument);
+            }
+            Ok(RequestBody::WriteBuffer {
+                transfer: decode_transfer(payload)?,
+                data: &payload[24..],
+            })
+        }
+        Opcode::ReadBuffer => {
+            require_exact(payload, 24)?;
+            Ok(RequestBody::ReadBuffer(decode_transfer(payload)?))
+        }
+        Opcode::LoadProgram => {
+            if payload.len() < 80 {
+                return Err(Error::InvalidArgument);
+            }
+            if read_u32(payload, 12)? != 0 {
+                return Err(Error::Unsupported);
+            }
+            let mut target = [0_u32; 12];
+            for (index, word) in target.iter_mut().enumerate() {
+                *word = read_u32(payload, 16 + index * 4)?;
+            }
+            let artifact = &payload[80..];
+            let declared_bytes =
+                usize::try_from(read_u64(payload, 64)?).map_err(|_| Error::ResourceLimit)?;
+            if declared_bytes != artifact.len() {
+                return Err(Error::InvalidArgument);
+            }
+            Ok(RequestBody::LoadProgram(LoadProgram {
+                context_id: read_u64(payload, 0)?,
+                format: read_u32(payload, 8)?,
+                target,
+                resident_bytes: read_u64(payload, 72)?,
+                artifact,
+            }))
+        }
+        Opcode::UnloadProgram => Ok(RequestBody::UnloadProgram {
+            program_id: decode_object(payload)?,
+        }),
+        Opcode::CreateQueue => {
+            require_exact(payload, 16)?;
+            if read_u32(payload, 8)? != 0 {
+                return Err(Error::Unsupported);
+            }
+            if read_u32(payload, 12)? != 0 {
+                return Err(Error::InvalidArgument);
+            }
+            Ok(RequestBody::CreateQueue {
+                context_id: read_u64(payload, 0)?,
+            })
+        }
+        Opcode::DestroyQueue => Ok(RequestBody::DestroyQueue {
+            queue_id: decode_object(payload)?,
+        }),
+        Opcode::Submit => {
+            if payload.len() < 32 {
+                return Err(Error::InvalidArgument);
+            }
+            let count = read_u32(payload, 16)?;
+            if count == 0 {
+                return Err(Error::InvalidArgument);
+            }
+            if count > HARD_MAX_BINDINGS {
+                return Err(Error::ResourceLimit);
+            }
+            if read_u32(payload, 20)? != 0 {
+                return Err(Error::Unsupported);
+            }
+            Ok(RequestBody::Submit(Submit {
+                queue_id: read_u64(payload, 0)?,
+                program_id: read_u64(payload, 8)?,
+                timeout_ns: read_u64(payload, 24)?,
+                bindings: Bindings::Encoded {
+                    bytes: &payload[32..],
+                    count,
+                },
+            }))
+        }
+        Opcode::PollEvent => Ok(RequestBody::PollEvent {
+            event_id: decode_object(payload)?,
+        }),
+        Opcode::CancelEvent => Ok(RequestBody::CancelEvent {
+            event_id: decode_object(payload)?,
+        }),
+        Opcode::DestroyEvent => Ok(RequestBody::DestroyEvent {
+            event_id: decode_object(payload)?,
+        }),
+    }
+}
+
+fn request_payload_len(body: &RequestBody<'_>) -> Result<usize, Error> {
+    match body {
+        RequestBody::GetDeviceInfo => Ok(0),
+        RequestBody::CreateContext => Ok(8),
+        RequestBody::DestroyContext { context_id } => object_len(*context_id),
+        RequestBody::AllocateBuffer(request) => {
+            validate_allocate(*request)?;
+            Ok(40)
+        }
+        RequestBody::FreeBuffer { buffer_id } => object_len(*buffer_id),
+        RequestBody::WriteBuffer { transfer, data } => {
+            validate_transfer(*transfer)?;
+            let bytes = usize::try_from(transfer.bytes).map_err(|_| Error::ResourceLimit)?;
+            if bytes != data.len() {
+                return Err(Error::InvalidArgument);
+            }
+            24_usize.checked_add(bytes).ok_or(Error::ResourceLimit)
+        }
+        RequestBody::ReadBuffer(transfer) => {
+            validate_transfer(*transfer)?;
+            Ok(24)
+        }
+        RequestBody::LoadProgram(request) => {
+            if request.context_id == 0
+                || request.format == 0
+                || request.artifact.is_empty()
+                || request.resident_bytes == 0
+            {
+                return Err(Error::InvalidArgument);
+            }
+            80_usize
+                .checked_add(request.artifact.len())
+                .ok_or(Error::ResourceLimit)
+        }
+        RequestBody::UnloadProgram { program_id } => object_len(*program_id),
+        RequestBody::CreateQueue { context_id } => {
+            object_len(*context_id)?;
+            Ok(16)
+        }
+        RequestBody::DestroyQueue { queue_id } => object_len(*queue_id),
+        RequestBody::Submit(request) => {
+            if request.queue_id == 0 || request.program_id == 0 {
+                return Err(Error::InvalidArgument);
+            }
+            validate_bindings(request.bindings)
+        }
+        RequestBody::PollEvent { event_id }
+        | RequestBody::CancelEvent { event_id }
+        | RequestBody::DestroyEvent { event_id } => object_len(*event_id),
+    }
+}
+
+fn encode_request_body(body: &RequestBody<'_>, output: &mut [u8]) -> Result<(), Error> {
+    output.fill(0);
+    match body {
+        RequestBody::GetDeviceInfo | RequestBody::CreateContext => {}
+        RequestBody::DestroyContext { context_id } => write_u64(output, 0, *context_id)?,
+        RequestBody::AllocateBuffer(request) => {
+            write_u64(output, 0, request.context_id)?;
+            write_u64(output, 8, request.bytes)?;
+            write_u64(output, 16, request.alignment)?;
+            output[24] = request.memory_domain;
+            write_u32(output, 32, request.usage)?;
+        }
+        RequestBody::FreeBuffer { buffer_id } => write_u64(output, 0, *buffer_id)?,
+        RequestBody::WriteBuffer { transfer, data } => {
+            encode_transfer(*transfer, output)?;
+            write_slice(output, 24, data)?;
+        }
+        RequestBody::ReadBuffer(transfer) => encode_transfer(*transfer, output)?,
+        RequestBody::LoadProgram(request) => {
+            write_u64(output, 0, request.context_id)?;
+            write_u32(output, 8, request.format)?;
+            for (index, word) in request.target.iter().enumerate() {
+                write_u32(output, 16 + index * 4, *word)?;
+            }
+            write_u64(
+                output,
+                64,
+                u64::try_from(request.artifact.len()).map_err(|_| Error::ResourceLimit)?,
+            )?;
+            write_u64(output, 72, request.resident_bytes)?;
+            write_slice(output, 80, request.artifact)?;
+        }
+        RequestBody::UnloadProgram { program_id } => write_u64(output, 0, *program_id)?,
+        RequestBody::CreateQueue { context_id } => write_u64(output, 0, *context_id)?,
+        RequestBody::DestroyQueue { queue_id } => write_u64(output, 0, *queue_id)?,
+        RequestBody::Submit(request) => {
+            write_u64(output, 0, request.queue_id)?;
+            write_u64(output, 8, request.program_id)?;
+            let count = request.bindings.count()?;
+            write_u32(output, 16, count)?;
+            write_u64(output, 24, request.timeout_ns)?;
+            for index in 0..count {
+                encode_binding(
+                    request.bindings.get(index)?,
+                    output,
+                    32 + index as usize * 32,
+                )?;
+            }
+        }
+        RequestBody::PollEvent { event_id }
+        | RequestBody::CancelEvent { event_id }
+        | RequestBody::DestroyEvent { event_id } => write_u64(output, 0, *event_id)?,
+    }
+    Ok(())
+}
+
+fn validate_allocate(request: AllocateBuffer) -> Result<(), Error> {
+    if request.context_id == 0
+        || request.bytes == 0
+        || request.alignment == 0
+        || !request.alignment.is_power_of_two()
+        || !(1..=3).contains(&request.memory_domain)
+        || request.usage == 0
+    {
+        return Err(Error::InvalidArgument);
+    }
+    if request.usage & !KNOWN_BUFFER_USAGE_BITS != 0 {
+        return Err(Error::Unsupported);
+    }
+    Ok(())
+}
+
+fn decode_transfer(bytes: &[u8]) -> Result<TransferBuffer, Error> {
+    Ok(TransferBuffer {
+        buffer_id: read_u64(bytes, 0)?,
+        offset: read_u64(bytes, 8)?,
+        bytes: read_u64(bytes, 16)?,
+    })
+}
+
+fn validate_transfer(transfer: TransferBuffer) -> Result<(), Error> {
+    if transfer.buffer_id == 0 || transfer.bytes == 0 {
+        return Err(Error::InvalidArgument);
+    }
+    transfer
+        .offset
+        .checked_add(transfer.bytes)
+        .ok_or(Error::InvalidArgument)?;
+    Ok(())
+}
+
+fn encode_transfer(transfer: TransferBuffer, output: &mut [u8]) -> Result<(), Error> {
+    write_u64(output, 0, transfer.buffer_id)?;
+    write_u64(output, 8, transfer.offset)?;
+    write_u64(output, 16, transfer.bytes)
+}
+
+fn validate_bindings(bindings: Bindings<'_>) -> Result<usize, Error> {
+    let count = bindings.count()?;
+    if count == 0 {
+        return Err(Error::InvalidArgument);
+    }
+    if count > HARD_MAX_BINDINGS {
+        return Err(Error::ResourceLimit);
+    }
+    if let Bindings::Encoded { bytes, count } = bindings {
+        let expected = usize::try_from(count)
+            .map_err(|_| Error::ResourceLimit)?
+            .checked_mul(32)
+            .ok_or(Error::ResourceLimit)?;
+        if bytes.len() != expected {
+            return Err(Error::InvalidArgument);
+        }
+    }
+    for index in 0..count {
+        let binding = bindings.get(index)?;
+        validate_binding(binding)?;
+        for previous in 0..index {
+            if bindings.get(previous)?.slot == binding.slot {
+                return Err(Error::InvalidArgument);
+            }
+        }
+    }
+    32_usize
+        .checked_add(
+            usize::try_from(count)
+                .map_err(|_| Error::ResourceLimit)?
+                .checked_mul(32)
+                .ok_or(Error::ResourceLimit)?,
+        )
+        .ok_or(Error::ResourceLimit)
+}
+
+fn decode_binding(bytes: &[u8], offset: usize) -> Result<Binding, Error> {
+    let end = offset.checked_add(32).ok_or(Error::ResourceLimit)?;
+    let binding = bytes.get(offset..end).ok_or(Error::InvalidArgument)?;
+    if binding[29..32].iter().any(|byte| *byte != 0) {
+        return Err(Error::InvalidArgument);
+    }
+    Ok(Binding {
+        buffer_id: read_u64(binding, 0)?,
+        offset: read_u64(binding, 8)?,
+        bytes: read_u64(binding, 16)?,
+        slot: read_u32(binding, 24)?,
+        access: binding[28],
+    })
+}
+
+fn validate_binding(binding: Binding) -> Result<(), Error> {
+    if binding.buffer_id == 0 || binding.bytes == 0 || !(1..=3).contains(&binding.access) {
+        return Err(Error::InvalidArgument);
+    }
+    binding
+        .offset
+        .checked_add(binding.bytes)
+        .ok_or(Error::InvalidArgument)?;
+    Ok(())
+}
+
+fn encode_binding(binding: Binding, output: &mut [u8], offset: usize) -> Result<(), Error> {
+    write_u64(output, offset, binding.buffer_id)?;
+    write_u64(output, offset + 8, binding.offset)?;
+    write_u64(output, offset + 16, binding.bytes)?;
+    write_u32(output, offset + 24, binding.slot)?;
+    *output.get_mut(offset + 28).ok_or(Error::OutputTooSmall)? = binding.access;
+    Ok(())
+}
+
+fn decode_object(payload: &[u8]) -> Result<u64, Error> {
+    require_exact(payload, 8)?;
+    let object = read_u64(payload, 0)?;
+    object_len(object)?;
+    Ok(object)
+}
+
+fn object_len(object: u64) -> Result<usize, Error> {
+    if object == 0 {
+        Err(Error::InvalidArgument)
+    } else {
+        Ok(8)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DeviceInfo {
+    pub uuid: [u8; 16],
+    pub class: u16,
+    pub vendor_id: u32,
+    pub device_id: u32,
+    pub capabilities: u64,
+    pub max_contexts: u32,
+    pub max_buffers_per_context: u32,
+    pub max_programs_per_context: u32,
+    pub max_queues_per_context: u32,
+    pub max_events_per_context: u32,
+    pub max_bindings_per_submission: u32,
+    pub max_buffer_bytes: u64,
+    pub max_artifact_bytes: u64,
+}
+
+impl DeviceInfo {
+    pub const ENCODED_BYTES: usize = 76;
+
+    fn validate(self) -> Result<(), Error> {
+        if self.max_contexts == 0
+            || self.max_buffers_per_context == 0
+            || self.max_programs_per_context == 0
+            || self.max_queues_per_context == 0
+            || self.max_events_per_context == 0
+            || self.max_bindings_per_submission == 0
+            || self.max_buffer_bytes == 0
+            || self.max_artifact_bytes == 0
+        {
+            return Err(Error::InvalidArgument);
+        }
+        if self.max_bindings_per_submission > HARD_MAX_BINDINGS {
+            return Err(Error::ResourceLimit);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u16)]
+pub enum EventKind {
+    Pending = 0,
+    Complete = 1,
+    Failed = 2,
+    Cancelled = 3,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct EventState {
+    pub kind: EventKind,
+    pub error: u16,
+}
+
+impl EventState {
+    fn validate(self) -> Result<(), Error> {
+        match self.kind {
+            EventKind::Failed if self.error != 0 => Ok(()),
+            EventKind::Pending | EventKind::Complete | EventKind::Cancelled if self.error == 0 => {
+                Ok(())
+            }
+            _ => Err(Error::InvalidArgument),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ResponseBody<'a> {
+    Empty,
+    DeviceInfo(DeviceInfo),
+    Object(u64),
+    Data(&'a [u8]),
+    EventId(u64),
+    EventState(EventState),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Response<'a> {
+    pub status: u16,
+    pub request_id: u64,
+    pub body: ResponseBody<'a>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ResponseContext {
+    pub opcode: Option<Opcode>,
+    pub request_id: u64,
+    pub read_bytes: Option<usize>,
+}
+
+impl Response<'_> {
+    pub fn encoded_len(&self, context: ResponseContext) -> Result<usize, Error> {
+        let payload = response_payload_len(self, context)?;
+        let total = RESPONSE_HEADER_BYTES
+            .checked_add(payload)
+            .ok_or(Error::ResourceLimit)?;
+        if total > HARD_MAX_RESPONSE_BYTES as usize {
+            return Err(Error::ResourceLimit);
+        }
+        Ok(total)
+    }
+
+    pub fn encode(&self, context: ResponseContext, output: &mut [u8]) -> Result<usize, Error> {
+        let payload_len = response_payload_len(self, context)?;
+        let total = RESPONSE_HEADER_BYTES
+            .checked_add(payload_len)
+            .ok_or(Error::ResourceLimit)?;
+        if total > HARD_MAX_RESPONSE_BYTES as usize {
+            return Err(Error::ResourceLimit);
+        }
+        require_output(output, total)?;
+        write_u16(output, 0, self.status)?;
+        write_u16(output, 2, 0)?;
+        write_u32(
+            output,
+            4,
+            u32::try_from(payload_len).map_err(|_| Error::ResourceLimit)?,
+        )?;
+        write_u64(output, 8, self.request_id)?;
+        encode_response_body(self.body, &mut output[RESPONSE_HEADER_BYTES..total])?;
+        Ok(total)
+    }
+}
+
+pub fn decode_response(bytes: &[u8], context: ResponseContext) -> Result<Response<'_>, Error> {
+    if bytes.len() < RESPONSE_HEADER_BYTES {
+        return Err(Error::Size);
+    }
+    let status = read_u16(bytes, 0)?;
+    if read_u16(bytes, 2)? != 0 {
+        return Err(Error::InvalidArgument);
+    }
+    let payload_len = usize::try_from(read_u32(bytes, 4)?).map_err(|_| Error::ResourceLimit)?;
+    let total = RESPONSE_HEADER_BYTES
+        .checked_add(payload_len)
+        .ok_or(Error::ResourceLimit)?;
+    if total != bytes.len() {
+        return Err(Error::InvalidArgument);
+    }
+    if total > HARD_MAX_RESPONSE_BYTES as usize {
+        return Err(Error::ResourceLimit);
+    }
+    let request_id = read_u64(bytes, 8)?;
+    if request_id != context.request_id || request_id == 0 {
+        return Err(Error::InvalidArgument);
+    }
+    let payload = &bytes[RESPONSE_HEADER_BYTES..];
+    let body = decode_response_body(status, payload, context)?;
+    let response = Response {
+        status,
+        request_id,
+        body,
+    };
+    if response_payload_len(&response, context)? != payload_len {
+        return Err(Error::InvalidArgument);
+    }
+    Ok(response)
+}
+
+fn decode_response_body<'a>(
+    status: u16,
+    payload: &'a [u8],
+    context: ResponseContext,
+) -> Result<ResponseBody<'a>, Error> {
+    if status != 0 {
+        if context.opcode == Some(Opcode::Submit) && payload.len() == 8 {
+            return Ok(ResponseBody::EventId(decode_object(payload)?));
+        }
+        require_exact(payload, 0)?;
+        return Ok(ResponseBody::Empty);
+    }
+
+    match context.opcode.ok_or(Error::InvalidArgument)? {
+        Opcode::GetDeviceInfo => Ok(ResponseBody::DeviceInfo(decode_device_info(payload)?)),
+        Opcode::CreateContext
+        | Opcode::AllocateBuffer
+        | Opcode::LoadProgram
+        | Opcode::CreateQueue => Ok(ResponseBody::Object(decode_object(payload)?)),
+        Opcode::DestroyContext
+        | Opcode::FreeBuffer
+        | Opcode::WriteBuffer
+        | Opcode::UnloadProgram
+        | Opcode::DestroyQueue
+        | Opcode::CancelEvent
+        | Opcode::DestroyEvent => {
+            require_exact(payload, 0)?;
+            Ok(ResponseBody::Empty)
+        }
+        Opcode::ReadBuffer => {
+            let expected = context.read_bytes.ok_or(Error::InvalidArgument)?;
+            require_exact(payload, expected)?;
+            Ok(ResponseBody::Data(payload))
+        }
+        Opcode::Submit => Ok(ResponseBody::EventId(decode_object(payload)?)),
+        Opcode::PollEvent => Ok(ResponseBody::EventState(decode_event_state(payload)?)),
+    }
+}
+
+fn response_payload_len(response: &Response<'_>, context: ResponseContext) -> Result<usize, Error> {
+    if response.request_id == 0 || response.request_id != context.request_id {
+        return Err(Error::InvalidArgument);
+    }
+    if response.status != 0 {
+        return match (context.opcode, response.body) {
+            (Some(Opcode::Submit), ResponseBody::EventId(event_id)) => object_len(event_id),
+            (_, ResponseBody::Empty) => Ok(0),
+            _ => Err(Error::InvalidArgument),
+        };
+    }
+
+    match (context.opcode, response.body) {
+        (Some(Opcode::GetDeviceInfo), ResponseBody::DeviceInfo(info)) => {
+            info.validate()?;
+            Ok(DeviceInfo::ENCODED_BYTES)
+        }
+        (
+            Some(
+                Opcode::CreateContext
+                | Opcode::AllocateBuffer
+                | Opcode::LoadProgram
+                | Opcode::CreateQueue,
+            ),
+            ResponseBody::Object(object),
+        ) => object_len(object),
+        (
+            Some(
+                Opcode::DestroyContext
+                | Opcode::FreeBuffer
+                | Opcode::WriteBuffer
+                | Opcode::UnloadProgram
+                | Opcode::DestroyQueue
+                | Opcode::CancelEvent
+                | Opcode::DestroyEvent,
+            ),
+            ResponseBody::Empty,
+        ) => Ok(0),
+        (Some(Opcode::ReadBuffer), ResponseBody::Data(data)) => {
+            if Some(data.len()) != context.read_bytes {
+                return Err(Error::InvalidArgument);
+            }
+            Ok(data.len())
+        }
+        (Some(Opcode::Submit), ResponseBody::EventId(event_id)) => object_len(event_id),
+        (Some(Opcode::PollEvent), ResponseBody::EventState(state)) => {
+            state.validate()?;
+            Ok(8)
+        }
+        _ => Err(Error::InvalidArgument),
+    }
+}
+
+fn decode_device_info(payload: &[u8]) -> Result<DeviceInfo, Error> {
+    require_exact(payload, DeviceInfo::ENCODED_BYTES)?;
+    if read_u16(payload, 18)? != 0 {
+        return Err(Error::InvalidArgument);
+    }
+    let mut uuid = [0_u8; 16];
+    uuid.copy_from_slice(&payload[..16]);
+    let info = DeviceInfo {
+        uuid,
+        class: read_u16(payload, 16)?,
+        vendor_id: read_u32(payload, 20)?,
+        device_id: read_u32(payload, 24)?,
+        capabilities: read_u64(payload, 28)?,
+        max_contexts: read_u32(payload, 36)?,
+        max_buffers_per_context: read_u32(payload, 40)?,
+        max_programs_per_context: read_u32(payload, 44)?,
+        max_queues_per_context: read_u32(payload, 48)?,
+        max_events_per_context: read_u32(payload, 52)?,
+        max_bindings_per_submission: read_u32(payload, 56)?,
+        max_buffer_bytes: read_u64(payload, 60)?,
+        max_artifact_bytes: read_u64(payload, 68)?,
+    };
+    info.validate()?;
+    Ok(info)
+}
+
+fn decode_event_state(payload: &[u8]) -> Result<EventState, Error> {
+    require_exact(payload, 8)?;
+    if read_u32(payload, 4)? != 0 {
+        return Err(Error::InvalidArgument);
+    }
+    let kind = match read_u16(payload, 0)? {
+        0 => EventKind::Pending,
+        1 => EventKind::Complete,
+        2 => EventKind::Failed,
+        3 => EventKind::Cancelled,
+        _ => return Err(Error::RecoveryRequired),
+    };
+    let state = EventState {
+        kind,
+        error: read_u16(payload, 2)?,
+    };
+    state.validate()?;
+    Ok(state)
+}
+
+fn encode_response_body(body: ResponseBody<'_>, output: &mut [u8]) -> Result<(), Error> {
+    output.fill(0);
+    match body {
+        ResponseBody::Empty => {}
+        ResponseBody::DeviceInfo(info) => {
+            write_slice(output, 0, &info.uuid)?;
+            write_u16(output, 16, info.class)?;
+            write_u32(output, 20, info.vendor_id)?;
+            write_u32(output, 24, info.device_id)?;
+            write_u64(output, 28, info.capabilities)?;
+            write_u32(output, 36, info.max_contexts)?;
+            write_u32(output, 40, info.max_buffers_per_context)?;
+            write_u32(output, 44, info.max_programs_per_context)?;
+            write_u32(output, 48, info.max_queues_per_context)?;
+            write_u32(output, 52, info.max_events_per_context)?;
+            write_u32(output, 56, info.max_bindings_per_submission)?;
+            write_u64(output, 60, info.max_buffer_bytes)?;
+            write_u64(output, 68, info.max_artifact_bytes)?;
+        }
+        ResponseBody::Object(object) | ResponseBody::EventId(object) => {
+            write_u64(output, 0, object)?;
+        }
+        ResponseBody::Data(data) => write_slice(output, 0, data)?,
+        ResponseBody::EventState(state) => {
+            write_u16(output, 0, state.kind as u16)?;
+            write_u16(output, 2, state.error)?;
+        }
+    }
+    Ok(())
+}
+
+fn require_exact(bytes: &[u8], expected: usize) -> Result<(), Error> {
+    if bytes.len() == expected {
+        Ok(())
+    } else {
+        Err(Error::InvalidArgument)
+    }
+}
+
+fn require_output(output: &[u8], required: usize) -> Result<(), Error> {
+    if output.len() >= required {
+        Ok(())
+    } else {
+        Err(Error::OutputTooSmall)
+    }
+}
+
+fn read_u16(bytes: &[u8], offset: usize) -> Result<u16, Error> {
+    let raw: [u8; 2] = bytes
+        .get(offset..offset.checked_add(2).ok_or(Error::Size)?)
+        .ok_or(Error::Size)?
+        .try_into()
+        .map_err(|_| Error::Size)?;
+    Ok(u16::from_le_bytes(raw))
+}
+
+fn read_u32(bytes: &[u8], offset: usize) -> Result<u32, Error> {
+    let raw: [u8; 4] = bytes
+        .get(offset..offset.checked_add(4).ok_or(Error::Size)?)
+        .ok_or(Error::Size)?
+        .try_into()
+        .map_err(|_| Error::Size)?;
+    Ok(u32::from_le_bytes(raw))
+}
+
+fn read_u64(bytes: &[u8], offset: usize) -> Result<u64, Error> {
+    let raw: [u8; 8] = bytes
+        .get(offset..offset.checked_add(8).ok_or(Error::Size)?)
+        .ok_or(Error::Size)?
+        .try_into()
+        .map_err(|_| Error::Size)?;
+    Ok(u64::from_le_bytes(raw))
+}
+
+fn write_u16(output: &mut [u8], offset: usize, value: u16) -> Result<(), Error> {
+    write_slice(output, offset, &value.to_le_bytes())
+}
+
+fn write_u32(output: &mut [u8], offset: usize, value: u32) -> Result<(), Error> {
+    write_slice(output, offset, &value.to_le_bytes())
+}
+
+fn write_u64(output: &mut [u8], offset: usize, value: u64) -> Result<(), Error> {
+    write_slice(output, offset, &value.to_le_bytes())
+}
+
+fn write_slice(output: &mut [u8], offset: usize, value: &[u8]) -> Result<(), Error> {
+    let end = offset
+        .checked_add(value.len())
+        .ok_or(Error::OutputTooSmall)?;
+    output
+        .get_mut(offset..end)
+        .ok_or(Error::OutputTooSmall)?
+        .copy_from_slice(value);
+    Ok(())
+}

--- a/conformance/rust-clean-room/tests/vectors.rs
+++ b/conformance/rust-clean-room/tests/vectors.rs
@@ -1,0 +1,304 @@
+use serde_json::Value;
+use std::collections::BTreeSet;
+use virtio_accel_cleanroom::{
+    Binding, Bindings, Error, EventKind, EventState, Opcode, Request, RequestBody, Response,
+    ResponseBody, ResponseContext, Submit, TransferBuffer, decode_config, decode_request,
+    decode_response, validate_features,
+};
+
+const REQUEST_ID: u64 = 0x0102_0304_0506_0708;
+
+fn corpus() -> Value {
+    serde_json::from_str(include_str!("../../v1.0/vectors.json")).unwrap()
+}
+
+fn decode_hex(hex: &str) -> Vec<u8> {
+    assert_eq!(hex.len() % 2, 0);
+    (0..hex.len())
+        .step_by(2)
+        .map(|offset| u8::from_str_radix(&hex[offset..offset + 2], 16).unwrap())
+        .collect()
+}
+
+fn vector(group: &str, name: &str) -> Vec<u8> {
+    let corpus = corpus();
+    let entry = corpus[group]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|entry| entry["name"] == name)
+        .unwrap_or_else(|| panic!("missing vector {name}"));
+    decode_hex(entry["hex"].as_str().unwrap())
+}
+
+fn response_context(name: &str) -> ResponseContext {
+    let opcode = match name {
+        "response_get_device_info" => Some(Opcode::GetDeviceInfo),
+        "response_create_context" => Some(Opcode::CreateContext),
+        "response_destroy_context" => Some(Opcode::DestroyContext),
+        "response_allocate_buffer" => Some(Opcode::AllocateBuffer),
+        "response_free_buffer" => Some(Opcode::FreeBuffer),
+        "response_write_buffer" => Some(Opcode::WriteBuffer),
+        "response_read_buffer" => Some(Opcode::ReadBuffer),
+        "response_load_program" => Some(Opcode::LoadProgram),
+        "response_unload_program" => Some(Opcode::UnloadProgram),
+        "response_create_queue" => Some(Opcode::CreateQueue),
+        "response_destroy_queue" => Some(Opcode::DestroyQueue),
+        "response_submit_accepted" | "response_submit_indeterminate" => Some(Opcode::Submit),
+        name if name.starts_with("response_poll_event_") => Some(Opcode::PollEvent),
+        "response_cancel_event" => Some(Opcode::CancelEvent),
+        "response_destroy_event" => Some(Opcode::DestroyEvent),
+        "response_unknown_opcode" => None,
+        other => panic!("no response context for {other}"),
+    };
+    ResponseContext {
+        opcode,
+        request_id: REQUEST_ID,
+        read_bytes: (opcode == Some(Opcode::ReadBuffer)).then_some(4),
+    }
+}
+
+#[test]
+fn every_canonical_frame_round_trips_through_the_independent_codec() {
+    let corpus = corpus();
+    let mut request_opcodes = BTreeSet::new();
+    let mut response_names = BTreeSet::new();
+    let mut config_count = 0;
+
+    for frame in corpus["frames"].as_array().unwrap() {
+        let name = frame["name"].as_str().unwrap();
+        let bytes = decode_hex(frame["hex"].as_str().unwrap());
+        let mut output = vec![0xa5; bytes.len()];
+        let written = match frame["kind"].as_str().unwrap() {
+            "config" => {
+                config_count += 1;
+                decode_config(&bytes, 256)
+                    .unwrap()
+                    .encode(256, &mut output)
+                    .unwrap()
+            }
+            "request" => {
+                let request = decode_request(&bytes).unwrap();
+                request_opcodes.insert(request.body.opcode() as u16);
+                request.encode(&mut output).unwrap()
+            }
+            "response" => {
+                response_names.insert(name);
+                let context = response_context(name);
+                decode_response(&bytes, context)
+                    .unwrap()
+                    .encode(context, &mut output)
+                    .unwrap()
+            }
+            other => panic!("unknown frame kind {other}"),
+        };
+        assert_eq!(written, bytes.len(), "{name}");
+        assert_eq!(output, bytes, "{name}");
+    }
+
+    assert_eq!(config_count, 2);
+    assert_eq!(request_opcodes.len(), 15);
+    assert_eq!(response_names.len(), 20);
+}
+
+#[test]
+fn independent_semantics_match_the_reviewed_values() {
+    let submit_bytes = vector("frames", "request_submit");
+    let submit = decode_request(&submit_bytes).unwrap();
+    let RequestBody::Submit(submit) = submit.body else {
+        panic!("SUBMIT vector decoded as the wrong command");
+    };
+    assert_eq!(submit.queue_id, 0x4142_4344_4546_4748);
+    assert_eq!(submit.program_id, 0x3132_3334_3536_3738);
+    assert_eq!(submit.timeout_ns, 1_000_000);
+    assert_eq!(submit.bindings.count(), Ok(1));
+    assert_eq!(
+        submit.bindings.get(0),
+        Ok(Binding {
+            buffer_id: 0x2122_2324_2526_2728,
+            offset: 0,
+            bytes: 4_096,
+            slot: 7,
+            access: 3,
+        })
+    );
+
+    let info_context = response_context("response_get_device_info");
+    let info_bytes = vector("frames", "response_get_device_info");
+    let info = decode_response(&info_bytes, info_context).unwrap();
+    let ResponseBody::DeviceInfo(info) = info.body else {
+        panic!("device-info response decoded as the wrong payload");
+    };
+    assert_eq!(&info.uuid, b"virtio-accelmock");
+    assert_eq!(info.class, 1);
+    assert_eq!(info.vendor_id, 0x1234_5678);
+    assert_eq!(info.device_id, 0x9abc_def0);
+    assert_eq!(info.max_bindings_per_submission, 256);
+
+    let failed_context = response_context("response_poll_event_failed");
+    let failed_bytes = vector("frames", "response_poll_event_failed");
+    let failed = decode_response(&failed_bytes, failed_context).unwrap();
+    assert_eq!(
+        failed.body,
+        ResponseBody::EventState(EventState {
+            kind: EventKind::Failed,
+            error: 9,
+        })
+    );
+}
+
+#[test]
+fn reviewed_edge_vectors_receive_the_normative_classification() {
+    assert_eq!(
+        decode_config(
+            &vector("edge_cases", "config_descriptor_limit_above_hard_max"),
+            256,
+        ),
+        Err(Error::ChainDescriptorLimit)
+    );
+    assert_eq!(
+        decode_config(&vector("frames", "config_maximum"), 128),
+        Err(Error::ChainDescriptorLimit)
+    );
+
+    let future =
+        decode_config(&vector("edge_cases", "config_future_minor_compatible"), 256).unwrap();
+    assert!(future.protocol_minor > virtio_accel_cleanroom::PROTOCOL_MINOR);
+
+    assert_eq!(
+        decode_config(&vector("edge_cases", "config_unknown_major"), 256),
+        Err(Error::Version)
+    );
+    assert_eq!(
+        decode_request(&vector("edge_cases", "request_header_truncated")),
+        Err(Error::Size)
+    );
+    assert_eq!(
+        decode_request(&vector("edge_cases", "request_unknown_opcode")),
+        Err(Error::Unsupported)
+    );
+    assert_eq!(
+        decode_request(&vector("edge_cases", "request_reserved_flag")),
+        Err(Error::Unsupported)
+    );
+    assert_eq!(
+        decode_request(&vector("edge_cases", "request_trailing_byte")),
+        Err(Error::InvalidArgument)
+    );
+    assert_eq!(
+        decode_request(&vector("edge_cases", "request_reserved_context_flag")),
+        Err(Error::Unsupported)
+    );
+    assert_eq!(
+        decode_request(&vector("edge_cases", "request_unknown_memory_domain")),
+        Err(Error::InvalidArgument)
+    );
+    assert_eq!(
+        decode_request(&vector("edge_cases", "request_binding_count_overflow")),
+        Err(Error::ResourceLimit)
+    );
+
+    let unknown_status = vector("edge_cases", "response_unknown_status");
+    let context = ResponseContext {
+        opcode: None,
+        request_id: REQUEST_ID,
+        read_bytes: None,
+    };
+    let response = decode_response(&unknown_status, context).unwrap();
+    assert_eq!(response.status, 0x1234);
+    assert_eq!(response.body, ResponseBody::Empty);
+
+    let unknown_event = vector("edge_cases", "response_unknown_event_state");
+    let context = ResponseContext {
+        opcode: Some(Opcode::PollEvent),
+        request_id: REQUEST_ID,
+        read_bytes: None,
+    };
+    assert_eq!(
+        decode_response(&unknown_event, context),
+        Err(Error::RecoveryRequired)
+    );
+}
+
+#[test]
+fn encoder_rejects_values_that_cannot_cross_the_wire() {
+    assert_eq!(validate_features(1), Err(Error::Unsupported));
+
+    let zero_object = Request {
+        request_id: REQUEST_ID,
+        body: RequestBody::DestroyContext { context_id: 0 },
+    };
+    assert_eq!(zero_object.encoded_len(), Err(Error::InvalidArgument));
+
+    let overflowing_transfer = Request {
+        request_id: REQUEST_ID,
+        body: RequestBody::ReadBuffer(TransferBuffer {
+            buffer_id: 1,
+            offset: u64::MAX,
+            bytes: 1,
+        }),
+    };
+    assert_eq!(
+        overflowing_transfer.encoded_len(),
+        Err(Error::InvalidArgument)
+    );
+
+    let duplicate_bindings = [
+        Binding {
+            buffer_id: 1,
+            offset: 0,
+            bytes: 4,
+            slot: 7,
+            access: 1,
+        },
+        Binding {
+            buffer_id: 2,
+            offset: 0,
+            bytes: 4,
+            slot: 7,
+            access: 2,
+        },
+    ];
+    let duplicate_submit = Request {
+        request_id: REQUEST_ID,
+        body: RequestBody::Submit(Submit {
+            queue_id: 3,
+            program_id: 4,
+            timeout_ns: 0,
+            bindings: Bindings::Values(&duplicate_bindings),
+        }),
+    };
+    assert_eq!(duplicate_submit.encoded_len(), Err(Error::InvalidArgument));
+
+    let invalid_event = Response {
+        status: 0,
+        request_id: REQUEST_ID,
+        body: ResponseBody::EventState(EventState {
+            kind: EventKind::Failed,
+            error: 0,
+        }),
+    };
+    let event_context = ResponseContext {
+        opcode: Some(Opcode::PollEvent),
+        request_id: REQUEST_ID,
+        read_bytes: None,
+    };
+    assert_eq!(
+        invalid_event.encoded_len(event_context),
+        Err(Error::InvalidArgument)
+    );
+
+    let mut mismatched = vector("frames", "response_create_context");
+    mismatched[8] ^= 1;
+    assert_eq!(
+        decode_response(
+            &mismatched,
+            ResponseContext {
+                opcode: Some(Opcode::CreateContext),
+                request_id: REQUEST_ID,
+                read_bytes: None,
+            },
+        ),
+        Err(Error::InvalidArgument)
+    );
+}

--- a/conformance/v1.0/README.md
+++ b/conformance/v1.0/README.md
@@ -9,6 +9,8 @@ This directory contains implementation-independent inputs for the portable proto
   reviewed malformed/unknown boundary cases.
 - [`coverage.md`](coverage.md) maps the normative document areas to executable evidence or an
   explicitly tracked implementation issue.
+- [`requirements.json`](requirements.json) catalogs every normative keyword occurrence with a
+  content-derived ID, source line, executable evidence, tracked issues, and rationale.
 - [`../rust-clean-room`](../rust-clean-room) contains a dependency-free `no_std` Rust codec that
   implements the byte contract manually without importing `virtio-accel-proto` or its wire types.
 
@@ -22,4 +24,11 @@ versioned directory.
 
 The primary ABI and clean-room codec independently decode and encode every canonical frame. The
 primary crate's bridge test runs both implementations over the same bytes and compares their raw
-headers and exact output. CI also enforces that the clean-room codec remains dependency-free.
+headers and exact output. A separate semantic interoperability test constructs every distinct
+request and response layout in each implementation, crosses only bytes, and checks every decoded
+field in the other implementation. CI also enforces that the clean-room codec remains
+dependency-free.
+
+`ci/check-normative-requirements.py --check` reconstructs the requirement ledger from the normative
+Markdown. CI fails if a requirement is added, removed, moved, or reworded without regenerating and
+reviewing its exact evidence/rationale entry.

--- a/conformance/v1.0/README.md
+++ b/conformance/v1.0/README.md
@@ -7,6 +7,10 @@ This directory contains implementation-independent inputs for the portable proto
 - [`vectors.json`](vectors.json) contains canonical hexadecimal bytes for the device configuration,
   all 15 request opcodes, every success and command-specific response shape, all event states, and
   reviewed malformed/unknown boundary cases.
+- [`coverage.md`](coverage.md) maps the normative document areas to executable evidence or an
+  explicitly tracked implementation issue.
+- [`../rust-clean-room`](../rust-clean-room) contains a dependency-free `no_std` Rust codec that
+  implements the byte contract manually without importing `virtio-accel-proto` or its wire types.
 
 The files are deliberately plain JSON with hexadecimal byte strings so implementations do not need
 Rust tooling to consume them.
@@ -15,3 +19,7 @@ Ordinary tests parse these checked-in files as inputs. They do not regenerate th
 candidate revision must update the normative specification, Rust layout assertions, manifest, and
 vectors in one reviewed change. After the final freeze audit, incompatible changes require a new
 versioned directory.
+
+The primary ABI and clean-room codec independently decode and encode every canonical frame. The
+primary crate's bridge test runs both implementations over the same bytes and compares their raw
+headers and exact output. CI also enforces that the clean-room codec remains dependency-free.

--- a/conformance/v1.0/coverage.md
+++ b/conformance/v1.0/coverage.md
@@ -1,8 +1,10 @@
 # Protocol 1.0 candidate conformance coverage
 
-This matrix records where each normative area is executable today and where implementation-level
-behavior is deliberately tracked by a later issue. A tracked issue is the explicit rationale
-required by epic #2; it is not an assertion that unimplemented behavior already conforms.
+This matrix summarizes where each normative area is executable today and where implementation-level
+behavior is deliberately tracked by a later issue. The exact per-keyword ledger is
+[`requirements.json`](requirements.json), mechanically checked by
+`ci/check-normative-requirements.py`. A tracked issue is the explicit rationale required by epic
+#2; it is not an assertion that unimplemented behavior already conforms.
 
 | Normative area | Current executable evidence | Tracked completion rationale |
 |---|---|---|
@@ -38,7 +40,10 @@ The clean-room suite:
 
 The bridge test in `virtio-accel-proto` decodes each frame with both implementations, compares the
 independently derived header semantics, and requires the manual encoder to reproduce the exact
-canonical bytes. No Rust wire structure crosses that boundary.
+canonical bytes. `crates/virtio-accel-proto/tests/semantic_interop.rs` additionally constructs every
+distinct config, request, and response layout in each implementation and checks every semantic
+field after the other implementation decodes the bytes. No Rust wire structure crosses either
+boundary.
 
 The clean-room binding uniqueness check is intentionally allocation-free and quadratic. This crate
 is portable conformance evidence, not the production command-engine hot path; #20 may use a bounded

--- a/conformance/v1.0/coverage.md
+++ b/conformance/v1.0/coverage.md
@@ -1,0 +1,45 @@
+# Protocol 1.0 candidate conformance coverage
+
+This matrix records where each normative area is executable today and where implementation-level
+behavior is deliberately tracked by a later issue. A tracked issue is the explicit rationale
+required by epic #2; it is not an assertion that unimplemented behavior already conforms.
+
+| Normative area | Current executable evidence | Tracked completion rationale |
+|---|---|---|
+| `specification.md` sections 2-3: scope and layer boundaries | Workspace dependency direction, `no_std` target checks, and the clean-room dependency guard | Concrete transport/provider boundary audits continue in #17, #20, and #21 |
+| Section 4: contexts, buffers, programs, queues, submissions, and events | `virtio-accel-core`, object-table, and mock lifecycle tests | Full command-engine ownership behavior is #20; remaining backend semantics are #21 |
+| Section 5: mandatory baseline, reserved features, flags, and scalar namespaces | Primary ABI namespace tests plus clean-room request validation and edge vectors | Optional features remain unadvertised; their future policy is #32 |
+| Section 6: versions, exact lengths, unknown values, and extension rules | Config/version edge vectors, both codecs, immutable manifests, and layout assertions | Candidate-to-stable freeze and clean-room review are audited again in #33 |
+| Sections 7-9: ownership, time, progress, and error truth | Generational-ID, timeout, mock lifecycle, unknown-status, and indeterminate-submit tests | End-to-end recovery and response atomicity are #20; backend policy details are #21 |
+| Section 10: portability | Stable/MSRV, Linux/macOS/Windows, Wasm, AArch64, RISC-V, feature, dependency, and documentation CI | Concrete OS/VMM adapters remain intentionally outside portable v1 |
+| `wire-abi.md` sections 1-6: config, headers, namespaces, all payloads, statuses, limits, and reserved fields | `layout.json`, `vectors.json`, primary `zerocopy` assertions, and the manual dependency-free codec | Device-state limits that require live objects are exercised by #20 and threat-model issue #25 |
+| `wire-abi.md` section 7: preflight and response atomicity | Error-shape vectors and ownership-aware core error types | Writable-region preflight and post-mutation failure are VQ-012/VQ-020 in #18 and #20 |
+| `wire-abi.md` sections 8-9: versioned artifacts and change control | Checked-in inputs, drift tests, and coordinated-change documentation | Release freeze governance is finalized by #32 and #33 |
+| `virtqueue.md` sections 1-12 | Stable executable case identifiers `VQ-001` through `VQ-020` define the required assertions | Region ports are #17, split-ring model tests are #18, guest compatibility is #19, and full-path behavior is #20 |
+
+## Independent implementation evidence
+
+The two Rust implementations share only the normative documents and checked-in byte artifacts:
+
+1. `virtio-accel-proto` uses explicit packed Rust wire structures and `zerocopy`.
+2. `virtio-accel-cleanroom` uses manual slice indexing and little-endian conversion, defines its own
+   semantic types, has no normal/build dependencies, and is never a production dependency.
+
+The clean-room suite:
+
+- decodes and re-encodes both configurations, all 15 request opcodes, and all 20 canonical response
+  shapes byte-for-byte;
+- validates every binding rather than copying an opaque submission tail;
+- independently classifies every reviewed adversarial vector;
+- preserves unknown response statuses as opaque failures;
+- rejects unknown event states with recovery required; and
+- tests zero IDs, integer overflow, duplicate binding slots, response correlation, reserved values,
+  and invalid event-state combinations.
+
+The bridge test in `virtio-accel-proto` decodes each frame with both implementations, compares the
+independently derived header semantics, and requires the manual encoder to reproduce the exact
+canonical bytes. No Rust wire structure crosses that boundary.
+
+The clean-room binding uniqueness check is intentionally allocation-free and quadratic. This crate
+is portable conformance evidence, not the production command-engine hot path; #20 may use a bounded
+set or table consistent with its resource accounting.

--- a/conformance/v1.0/requirements.json
+++ b/conformance/v1.0/requirements.json
@@ -1,0 +1,2176 @@
+{
+  "schema": "virtio-accel-normative-requirements-1",
+  "generated_by": "ci/check-normative-requirements.py",
+  "requirement_count": 113,
+  "requirements": [
+    {
+      "id": "REQ-SPEC-A29885B44214",
+      "source": "docs/specification.md",
+      "line": 17,
+      "section": "1. Normative language",
+      "keyword": "MUST",
+      "statement": "The key words **MUST**, **MUST NOT**, **REQUIRED**, **SHOULD**, **SHOULD NOT**, **MAY**, and",
+      "coverage": {
+        "status": "definition",
+        "evidence": [],
+        "issues": [],
+        "rationale": "Defines RFC 2119 and RFC 8174 terminology; it imposes no implementation behavior."
+      }
+    },
+    {
+      "id": "REQ-SPEC-A27DAE6247C8",
+      "source": "docs/specification.md",
+      "line": 17,
+      "section": "1. Normative language",
+      "keyword": "MUST NOT",
+      "statement": "The key words **MUST**, **MUST NOT**, **REQUIRED**, **SHOULD**, **SHOULD NOT**, **MAY**, and",
+      "coverage": {
+        "status": "definition",
+        "evidence": [],
+        "issues": [],
+        "rationale": "Defines RFC 2119 and RFC 8174 terminology; it imposes no implementation behavior."
+      }
+    },
+    {
+      "id": "REQ-SPEC-87FFBBAC9666",
+      "source": "docs/specification.md",
+      "line": 17,
+      "section": "1. Normative language",
+      "keyword": "REQUIRED",
+      "statement": "The key words **MUST**, **MUST NOT**, **REQUIRED**, **SHOULD**, **SHOULD NOT**, **MAY**, and",
+      "coverage": {
+        "status": "definition",
+        "evidence": [],
+        "issues": [],
+        "rationale": "Defines RFC 2119 and RFC 8174 terminology; it imposes no implementation behavior."
+      }
+    },
+    {
+      "id": "REQ-SPEC-D0762D106FF8",
+      "source": "docs/specification.md",
+      "line": 17,
+      "section": "1. Normative language",
+      "keyword": "SHOULD",
+      "statement": "The key words **MUST**, **MUST NOT**, **REQUIRED**, **SHOULD**, **SHOULD NOT**, **MAY**, and",
+      "coverage": {
+        "status": "definition",
+        "evidence": [],
+        "issues": [],
+        "rationale": "Defines RFC 2119 and RFC 8174 terminology; it imposes no implementation behavior."
+      }
+    },
+    {
+      "id": "REQ-SPEC-FADE6A0C8000",
+      "source": "docs/specification.md",
+      "line": 17,
+      "section": "1. Normative language",
+      "keyword": "SHOULD NOT",
+      "statement": "The key words **MUST**, **MUST NOT**, **REQUIRED**, **SHOULD**, **SHOULD NOT**, **MAY**, and",
+      "coverage": {
+        "status": "definition",
+        "evidence": [],
+        "issues": [],
+        "rationale": "Defines RFC 2119 and RFC 8174 terminology; it imposes no implementation behavior."
+      }
+    },
+    {
+      "id": "REQ-SPEC-6A4E1EAA8AEC",
+      "source": "docs/specification.md",
+      "line": 17,
+      "section": "1. Normative language",
+      "keyword": "MAY",
+      "statement": "The key words **MUST**, **MUST NOT**, **REQUIRED**, **SHOULD**, **SHOULD NOT**, **MAY**, and",
+      "coverage": {
+        "status": "definition",
+        "evidence": [],
+        "issues": [],
+        "rationale": "Defines RFC 2119 and RFC 8174 terminology; it imposes no implementation behavior."
+      }
+    },
+    {
+      "id": "REQ-SPEC-02F2CB1C0E65",
+      "source": "docs/specification.md",
+      "line": 18,
+      "section": "1. Normative language",
+      "keyword": "OPTIONAL",
+      "statement": "**OPTIONAL** are to be interpreted as described by RFC 2119 and RFC 8174 when, and only when, they",
+      "coverage": {
+        "status": "definition",
+        "evidence": [],
+        "issues": [],
+        "rationale": "Defines RFC 2119 and RFC 8174 terminology; it imposes no implementation behavior."
+      }
+    },
+    {
+      "id": "REQ-SPEC-7C1477A412E8",
+      "source": "docs/specification.md",
+      "line": 48,
+      "section": "2. Scope",
+      "keyword": "MUST NOT",
+      "statement": "Adding an integration listed above **MUST NOT** change the portable object lifecycle by convention.",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "ci/check-portable-dependencies.sh",
+          "docs/architecture.md"
+        ],
+        "issues": [
+          "#17",
+          "#20",
+          "#21"
+        ],
+        "rationale": "Portable dependency direction is enforced now; concrete transport and provider boundaries are tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-46879D8954C6",
+      "source": "docs/specification.md",
+      "line": 60,
+      "section": "3. Roles and boundaries",
+      "keyword": "MUST",
+      "statement": "The driver **MUST** treat all device-written bytes as untrusted.",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "ci/check-portable-dependencies.sh",
+          "docs/architecture.md"
+        ],
+        "issues": [
+          "#17",
+          "#20",
+          "#21"
+        ],
+        "rationale": "Layer dependencies are enforceable now; runtime adapter boundaries require their implementations."
+      }
+    },
+    {
+      "id": "REQ-SPEC-35351F1F3E8C",
+      "source": "docs/specification.md",
+      "line": 68,
+      "section": "3. Roles and boundaries",
+      "keyword": "MUST",
+      "statement": "The device **MUST** treat all driver-written bytes, lengths, counts, object IDs, flags, and timing as",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "ci/check-portable-dependencies.sh",
+          "docs/architecture.md"
+        ],
+        "issues": [
+          "#17",
+          "#20",
+          "#21"
+        ],
+        "rationale": "Layer dependencies are enforceable now; runtime adapter boundaries require their implementations."
+      }
+    },
+    {
+      "id": "REQ-SPEC-2FA8687B7253",
+      "source": "docs/specification.md",
+      "line": 76,
+      "section": "3. Roles and boundaries",
+      "keyword": "MUST NOT",
+      "statement": "A transport adapter **MUST NOT** expose guest addresses, descriptor objects, host mappings, or",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "ci/check-portable-dependencies.sh",
+          "docs/architecture.md"
+        ],
+        "issues": [
+          "#17",
+          "#20",
+          "#21"
+        ],
+        "rationale": "Layer dependencies are enforceable now; runtime adapter boundaries require their implementations."
+      }
+    },
+    {
+      "id": "REQ-SPEC-6F4FE5DEC4D4",
+      "source": "docs/specification.md",
+      "line": 85,
+      "section": "3. Roles and boundaries",
+      "keyword": "MUST NOT",
+      "statement": "The command engine **MUST NOT** depend on an operating system, VMM, kernel, guest-memory crate, vendor",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "ci/check-portable-dependencies.sh",
+          "docs/architecture.md"
+        ],
+        "issues": [
+          "#17",
+          "#20",
+          "#21"
+        ],
+        "rationale": "Layer dependencies are enforceable now; runtime adapter boundaries require their implementations."
+      }
+    },
+    {
+      "id": "REQ-SPEC-09014BF54341",
+      "source": "docs/specification.md",
+      "line": 93,
+      "section": "3. Roles and boundaries",
+      "keyword": "MUST NOT",
+      "statement": "A backend **MUST NOT** receive wire structures, object IDs, guest addresses, or virtqueue",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "ci/check-portable-dependencies.sh",
+          "docs/architecture.md"
+        ],
+        "issues": [
+          "#17",
+          "#20",
+          "#21"
+        ],
+        "rationale": "Layer dependencies are enforceable now; runtime adapter boundaries require their implementations."
+      }
+    },
+    {
+      "id": "REQ-SPEC-91455147F9D0",
+      "source": "docs/specification.md",
+      "line": 122,
+      "section": "4. Terminology and object model",
+      "keyword": "MUST",
+      "statement": "A device **MUST** reject an operation that combines objects from different contexts before invoking",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/src/object_table.rs",
+          "crates/virtio-accel-mock/src/lib.rs"
+        ],
+        "issues": [
+          "#20",
+          "#21"
+        ],
+        "rationale": "Core ownership types and lifecycle tests exist; the command engine and complete backend policy remain tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-10044BA7BF6B",
+      "source": "docs/specification.md",
+      "line": 123,
+      "section": "4. Terminology and object model",
+      "keyword": "MUST NOT",
+      "statement": "the backend. A context **MUST NOT** be destroyed while any child object or in-flight reference",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/src/object_table.rs",
+          "crates/virtio-accel-mock/src/lib.rs"
+        ],
+        "issues": [
+          "#20",
+          "#21"
+        ],
+        "rationale": "Core ownership types and lifecycle tests exist; the command engine and complete backend policy remain tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-4AFE9E8DAC8A",
+      "source": "docs/specification.md",
+      "line": 135,
+      "section": "4. Terminology and object model",
+      "keyword": "MUST",
+      "statement": "The buffer\u2019s guest-visible object ID is not an address. Every transfer and binding range **MUST** fit",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/src/object_table.rs",
+          "crates/virtio-accel-mock/src/lib.rs"
+        ],
+        "issues": [
+          "#20",
+          "#21"
+        ],
+        "rationale": "Core ownership types and lifecycle tests exist; the command engine and complete backend policy remain tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-56AF235C5973",
+      "source": "docs/specification.md",
+      "line": 143,
+      "section": "4. Terminology and object model",
+      "keyword": "MUST NOT",
+      "statement": "The transport **MUST NOT** interpret vendor artifact contents. Artifact-format adapters own their",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/src/object_table.rs",
+          "crates/virtio-accel-mock/src/lib.rs"
+        ],
+        "issues": [
+          "#20",
+          "#21"
+        ],
+        "rationale": "Core ownership types and lifecycle tests exist; the command engine and complete backend policy remain tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-99785E39EE23",
+      "source": "docs/specification.md",
+      "line": 152,
+      "section": "4. Terminology and object model",
+      "keyword": "SHOULD",
+      "statement": "It is unrelated to a Virtio queue index. Documentation and APIs **SHOULD** use \u201cexecution queue\u201d",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/src/object_table.rs",
+          "crates/virtio-accel-mock/src/lib.rs"
+        ],
+        "issues": [
+          "#20",
+          "#21"
+        ],
+        "rationale": "Core ownership types and lifecycle tests exist; the command engine and complete backend policy remain tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-446BAC519DC5",
+      "source": "docs/specification.md",
+      "line": 160,
+      "section": "4. Terminology and object model",
+      "keyword": "MUST",
+      "statement": "Binding slot numbers **MUST** be unique within a submission. A binding does not transfer ownership",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/src/object_table.rs",
+          "crates/virtio-accel-mock/src/lib.rs"
+        ],
+        "issues": [
+          "#20",
+          "#21"
+        ],
+        "rationale": "Core ownership types and lifecycle tests exist; the command engine and complete backend policy remain tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-B509E77DB3D3",
+      "source": "docs/specification.md",
+      "line": 161,
+      "section": "4. Terminology and object model",
+      "keyword": "MUST",
+      "statement": "of its buffer, but the device **MUST** retain the buffer until the resulting event is safely",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/src/object_table.rs",
+          "crates/virtio-accel-mock/src/lib.rs"
+        ],
+        "issues": [
+          "#20",
+          "#21"
+        ],
+        "rationale": "Core ownership types and lifecycle tests exist; the command engine and complete backend policy remain tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-B71B5452BE12",
+      "source": "docs/specification.md",
+      "line": 177,
+      "section": "4. Terminology and object model",
+      "keyword": "MUST NOT",
+      "statement": "The command engine **MUST NOT** convert an indeterminate submission into an ordinary error.",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/src/object_table.rs",
+          "crates/virtio-accel-mock/src/lib.rs"
+        ],
+        "issues": [
+          "#20",
+          "#21"
+        ],
+        "rationale": "Core ownership types and lifecycle tests exist; the command engine and complete backend policy remain tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-66AFC1A94561",
+      "source": "docs/specification.md",
+      "line": 184,
+      "section": "4. Terminology and object model",
+      "keyword": "MUST",
+      "statement": "An event **MUST** retain its execution queue, program, buffers, and per-invocation backend state until",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/src/object_table.rs",
+          "crates/virtio-accel-mock/src/lib.rs"
+        ],
+        "issues": [
+          "#20",
+          "#21"
+        ],
+        "rationale": "Core ownership types and lifecycle tests exist; the command engine and complete backend policy remain tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-10FC985A68FF",
+      "source": "docs/specification.md",
+      "line": 185,
+      "section": "4. Terminology and object model",
+      "keyword": "MUST NOT",
+      "statement": "it is terminal and successfully destroyed. A pending event **MUST NOT** be destroyed.",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/src/object_table.rs",
+          "crates/virtio-accel-mock/src/lib.rs"
+        ],
+        "issues": [
+          "#20",
+          "#21"
+        ],
+        "rationale": "Core ownership types and lifecycle tests exist; the command engine and complete backend policy remain tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-5BB719500123",
+      "source": "docs/specification.md",
+      "line": 206,
+      "section": "5. Baseline capabilities and feature policy",
+      "keyword": "MUST",
+      "statement": "The portable v1 baseline **MUST** provide:",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "crates/virtio-accel-proto/src/lib.rs"
+        ],
+        "issues": [
+          "#20",
+          "#32"
+        ],
+        "rationale": "Namespaces and reserved values are executable; runtime negotiation and future evolution remain tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-47C10706DD08",
+      "source": "docs/specification.md",
+      "line": 221,
+      "section": "5. Baseline capabilities and feature policy",
+      "keyword": "MUST",
+      "statement": "advertise semantic event-cancellation capability, the device **MUST** return `UNSUPPORTED` without",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "crates/virtio-accel-proto/src/lib.rs"
+        ],
+        "issues": [
+          "#20",
+          "#32"
+        ],
+        "rationale": "Namespaces and reserved values are executable; runtime negotiation and future evolution remain tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-6AE883563CDE",
+      "source": "docs/specification.md",
+      "line": 230,
+      "section": "5. Baseline capabilities and feature policy",
+      "keyword": "MUST NOT",
+      "statement": "`TIMELINE_FENCES`, and `SECURE_CONTEXTS` reserve numeric positions only. A baseline device **MUST NOT**",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "crates/virtio-accel-proto/src/lib.rs"
+        ],
+        "issues": [
+          "#20",
+          "#32"
+        ],
+        "rationale": "Namespaces and reserved values are executable; runtime negotiation and future evolution remain tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-0451EDD49C74",
+      "source": "docs/specification.md",
+      "line": 231,
+      "section": "5. Baseline capabilities and feature policy",
+      "keyword": "MUST NOT",
+      "statement": "advertise them and a baseline driver **MUST NOT** accept them. Protocol 1.0 assigns no semantics to",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "crates/virtio-accel-proto/src/lib.rs"
+        ],
+        "issues": [
+          "#20",
+          "#32"
+        ],
+        "rationale": "Namespaces and reserved values are executable; runtime negotiation and future evolution remain tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-4790D362BFD9",
+      "source": "docs/specification.md",
+      "line": 234,
+      "section": "5. Baseline capabilities and feature policy",
+      "keyword": "MUST NOT",
+      "statement": "Unknown device-specific feature bits **MUST NOT** be accepted by a driver. A device **MUST NOT**",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "crates/virtio-accel-proto/src/lib.rs"
+        ],
+        "issues": [
+          "#20",
+          "#32"
+        ],
+        "rationale": "Namespaces and reserved values are executable; runtime negotiation and future evolution remain tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-4F438014BEF4",
+      "source": "docs/specification.md",
+      "line": 234,
+      "section": "5. Baseline capabilities and feature policy",
+      "keyword": "MUST NOT",
+      "statement": "Unknown device-specific feature bits **MUST NOT** be accepted by a driver. A device **MUST NOT**",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "crates/virtio-accel-proto/src/lib.rs"
+        ],
+        "issues": [
+          "#20",
+          "#32"
+        ],
+        "rationale": "Namespaces and reserved values are executable; runtime negotiation and future evolution remain tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-F04C99D52AC3",
+      "source": "docs/specification.md",
+      "line": 243,
+      "section": "5. Baseline capabilities and feature policy",
+      "keyword": "MUST",
+      "statement": "new synchronization, or changed lifetime rules, the device **MUST** also negotiate an appropriate",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "crates/virtio-accel-proto/src/lib.rs"
+        ],
+        "issues": [
+          "#20",
+          "#32"
+        ],
+        "rationale": "Namespaces and reserved values are executable; runtime negotiation and future evolution remain tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-8B2416B7246F",
+      "source": "docs/specification.md",
+      "line": 248,
+      "section": "5. Baseline capabilities and feature policy",
+      "keyword": "MUST NOT",
+      "statement": "listed in [wire-abi.md](wire-abi.md); the reference implementation **MUST NOT** translate an",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "crates/virtio-accel-proto/src/lib.rs"
+        ],
+        "issues": [
+          "#20",
+          "#32"
+        ],
+        "rationale": "Namespaces and reserved values are executable; runtime negotiation and future evolution remain tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-13AAF8D4B1EE",
+      "source": "docs/specification.md",
+      "line": 254,
+      "section": "5. Baseline capabilities and feature policy",
+      "keyword": "MUST",
+      "statement": "reserved and **MUST** be zero.",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "crates/virtio-accel-proto/src/lib.rs"
+        ],
+        "issues": [
+          "#20",
+          "#32"
+        ],
+        "rationale": "Namespaces and reserved values are executable; runtime negotiation and future evolution remain tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-7A71D9423437",
+      "source": "docs/specification.md",
+      "line": 257,
+      "section": "5. Baseline capabilities and feature policy",
+      "keyword": "MUST",
+      "statement": "**MUST** be rejected before backend invocation. Reserved fields **MUST** be zero.",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "crates/virtio-accel-proto/src/lib.rs"
+        ],
+        "issues": [
+          "#20",
+          "#32"
+        ],
+        "rationale": "Namespaces and reserved values are executable; runtime negotiation and future evolution remain tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-7FAC1C244457",
+      "source": "docs/specification.md",
+      "line": 257,
+      "section": "5. Baseline capabilities and feature policy",
+      "keyword": "MUST",
+      "statement": "**MUST** be rejected before backend invocation. Reserved fields **MUST** be zero.",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "crates/virtio-accel-proto/src/lib.rs"
+        ],
+        "issues": [
+          "#20",
+          "#32"
+        ],
+        "rationale": "Namespaces and reserved values are executable; runtime negotiation and future evolution remain tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-30B9B112E166",
+      "source": "docs/specification.md",
+      "line": 264,
+      "section": "6. Versioning and compatibility",
+      "keyword": "MUST",
+      "statement": "Candidate implementations **MUST** expose major `1` and minor `0` in device-specific configuration",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "conformance/v1.0/layout.json",
+          "conformance/v1.0/vectors.json"
+        ],
+        "issues": [
+          "#32",
+          "#33"
+        ],
+        "rationale": "Version and exact-length behavior is executable; release governance and the final freeze remain tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-2BF6F42BB323",
+      "source": "docs/specification.md",
+      "line": 265,
+      "section": "6. Versioning and compatibility",
+      "keyword": "MUST NOT",
+      "statement": "and **MUST NOT** claim candidate protocol 1.0 conformance unless they satisfy the normative wire,",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "conformance/v1.0/layout.json",
+          "conformance/v1.0/vectors.json"
+        ],
+        "issues": [
+          "#32",
+          "#33"
+        ],
+        "rationale": "Version and exact-length behavior is executable; release governance and the final freeze remain tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-ED6E6EBD406D",
+      "source": "docs/specification.md",
+      "line": 269,
+      "section": "6. Versioning and compatibility",
+      "keyword": "MUST",
+      "statement": "#33. Before that audit, an intentional candidate revision **MUST** follow the coordinated procedure",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "conformance/v1.0/layout.json",
+          "conformance/v1.0/vectors.json"
+        ],
+        "issues": [
+          "#32",
+          "#33"
+        ],
+        "rationale": "Version and exact-length behavior is executable; release governance and the final freeze remain tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-5687B484D7C0",
+      "source": "docs/specification.md",
+      "line": 270,
+      "section": "6. Versioning and compatibility",
+      "keyword": "MUST NOT",
+      "statement": "in [wire-abi.md](wire-abi.md) and **MUST NOT** be described as a frozen or stable release.",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "conformance/v1.0/layout.json",
+          "conformance/v1.0/vectors.json"
+        ],
+        "issues": [
+          "#32",
+          "#33"
+        ],
+        "rationale": "Version and exact-length behavior is executable; release governance and the final freeze remain tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-C559442F7881",
+      "source": "docs/specification.md",
+      "line": 276,
+      "section": "6. Versioning and compatibility",
+      "keyword": "MUST",
+      "statement": "- a driver **MUST** reject a device with an unsupported major version;",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "conformance/v1.0/layout.json",
+          "conformance/v1.0/vectors.json"
+        ],
+        "issues": [
+          "#32",
+          "#33"
+        ],
+        "rationale": "Version and exact-length behavior is executable; release governance and the final freeze remain tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-97B5F1905B00",
+      "source": "docs/specification.md",
+      "line": 278,
+      "section": "6. Versioning and compatibility",
+      "keyword": "MUST NOT",
+      "statement": "- a driver **MUST NOT** use behavior newer than the device minor version it observed; and",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "conformance/v1.0/layout.json",
+          "conformance/v1.0/vectors.json"
+        ],
+        "issues": [
+          "#32",
+          "#33"
+        ],
+        "rationale": "Version and exact-length behavior is executable; release governance and the final freeze remain tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-3C80B5950333",
+      "source": "docs/specification.md",
+      "line": 287,
+      "section": "6. Versioning and compatibility",
+      "keyword": "MUST NOT",
+      "statement": "Therefore a minor version alone **MUST NOT** append fields to an existing response that an older",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "conformance/v1.0/layout.json",
+          "conformance/v1.0/vectors.json"
+        ],
+        "issues": [
+          "#32",
+          "#33"
+        ],
+        "rationale": "Version and exact-length behavior is executable; release governance and the final freeze remain tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-C606EBB6B424",
+      "source": "docs/specification.md",
+      "line": 291,
+      "section": "6. Versioning and compatibility",
+      "keyword": "SHOULD",
+      "statement": "negotiated feature explicitly selects a different layout. Extensions **SHOULD** use a new opcode or",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "conformance/v1.0/layout.json",
+          "conformance/v1.0/vectors.json"
+        ],
+        "issues": [
+          "#32",
+          "#33"
+        ],
+        "rationale": "Version and exact-length behavior is executable; release governance and the final freeze remain tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-5D0FF22C6F7F",
+      "source": "docs/specification.md",
+      "line": 294,
+      "section": "6. Versioning and compatibility",
+      "keyword": "MUST",
+      "statement": "Without such a feature, a receiver **MUST** require the exact payload length for the opcode and",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "conformance/v1.0/layout.json",
+          "conformance/v1.0/vectors.json"
+        ],
+        "issues": [
+          "#32",
+          "#33"
+        ],
+        "rationale": "Version and exact-length behavior is executable; release governance and the final freeze remain tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-9EE8CA6EE4D0",
+      "source": "docs/specification.md",
+      "line": 295,
+      "section": "6. Versioning and compatibility",
+      "keyword": "MUST",
+      "statement": "**MUST** reject trailing bytes. It **MUST NOT** silently reinterpret or ignore an unknown tail.",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "conformance/v1.0/layout.json",
+          "conformance/v1.0/vectors.json"
+        ],
+        "issues": [
+          "#32",
+          "#33"
+        ],
+        "rationale": "Version and exact-length behavior is executable; release governance and the final freeze remain tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-1E2D21965135",
+      "source": "docs/specification.md",
+      "line": 295,
+      "section": "6. Versioning and compatibility",
+      "keyword": "MUST NOT",
+      "statement": "**MUST** reject trailing bytes. It **MUST NOT** silently reinterpret or ignore an unknown tail.",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "conformance/v1.0/layout.json",
+          "conformance/v1.0/vectors.json"
+        ],
+        "issues": [
+          "#32",
+          "#33"
+        ],
+        "rationale": "Version and exact-length behavior is executable; release governance and the final freeze remain tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-5E601687AFF4",
+      "source": "docs/specification.md",
+      "line": 302,
+      "section": "6. Versioning and compatibility",
+      "keyword": "MUST NOT",
+      "statement": "- An unknown response status is an opaque failure. A driver **MUST NOT** treat it as success or",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "conformance/v1.0/layout.json",
+          "conformance/v1.0/vectors.json"
+        ],
+        "issues": [
+          "#32",
+          "#33"
+        ],
+        "rationale": "Version and exact-length behavior is executable; release governance and the final freeze remain tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-348C878520B7",
+      "source": "docs/specification.md",
+      "line": 309,
+      "section": "7. Ownership and destruction",
+      "keyword": "MUST",
+      "statement": "The device owns the mapping from opaque object IDs to backend handles. The mapping **MUST** reject:",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/src/object_table.rs",
+          "crates/virtio-accel-mock/src/lib.rs"
+        ],
+        "issues": [
+          "#20",
+          "#21"
+        ],
+        "rationale": "Handle and generational-ID invariants are tested; end-to-end release recovery remains tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-DF46FBE73D09",
+      "source": "docs/specification.md",
+      "line": 317,
+      "section": "7. Ownership and destruction",
+      "keyword": "MUST NOT",
+      "statement": "Object-ID encoding is implementation-private. Drivers **MUST NOT** infer slot, kind, generation, or",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/src/object_table.rs",
+          "crates/virtio-accel-mock/src/lib.rs"
+        ],
+        "issues": [
+          "#20",
+          "#21"
+        ],
+        "rationale": "Handle and generational-ID invariants are tested; end-to-end release recovery remains tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-43660E08DAB5",
+      "source": "docs/specification.md",
+      "line": 322,
+      "section": "7. Ownership and destruction",
+      "keyword": "MUST",
+      "statement": "- a rejected release returns the still-live handle and the device **MUST** restore it for retry;",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/src/object_table.rs",
+          "crates/virtio-accel-mock/src/lib.rs"
+        ],
+        "issues": [
+          "#20",
+          "#21"
+        ],
+        "rationale": "Handle and generational-ID invariants are tested; end-to-end release recovery remains tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-12D875ED1FD1",
+      "source": "docs/specification.md",
+      "line": 324,
+      "section": "7. Ownership and destruction",
+      "keyword": "MUST NOT",
+      "statement": "- an indeterminate release invalidates the guest ID and requires recovery. The device **MUST NOT**",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/src/object_table.rs",
+          "crates/virtio-accel-mock/src/lib.rs"
+        ],
+        "issues": [
+          "#20",
+          "#21"
+        ],
+        "rationale": "Handle and generational-ID invariants are tested; end-to-end release recovery remains tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-80762635C08B",
+      "source": "docs/specification.md",
+      "line": 327,
+      "section": "7. Ownership and destruction",
+      "keyword": "MUST NOT",
+      "statement": "`Drop` may provide defensive cleanup inside an implementation but **MUST NOT** be used as",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/src/object_table.rs",
+          "crates/virtio-accel-mock/src/lib.rs"
+        ],
+        "issues": [
+          "#20",
+          "#21"
+        ],
+        "rationale": "Handle and generational-ID invariants are tested; end-to-end release recovery remains tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-133784109D00",
+      "source": "docs/specification.md",
+      "line": 333,
+      "section": "8. Time and progress",
+      "keyword": "MUST NOT",
+      "statement": "infinite. Absolute guest timestamps **MUST NOT** be compared with a host clock because their",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "crates/virtio-accel-core/src/lib.rs"
+        ],
+        "issues": [
+          "#20",
+          "#21"
+        ],
+        "rationale": "Relative timeout semantics are tested; bounded polling and admission behavior require the command engine."
+      }
+    },
+    {
+      "id": "REQ-SPEC-1631781F77C9",
+      "source": "docs/specification.md",
+      "line": 336,
+      "section": "8. Time and progress",
+      "keyword": "MUST",
+      "statement": "Polling an event **MUST** be nonblocking and bounded. The portable contract creates no background",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "crates/virtio-accel-core/src/lib.rs"
+        ],
+        "issues": [
+          "#20",
+          "#21"
+        ],
+        "rationale": "Relative timeout semantics are tested; bounded polling and admission behavior require the command engine."
+      }
+    },
+    {
+      "id": "REQ-SPEC-8CD9DDF8269D",
+      "source": "docs/specification.md",
+      "line": 340,
+      "section": "8. Time and progress",
+      "keyword": "MUST",
+      "statement": "cannot prove rejection is indeterminate and **MUST** retain an event.",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "crates/virtio-accel-core/src/lib.rs"
+        ],
+        "issues": [
+          "#20",
+          "#21"
+        ],
+        "rationale": "Relative timeout semantics are tested; bounded polling and admission behavior require the command engine."
+      }
+    },
+    {
+      "id": "REQ-SPEC-8857EBAFBF73",
+      "source": "docs/specification.md",
+      "line": 349,
+      "section": "9. Errors",
+      "keyword": "MUST",
+      "statement": "A device **MUST** map errors deterministically and **MUST NOT** expose uninitialized response bytes.",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "crates/virtio-accel-core/src/lib.rs"
+        ],
+        "issues": [
+          "#20",
+          "#21"
+        ],
+        "rationale": "Wire error shapes and ownership-aware failures are executable; backend-to-device recovery is tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-584B530155E9",
+      "source": "docs/specification.md",
+      "line": 349,
+      "section": "9. Errors",
+      "keyword": "MUST NOT",
+      "statement": "A device **MUST** map errors deterministically and **MUST NOT** expose uninitialized response bytes.",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "crates/virtio-accel-core/src/lib.rs"
+        ],
+        "issues": [
+          "#20",
+          "#21"
+        ],
+        "rationale": "Wire error shapes and ownership-aware failures are executable; backend-to-device recovery is tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-8DCDDFCFBAD6",
+      "source": "docs/specification.md",
+      "line": 353,
+      "section": "9. Errors",
+      "keyword": "MUST NOT",
+      "statement": "An error response **MUST NOT** imply that a backend operation was rejected when acceptance was",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "crates/virtio-accel-core/src/lib.rs"
+        ],
+        "issues": [
+          "#20",
+          "#21"
+        ],
+        "rationale": "Wire error shapes and ownership-aware failures are executable; backend-to-device recovery is tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-400D30242C2D",
+      "source": "docs/specification.md",
+      "line": 358,
+      "section": "10. Portability requirements",
+      "keyword": "MUST NOT",
+      "statement": "Portable crates **MUST NOT** select an operating system, VMM, kernel, vendor API, or global runtime.",
+      "coverage": {
+        "status": "executable",
+        "evidence": [
+          ".github/workflows/ci.yml",
+          "ci/check-portable-dependencies.sh",
+          "docs/portability.md"
+        ],
+        "issues": [],
+        "rationale": "The target matrix and dependency guards directly enforce the portable-layer restrictions."
+      }
+    },
+    {
+      "id": "REQ-SPEC-A74AA2573F34",
+      "source": "docs/specification.md",
+      "line": 365,
+      "section": "10. Portability requirements",
+      "keyword": "MUST NOT",
+      "statement": "Platform adapters depend inward on the portable layers. A portable layer **MUST NOT** conditionally",
+      "coverage": {
+        "status": "executable",
+        "evidence": [
+          ".github/workflows/ci.yml",
+          "ci/check-portable-dependencies.sh",
+          "docs/portability.md"
+        ],
+        "issues": [],
+        "rationale": "The target matrix and dependency guards directly enforce the portable-layer restrictions."
+      }
+    },
+    {
+      "id": "REQ-SPEC-7224582FFB9A",
+      "source": "docs/specification.md",
+      "line": 381,
+      "section": "11. Tracked completion work",
+      "keyword": "MAY",
+      "statement": "No implementation **MAY** advertise a reserved optional feature merely because a Rust constant",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "ci/check-normative-requirements.py"
+        ],
+        "issues": [
+          "#21",
+          "#25",
+          "#32",
+          "#33"
+        ],
+        "rationale": "The ledger prevents silent requirements; the section's named completion work remains explicitly tracked."
+      }
+    },
+    {
+      "id": "REQ-WIRE-D28F1DD12601",
+      "source": "docs/wire-abi.md",
+      "line": 16,
+      "section": "1. Global limits",
+      "keyword": "MUST",
+      "statement": "| Protocol version | 1.0 | Configuration **MUST** report major 1 and minor 0 |",
+      "coverage": {
+        "status": "executable",
+        "evidence": [
+          "conformance/rust-clean-room/src/lib.rs",
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "crates/virtio-accel-proto/src/lib.rs"
+        ],
+        "issues": [],
+        "rationale": "Both codecs use checked arithmetic and independently enforce the global limits."
+      }
+    },
+    {
+      "id": "REQ-WIRE-7F150D936FA6",
+      "source": "docs/wire-abi.md",
+      "line": 18,
+      "section": "1. Global limits",
+      "keyword": "MUST",
+      "statement": "| Hard maximum chain descriptors | 256 | The advertised maximum **MUST** be 2 through 256 |",
+      "coverage": {
+        "status": "executable",
+        "evidence": [
+          "conformance/rust-clean-room/src/lib.rs",
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "crates/virtio-accel-proto/src/lib.rs"
+        ],
+        "issues": [],
+        "rationale": "Both codecs use checked arithmetic and independently enforce the global limits."
+      }
+    },
+    {
+      "id": "REQ-WIRE-9BCBB909EAB3",
+      "source": "docs/wire-abi.md",
+      "line": 23,
+      "section": "1. Global limits",
+      "keyword": "MUST NOT",
+      "statement": "The device-specific configuration limits are additional negotiated bounds. A device **MUST NOT**",
+      "coverage": {
+        "status": "executable",
+        "evidence": [
+          "conformance/rust-clean-room/src/lib.rs",
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "crates/virtio-accel-proto/src/lib.rs"
+        ],
+        "issues": [],
+        "rationale": "Both codecs use checked arithmetic and independently enforce the global limits."
+      }
+    },
+    {
+      "id": "REQ-WIRE-6172D6E589BA",
+      "source": "docs/wire-abi.md",
+      "line": 24,
+      "section": "1. Global limits",
+      "keyword": "MUST",
+      "statement": "advertise a limit above a hard maximum. A driver **MUST** reject invalid configuration rather than",
+      "coverage": {
+        "status": "executable",
+        "evidence": [
+          "conformance/rust-clean-room/src/lib.rs",
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "crates/virtio-accel-proto/src/lib.rs"
+        ],
+        "issues": [],
+        "rationale": "Both codecs use checked arithmetic and independently enforce the global limits."
+      }
+    },
+    {
+      "id": "REQ-WIRE-2103DF7325B8",
+      "source": "docs/wire-abi.md",
+      "line": 27,
+      "section": "1. Global limits",
+      "keyword": "MUST",
+      "statement": "Every count-to-byte conversion **MUST** use checked multiplication and addition. A value that",
+      "coverage": {
+        "status": "executable",
+        "evidence": [
+          "conformance/rust-clean-room/src/lib.rs",
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "crates/virtio-accel-proto/src/lib.rs"
+        ],
+        "issues": [],
+        "rationale": "Both codecs use checked arithmetic and independently enforce the global limits."
+      }
+    },
+    {
+      "id": "REQ-WIRE-E27D6E646B54",
+      "source": "docs/wire-abi.md",
+      "line": 36,
+      "section": "2. Device-specific configuration",
+      "keyword": "MUST",
+      "statement": "| 0 | 2 | `protocol_major` | **MUST** be 1 |",
+      "coverage": {
+        "status": "executable",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "crates/virtio-accel-proto/src/lib.rs"
+        ],
+        "issues": [],
+        "rationale": "Configuration limits, version compatibility, queue-size bounds, and features are tested."
+      }
+    },
+    {
+      "id": "REQ-WIRE-ACFBE7BF15C7",
+      "source": "docs/wire-abi.md",
+      "line": 37,
+      "section": "2. Device-specific configuration",
+      "keyword": "MUST",
+      "statement": "| 2 | 2 | `protocol_minor` | A conforming 1.0 device reports 0; a 1.0 driver **MUST** accept a higher minor and use only 1.0 behavior |",
+      "coverage": {
+        "status": "executable",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "crates/virtio-accel-proto/src/lib.rs"
+        ],
+        "issues": [],
+        "rationale": "Configuration limits, version compatibility, queue-size bounds, and features are tested."
+      }
+    },
+    {
+      "id": "REQ-WIRE-B67C957A8B76",
+      "source": "docs/wire-abi.md",
+      "line": 38,
+      "section": "2. Device-specific configuration",
+      "keyword": "MUST",
+      "statement": "| 4 | 2 | `command_queue_count` | **MUST** be 1 |",
+      "coverage": {
+        "status": "executable",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "crates/virtio-accel-proto/src/lib.rs"
+        ],
+        "issues": [],
+        "rationale": "Configuration limits, version compatibility, queue-size bounds, and features are tested."
+      }
+    },
+    {
+      "id": "REQ-WIRE-BE19FEC37A2E",
+      "source": "docs/wire-abi.md",
+      "line": 39,
+      "section": "2. Device-specific configuration",
+      "keyword": "MUST",
+      "statement": "| 6 | 2 | `max_chain_descriptors` | **MUST** be 2 through 256 and no greater than the configured queue size |",
+      "coverage": {
+        "status": "executable",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "crates/virtio-accel-proto/src/lib.rs"
+        ],
+        "issues": [],
+        "rationale": "Configuration limits, version compatibility, queue-size bounds, and features are tested."
+      }
+    },
+    {
+      "id": "REQ-WIRE-E7FF7EE101AA",
+      "source": "docs/wire-abi.md",
+      "line": 40,
+      "section": "2. Device-specific configuration",
+      "keyword": "MUST",
+      "statement": "| 8 | 4 | `max_request_bytes` | **MUST** be 97 through 16 MiB |",
+      "coverage": {
+        "status": "executable",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "crates/virtio-accel-proto/src/lib.rs"
+        ],
+        "issues": [],
+        "rationale": "Configuration limits, version compatibility, queue-size bounds, and features are tested."
+      }
+    },
+    {
+      "id": "REQ-WIRE-C2E3C296F81C",
+      "source": "docs/wire-abi.md",
+      "line": 41,
+      "section": "2. Device-specific configuration",
+      "keyword": "MUST",
+      "statement": "| 12 | 4 | `max_response_bytes` | **MUST** be 92 through 16 MiB |",
+      "coverage": {
+        "status": "executable",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "crates/virtio-accel-proto/src/lib.rs"
+        ],
+        "issues": [],
+        "rationale": "Configuration limits, version compatibility, queue-size bounds, and features are tested."
+      }
+    },
+    {
+      "id": "REQ-WIRE-E179A5BB6E5F",
+      "source": "docs/wire-abi.md",
+      "line": 53,
+      "section": "2. Device-specific configuration",
+      "keyword": "MUST NOT",
+      "statement": "protocol 1.0 device **MUST NOT** advertise them and a protocol 1.0 driver **MUST NOT** accept them.",
+      "coverage": {
+        "status": "executable",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "crates/virtio-accel-proto/src/lib.rs"
+        ],
+        "issues": [],
+        "rationale": "Configuration limits, version compatibility, queue-size bounds, and features are tested."
+      }
+    },
+    {
+      "id": "REQ-WIRE-2FDCA642A64A",
+      "source": "docs/wire-abi.md",
+      "line": 53,
+      "section": "2. Device-specific configuration",
+      "keyword": "MUST NOT",
+      "statement": "protocol 1.0 device **MUST NOT** advertise them and a protocol 1.0 driver **MUST NOT** accept them.",
+      "coverage": {
+        "status": "executable",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "crates/virtio-accel-proto/src/lib.rs"
+        ],
+        "issues": [],
+        "rationale": "Configuration limits, version compatibility, queue-size bounds, and features are tested."
+      }
+    },
+    {
+      "id": "REQ-WIRE-0499E704766B",
+      "source": "docs/wire-abi.md",
+      "line": 64,
+      "section": "3. Request and response frames",
+      "keyword": "MUST",
+      "statement": "| 2 | 2 | `flags` | **MUST** be zero |",
+      "coverage": {
+        "status": "executable",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "crates/virtio-accel-proto/src/lib.rs"
+        ],
+        "issues": [],
+        "rationale": "Headers, exact lengths, flags, request correlation, and unknown numeric values are tested."
+      }
+    },
+    {
+      "id": "REQ-WIRE-AACFD362DD18",
+      "source": "docs/wire-abi.md",
+      "line": 70,
+      "section": "3. Request and response frames",
+      "keyword": "MUST",
+      "statement": "The readable byte count **MUST** equal `16 + payload_bytes` exactly. There is no tolerated trailing",
+      "coverage": {
+        "status": "executable",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "crates/virtio-accel-proto/src/lib.rs"
+        ],
+        "issues": [],
+        "rationale": "Headers, exact lengths, flags, request correlation, and unknown numeric values are tested."
+      }
+    },
+    {
+      "id": "REQ-WIRE-FCAAF2171A9D",
+      "source": "docs/wire-abi.md",
+      "line": 72,
+      "section": "3. Request and response frames",
+      "keyword": "MUST NOT",
+      "statement": "**MUST NOT** be materialized as an invalid language enum.",
+      "coverage": {
+        "status": "executable",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "crates/virtio-accel-proto/src/lib.rs"
+        ],
+        "issues": [],
+        "rationale": "Headers, exact lengths, flags, request correlation, and unknown numeric values are tested."
+      }
+    },
+    {
+      "id": "REQ-WIRE-CB4234680368",
+      "source": "docs/wire-abi.md",
+      "line": 85,
+      "section": "3. Request and response frames",
+      "keyword": "MUST",
+      "statement": "| 2 | 2 | `flags` | **MUST** be zero |",
+      "coverage": {
+        "status": "executable",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "crates/virtio-accel-proto/src/lib.rs"
+        ],
+        "issues": [],
+        "rationale": "Headers, exact lengths, flags, request correlation, and unknown numeric values are tested."
+      }
+    },
+    {
+      "id": "REQ-WIRE-5BDC8FF44C6C",
+      "source": "docs/wire-abi.md",
+      "line": 89,
+      "section": "3. Request and response frames",
+      "keyword": "MUST",
+      "statement": "The driver **MUST** validate that the response request ID matches the request associated with the",
+      "coverage": {
+        "status": "executable",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "crates/virtio-accel-proto/src/lib.rs"
+        ],
+        "issues": [],
+        "rationale": "Headers, exact lengths, flags, request correlation, and unknown numeric values are tested."
+      }
+    },
+    {
+      "id": "REQ-WIRE-DC6D05EE9FD6",
+      "source": "docs/wire-abi.md",
+      "line": 124,
+      "section": "4. Common value namespaces",
+      "keyword": "MUST",
+      "statement": "At least one usage bit **MUST** be set. Unknown bits produce `UNSUPPORTED`.",
+      "coverage": {
+        "status": "executable",
+        "evidence": [
+          "conformance/rust-clean-room/src/lib.rs",
+          "conformance/rust-clean-room/tests/vectors.rs"
+        ],
+        "issues": [],
+        "rationale": "The independent semantic codec validates object IDs, domains, usage, access, and event states."
+      }
+    },
+    {
+      "id": "REQ-WIRE-521DFC5AAE65",
+      "source": "docs/wire-abi.md",
+      "line": 145,
+      "section": "4. Common value namespaces",
+      "keyword": "MUST",
+      "statement": "Unknown event states make the response invalid to a 1.0 driver. A driver **MUST** retain the event",
+      "coverage": {
+        "status": "executable",
+        "evidence": [
+          "conformance/rust-clean-room/src/lib.rs",
+          "conformance/rust-clean-room/tests/vectors.rs"
+        ],
+        "issues": [],
+        "rationale": "The independent semantic codec validates object IDs, domains, usage, access, and event states."
+      }
+    },
+    {
+      "id": "REQ-WIRE-64102815576B",
+      "source": "docs/wire-abi.md",
+      "line": 195,
+      "section": "5. Opcodes and payloads",
+      "keyword": "MUST NOT",
+      "statement": "Capability bits are semantic reports, not Virtio feature bits. A capability **MUST NOT** alter wire",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "crates/virtio-accel-proto/tests/semantic_interop.rs"
+        ],
+        "issues": [
+          "#20",
+          "#25"
+        ],
+        "rationale": "Every payload layout and scalar invariant is cross-decoded; live-object and advertised-quota checks are tracked."
+      }
+    },
+    {
+      "id": "REQ-WIRE-0824A8EE98CA",
+      "source": "docs/wire-abi.md",
+      "line": 201,
+      "section": "5. Opcodes and payloads",
+      "keyword": "MUST",
+      "statement": "`CreateContextRequest` is eight bytes: `flags: u32` followed by `reserved: u32`. Both fields **MUST**",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "crates/virtio-accel-proto/tests/semantic_interop.rs"
+        ],
+        "issues": [
+          "#20",
+          "#25"
+        ],
+        "rationale": "Every payload layout and scalar invariant is cross-decoded; live-object and advertised-quota checks are tracked."
+      }
+    },
+    {
+      "id": "REQ-WIRE-83B1B42B6991",
+      "source": "docs/wire-abi.md",
+      "line": 220,
+      "section": "5. Opcodes and payloads",
+      "keyword": "MUST",
+      "statement": "`TransferBufferRequest` is 24 bytes containing `buffer_id`, `offset`, and `bytes`. `bytes` **MUST**",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "crates/virtio-accel-proto/tests/semantic_interop.rs"
+        ],
+        "issues": [
+          "#20",
+          "#25"
+        ],
+        "rationale": "Every payload layout and scalar invariant is cross-decoded; live-object and advertised-quota checks are tracked."
+      }
+    },
+    {
+      "id": "REQ-WIRE-AB348136DD8D",
+      "source": "docs/wire-abi.md",
+      "line": 221,
+      "section": "5. Opcodes and payloads",
+      "keyword": "MUST NOT",
+      "statement": "be nonzero. `offset + bytes` **MUST NOT** overflow and **MUST** fit in the buffer.",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "crates/virtio-accel-proto/tests/semantic_interop.rs"
+        ],
+        "issues": [
+          "#20",
+          "#25"
+        ],
+        "rationale": "Every payload layout and scalar invariant is cross-decoded; live-object and advertised-quota checks are tracked."
+      }
+    },
+    {
+      "id": "REQ-WIRE-49564F60EF8C",
+      "source": "docs/wire-abi.md",
+      "line": 221,
+      "section": "5. Opcodes and payloads",
+      "keyword": "MUST",
+      "statement": "be nonzero. `offset + bytes` **MUST NOT** overflow and **MUST** fit in the buffer.",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "crates/virtio-accel-proto/tests/semantic_interop.rs"
+        ],
+        "issues": [
+          "#20",
+          "#25"
+        ],
+        "rationale": "Every payload layout and scalar invariant is cross-decoded; live-object and advertised-quota checks are tracked."
+      }
+    },
+    {
+      "id": "REQ-WIRE-AC75C61B84D8",
+      "source": "docs/wire-abi.md",
+      "line": 223,
+      "section": "5. Opcodes and payloads",
+      "keyword": "MUST",
+      "statement": "For `WRITE_BUFFER`, the request payload length **MUST** be `24 + bytes`, and bytes following the",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "crates/virtio-accel-proto/tests/semantic_interop.rs"
+        ],
+        "issues": [
+          "#20",
+          "#25"
+        ],
+        "rationale": "Every payload layout and scalar invariant is cross-decoded; live-object and advertised-quota checks are tracked."
+      }
+    },
+    {
+      "id": "REQ-WIRE-A70C3D08E0BB",
+      "source": "docs/wire-abi.md",
+      "line": 241,
+      "section": "5. Opcodes and payloads",
+      "keyword": "MUST",
+      "statement": "`80 + payload_bytes` **MUST** fit the request payload and configured frame limit.",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "crates/virtio-accel-proto/tests/semantic_interop.rs"
+        ],
+        "issues": [
+          "#20",
+          "#25"
+        ],
+        "rationale": "Every payload layout and scalar invariant is cross-decoded; live-object and advertised-quota checks are tracked."
+      }
+    },
+    {
+      "id": "REQ-WIRE-43560D158BB8",
+      "source": "docs/wire-abi.md",
+      "line": 246,
+      "section": "5. Opcodes and payloads",
+      "keyword": "MUST",
+      "statement": "reserved words **MUST** be zero in protocol 1.0.",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "crates/virtio-accel-proto/tests/semantic_interop.rs"
+        ],
+        "issues": [
+          "#20",
+          "#25"
+        ],
+        "rationale": "Every payload layout and scalar invariant is cross-decoded; live-object and advertised-quota checks are tracked."
+      }
+    },
+    {
+      "id": "REQ-WIRE-5E3A3B34D5A7",
+      "source": "docs/wire-abi.md",
+      "line": 253,
+      "section": "5. Opcodes and payloads",
+      "keyword": "MUST",
+      "statement": "- `binding_count` **MUST** be 1 through both advertised `max_bindings_per_submission` and 4096.",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "crates/virtio-accel-proto/tests/semantic_interop.rs"
+        ],
+        "issues": [
+          "#20",
+          "#25"
+        ],
+        "rationale": "Every payload layout and scalar invariant is cross-decoded; live-object and advertised-quota checks are tracked."
+      }
+    },
+    {
+      "id": "REQ-WIRE-3DB7CD56ECB9",
+      "source": "docs/wire-abi.md",
+      "line": 254,
+      "section": "5. Opcodes and payloads",
+      "keyword": "MUST",
+      "statement": "- `flags` **MUST** be zero.",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "crates/virtio-accel-proto/tests/semantic_interop.rs"
+        ],
+        "issues": [
+          "#20",
+          "#25"
+        ],
+        "rationale": "Every payload layout and scalar invariant is cross-decoded; live-object and advertised-quota checks are tracked."
+      }
+    },
+    {
+      "id": "REQ-WIRE-372ACF609966",
+      "source": "docs/wire-abi.md",
+      "line": 256,
+      "section": "5. Opcodes and payloads",
+      "keyword": "MUST",
+      "statement": "- The payload length **MUST** be `32 + binding_count * 32`.",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "crates/virtio-accel-proto/tests/semantic_interop.rs"
+        ],
+        "issues": [
+          "#20",
+          "#25"
+        ],
+        "rationale": "Every payload layout and scalar invariant is cross-decoded; live-object and advertised-quota checks are tracked."
+      }
+    },
+    {
+      "id": "REQ-WIRE-2A6C55913B50",
+      "source": "docs/wire-abi.md",
+      "line": 301,
+      "section": "7. Response atomicity",
+      "keyword": "MUST",
+      "statement": "Before backend invocation, the device **MUST** validate the complete readable frame and enough",
+      "coverage": {
+        "status": "tracked",
+        "evidence": [
+          "conformance/v1.0/vectors.json"
+        ],
+        "issues": [
+          "#18",
+          "#20"
+        ],
+        "rationale": "Error shapes are fixed, while writable preflight and post-mutation response atomicity require queue execution."
+      }
+    },
+    {
+      "id": "REQ-WIRE-9A07069A80BA",
+      "source": "docs/wire-abi.md",
+      "line": 302,
+      "section": "7. Response atomicity",
+      "keyword": "MUST",
+      "statement": "writable capacity for every possible response shape of that command. It **MUST** initialize every",
+      "coverage": {
+        "status": "tracked",
+        "evidence": [
+          "conformance/v1.0/vectors.json"
+        ],
+        "issues": [
+          "#18",
+          "#20"
+        ],
+        "rationale": "Error shapes are fixed, while writable preflight and post-mutation response atomicity require queue execution."
+      }
+    },
+    {
+      "id": "REQ-WIRE-F97FF8EB6E93",
+      "source": "docs/wire-abi.md",
+      "line": 306,
+      "section": "7. Response atomicity",
+      "keyword": "MUST",
+      "statement": "occurs after semantic mutation, or a release becomes indeterminate, the device **MUST** enter",
+      "coverage": {
+        "status": "tracked",
+        "evidence": [
+          "conformance/v1.0/vectors.json"
+        ],
+        "issues": [
+          "#18",
+          "#20"
+        ],
+        "rationale": "Error shapes are fixed, while writable preflight and post-mutation response atomicity require queue execution."
+      }
+    },
+    {
+      "id": "REQ-WIRE-236296B59AB4",
+      "source": "docs/wire-abi.md",
+      "line": 307,
+      "section": "7. Response atomicity",
+      "keyword": "MUST NOT",
+      "statement": "recovery and expose the Virtio `DEVICE_NEEDS_RESET` condition. It **MUST NOT** report an ordinary",
+      "coverage": {
+        "status": "tracked",
+        "evidence": [
+          "conformance/v1.0/vectors.json"
+        ],
+        "issues": [
+          "#18",
+          "#20"
+        ],
+        "rationale": "Error shapes are fixed, while writable preflight and post-mutation response atomicity require queue execution."
+      }
+    },
+    {
+      "id": "REQ-WIRE-CEF7A35F46A4",
+      "source": "docs/wire-abi.md",
+      "line": 321,
+      "section": "9. Candidate and post-freeze change procedure",
+      "keyword": "MUST",
+      "statement": "A proposed wire change **MUST** be classified before code is merged:",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "ci/check-normative-requirements.py"
+        ],
+        "issues": [
+          "#32",
+          "#33"
+        ],
+        "rationale": "Coordinated documentation and evidence are machine-checked; final release policy and freeze remain tracked."
+      }
+    },
+    {
+      "id": "REQ-WIRE-A595D1D65047",
+      "source": "docs/wire-abi.md",
+      "line": 334,
+      "section": "9. Candidate and post-freeze change procedure",
+      "keyword": "MUST",
+      "statement": "The same reviewed change **MUST** update the normative documents, Rust constants/layout assertions,",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "ci/check-normative-requirements.py"
+        ],
+        "issues": [
+          "#32",
+          "#33"
+        ],
+        "rationale": "Coordinated documentation and evidence are machine-checked; final release policy and freeze remain tracked."
+      }
+    },
+    {
+      "id": "REQ-VIRTQ-CF0F844D11C2",
+      "source": "docs/virtqueue.md",
+      "line": 19,
+      "section": "1. Relationship to the base Virtio specification",
+      "keyword": "MUST NOT",
+      "statement": "The reference device **MUST NOT** offer `VIRTIO_F_RING_PACKED`, `VIRTIO_F_IN_ORDER`,",
+      "coverage": {
+        "status": "tracked",
+        "evidence": [
+          "docs/virtqueue.md"
+        ],
+        "issues": [
+          "#17",
+          "#18"
+        ],
+        "rationale": "The negotiated reference profile is specified; transport feature enforcement requires the queue adapter."
+      }
+    },
+    {
+      "id": "REQ-VIRTQ-2ACFE4AF0F90",
+      "source": "docs/virtqueue.md",
+      "line": 38,
+      "section": "2. Flattened chain model",
+      "keyword": "MUST NOT",
+      "statement": "The command engine sees region lengths and byte access only. It **MUST NOT** receive guest physical",
+      "coverage": {
+        "status": "tracked",
+        "evidence": [
+          "docs/virtqueue.md"
+        ],
+        "issues": [
+          "#17",
+          "#18"
+        ],
+        "rationale": "The flattened region contract is specified and assigned to the region-port and split-ring implementations."
+      }
+    },
+    {
+      "id": "REQ-VIRTQ-DFB4CD008376",
+      "source": "docs/virtqueue.md",
+      "line": 58,
+      "section": "3. Descriptor-chain validity",
+      "keyword": "MUST",
+      "statement": "The transport adapter **MUST** validate the descriptor topology and map every readable and required",
+      "coverage": {
+        "status": "tracked",
+        "evidence": [
+          "docs/virtqueue.md"
+        ],
+        "issues": [
+          "#17",
+          "#18"
+        ],
+        "rationale": "Topology and mapping rules have stable VQ cases but require executable descriptor-chain ports."
+      }
+    },
+    {
+      "id": "REQ-VIRTQ-6F4055ACBD6C",
+      "source": "docs/virtqueue.md",
+      "line": 64,
+      "section": "4. One command per chain",
+      "keyword": "MUST",
+      "statement": "is request-header byte zero. The readable total **MUST** equal:",
+      "coverage": {
+        "status": "tracked",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs"
+        ],
+        "issues": [
+          "#17",
+          "#18"
+        ],
+        "rationale": "Frame exactness is executable; cross-region presentation requires the region adapter and split-ring model."
+      }
+    },
+    {
+      "id": "REQ-VIRTQ-E5DBDD7EA5F3",
+      "source": "docs/virtqueue.md",
+      "line": 105,
+      "section": "6. Response writing and used length",
+      "keyword": "MUST",
+      "statement": "The device **MUST** commit a response atomically from the protocol\u2019s point of view:",
+      "coverage": {
+        "status": "tracked",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs"
+        ],
+        "issues": [
+          "#18",
+          "#20"
+        ],
+        "rationale": "Response bytes and lengths are defined; scatter writes and post-mutation failure require queue execution."
+      }
+    },
+    {
+      "id": "REQ-VIRTQ-75F7566C2586",
+      "source": "docs/virtqueue.md",
+      "line": 114,
+      "section": "6. Response writing and used length",
+      "keyword": "MUST",
+      "statement": "Response bytes may span writable descriptors. A device **MUST** write them as if to one concatenated",
+      "coverage": {
+        "status": "tracked",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs"
+        ],
+        "issues": [
+          "#18",
+          "#20"
+        ],
+        "rationale": "Response bytes and lengths are defined; scatter writes and post-mutation failure require queue execution."
+      }
+    },
+    {
+      "id": "REQ-VIRTQ-3242A628583E",
+      "source": "docs/virtqueue.md",
+      "line": 119,
+      "section": "6. Response writing and used length",
+      "keyword": "MUST",
+      "statement": "If mutation or uncertain backend acceptance has occurred, the device **MUST** set",
+      "coverage": {
+        "status": "tracked",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs"
+        ],
+        "issues": [
+          "#18",
+          "#20"
+        ],
+        "rationale": "Response bytes and lengths are defined; scatter writes and post-mutation failure require queue execution."
+      }
+    },
+    {
+      "id": "REQ-VIRTQ-96D5B87E486E",
+      "source": "docs/virtqueue.md",
+      "line": 125,
+      "section": "7. Command and execution ordering",
+      "keyword": "MUST",
+      "statement": "The baseline command queue permits out-of-order command completion. The device **MUST** consume",
+      "coverage": {
+        "status": "tracked",
+        "evidence": [
+          "docs/virtqueue.md"
+        ],
+        "issues": [
+          "#18",
+          "#20"
+        ],
+        "rationale": "Stable VQ ordering cases exist; concurrent publication and completion behavior awaits the queue model."
+      }
+    },
+    {
+      "id": "REQ-VIRTQ-B86FF22390A9",
+      "source": "docs/virtqueue.md",
+      "line": 130,
+      "section": "7. Command and execution ordering",
+      "keyword": "MUST NOT",
+      "statement": "Request-ID uniqueness lasts until the corresponding chain is returned used. A driver **MUST NOT**",
+      "coverage": {
+        "status": "tracked",
+        "evidence": [
+          "docs/virtqueue.md"
+        ],
+        "issues": [
+          "#18",
+          "#20"
+        ],
+        "rationale": "Stable VQ ordering cases exist; concurrent publication and completion behavior awaits the queue model."
+      }
+    },
+    {
+      "id": "REQ-VIRTQ-C12E4EB85F3B",
+      "source": "docs/virtqueue.md",
+      "line": 139,
+      "section": "7. Command and execution ordering",
+      "keyword": "MUST NOT",
+      "statement": "Implementations may serialize command execution, but they **MUST NOT** promise in-order completion",
+      "coverage": {
+        "status": "tracked",
+        "evidence": [
+          "docs/virtqueue.md"
+        ],
+        "issues": [
+          "#18",
+          "#20"
+        ],
+        "rationale": "Stable VQ ordering cases exist; concurrent publication and completion behavior awaits the queue model."
+      }
+    },
+    {
+      "id": "REQ-VIRTQ-1D8B758040B1",
+      "source": "docs/virtqueue.md",
+      "line": 146,
+      "section": "8. Backpressure and queue fullness",
+      "keyword": "MUST",
+      "statement": "- A driver with no free descriptor head or insufficient writable buffers **MUST** retain the command",
+      "coverage": {
+        "status": "tracked",
+        "evidence": [
+          "docs/virtqueue.md"
+        ],
+        "issues": [
+          "#19",
+          "#20"
+        ],
+        "rationale": "Backpressure semantics are specified and assigned to the guest and full-path implementations."
+      }
+    },
+    {
+      "id": "REQ-VIRTQ-463482FDAC92",
+      "source": "docs/virtqueue.md",
+      "line": 148,
+      "section": "8. Backpressure and queue fullness",
+      "keyword": "MUST NOT",
+      "statement": "- It **MUST NOT** publish a partial command or reuse descriptors still owned by the device.",
+      "coverage": {
+        "status": "tracked",
+        "evidence": [
+          "docs/virtqueue.md"
+        ],
+        "issues": [
+          "#19",
+          "#20"
+        ],
+        "rationale": "Backpressure semantics are specified and assigned to the guest and full-path implementations."
+      }
+    },
+    {
+      "id": "REQ-VIRTQ-5AAD22870CBA",
+      "source": "docs/virtqueue.md",
+      "line": 183,
+      "section": "10. Malformed chains",
+      "keyword": "MUST NOT",
+      "statement": "limiting **MUST NOT** change object ownership or fabricate successful responses.",
+      "coverage": {
+        "status": "tracked",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs"
+        ],
+        "issues": [
+          "#18",
+          "#20"
+        ],
+        "rationale": "Malformed frame behavior is executable; malformed descriptor-chain isolation requires queue execution."
+      }
+    },
+    {
+      "id": "REQ-VIRTQ-323D67240916",
+      "source": "docs/virtqueue.md",
+      "line": 201,
+      "section": "11. Device reset and split-ring disposition",
+      "keyword": "MUST NOT",
+      "statement": "the base Virtio reset rule. It **MUST NOT** expect response bytes or used entries for those chains.",
+      "coverage": {
+        "status": "tracked",
+        "evidence": [
+          "docs/virtqueue.md"
+        ],
+        "issues": [
+          "#18",
+          "#19",
+          "#20"
+        ],
+        "rationale": "Reset cases are stable, while descriptor reclamation and late-completion exclusion require full implementations."
+      }
+    },
+    {
+      "id": "REQ-VIRTQ-FF01B37600D9",
+      "source": "docs/virtqueue.md",
+      "line": 219,
+      "section": "12. `DEVICE_NEEDS_RESET`",
+      "keyword": "SHOULD",
+      "statement": "After observing `DEVICE_NEEDS_RESET`, the driver **SHOULD** stop submitting commands and perform",
+      "coverage": {
+        "status": "tracked",
+        "evidence": [
+          "crates/virtio-accel-core/src/lib.rs"
+        ],
+        "issues": [
+          "#20",
+          "#25"
+        ],
+        "rationale": "Ownership-aware failure types exist; DEVICE_NEEDS_RESET transitions require the command engine and threat limits."
+      }
+    },
+    {
+      "id": "REQ-VIRTQ-718233B6C44C",
+      "source": "docs/virtqueue.md",
+      "line": 221,
+      "section": "12. `DEVICE_NEEDS_RESET`",
+      "keyword": "MUST NOT",
+      "statement": "but it **MUST NOT** accept new semantic work.",
+      "coverage": {
+        "status": "tracked",
+        "evidence": [
+          "crates/virtio-accel-core/src/lib.rs"
+        ],
+        "issues": [
+          "#20",
+          "#25"
+        ],
+        "rationale": "Ownership-aware failure types exist; DEVICE_NEEDS_RESET transitions require the command engine and threat limits."
+      }
+    }
+  ]
+}

--- a/crates/virtio-accel-proto/Cargo.toml
+++ b/crates/virtio-accel-proto/Cargo.toml
@@ -13,3 +13,4 @@ zerocopy.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true
+virtio-accel-cleanroom.workspace = true

--- a/crates/virtio-accel-proto/src/lib.rs
+++ b/crates/virtio-accel-proto/src/lib.rs
@@ -459,6 +459,7 @@ mod tests {
     use core::mem::{align_of, offset_of, size_of};
     use serde_json::Value;
     use std::collections::BTreeSet;
+    use virtio_accel_cleanroom as cleanroom;
     use zerocopy::IntoBytes;
 
     const REQUEST_ID: u64 = 0x0102_0304_0506_0708;
@@ -488,6 +489,35 @@ mod tests {
             .find(|entry| entry["name"] == name)
             .unwrap_or_else(|| panic!("missing vector {name}"));
         decode_hex(entry["hex"].as_str().unwrap())
+    }
+
+    fn cleanroom_response_context(name: &str) -> cleanroom::ResponseContext {
+        let opcode = match name {
+            "response_get_device_info" => Some(cleanroom::Opcode::GetDeviceInfo),
+            "response_create_context" => Some(cleanroom::Opcode::CreateContext),
+            "response_destroy_context" => Some(cleanroom::Opcode::DestroyContext),
+            "response_allocate_buffer" => Some(cleanroom::Opcode::AllocateBuffer),
+            "response_free_buffer" => Some(cleanroom::Opcode::FreeBuffer),
+            "response_write_buffer" => Some(cleanroom::Opcode::WriteBuffer),
+            "response_read_buffer" => Some(cleanroom::Opcode::ReadBuffer),
+            "response_load_program" => Some(cleanroom::Opcode::LoadProgram),
+            "response_unload_program" => Some(cleanroom::Opcode::UnloadProgram),
+            "response_create_queue" => Some(cleanroom::Opcode::CreateQueue),
+            "response_destroy_queue" => Some(cleanroom::Opcode::DestroyQueue),
+            "response_submit_accepted" | "response_submit_indeterminate" => {
+                Some(cleanroom::Opcode::Submit)
+            }
+            name if name.starts_with("response_poll_event_") => Some(cleanroom::Opcode::PollEvent),
+            "response_cancel_event" => Some(cleanroom::Opcode::CancelEvent),
+            "response_destroy_event" => Some(cleanroom::Opcode::DestroyEvent),
+            "response_unknown_opcode" => None,
+            other => panic!("no independent response context for {other}"),
+        };
+        cleanroom::ResponseContext {
+            opcode,
+            request_id: REQUEST_ID,
+            read_bytes: (opcode == Some(cleanroom::Opcode::ReadBuffer)).then_some(4),
+        }
     }
 
     fn assert_layout<T>(name: &str, fields: &[(&str, usize)]) {
@@ -1038,6 +1068,50 @@ mod tests {
             failed_event.as_bytes(),
             &vector("frames", "response_poll_event_failed")[16..]
         );
+    }
+
+    #[test]
+    fn independent_codec_interoperates_with_primary_wire_types() {
+        for frame in corpus()["frames"].as_array().unwrap() {
+            let name = frame["name"].as_str().unwrap();
+            let bytes = decode_hex(frame["hex"].as_str().unwrap());
+            let mut independent_bytes = std::vec![0_u8; bytes.len()];
+
+            match frame["kind"].as_str().unwrap() {
+                "config" => {
+                    let primary = read_exact::<WireConfig>(&bytes).unwrap();
+                    let independent = cleanroom::decode_config(&bytes, 256).unwrap();
+                    assert_eq!(primary.protocol_major.get(), independent.protocol_major);
+                    assert_eq!(primary.protocol_minor.get(), independent.protocol_minor);
+                    assert_eq!(
+                        primary.max_chain_descriptors.get(),
+                        independent.max_chain_descriptors
+                    );
+                    independent.encode(256, &mut independent_bytes).unwrap();
+                }
+                "request" => {
+                    let primary =
+                        read_exact::<RequestHeader>(&bytes[..size_of::<RequestHeader>()]).unwrap();
+                    let independent = cleanroom::decode_request(&bytes).unwrap();
+                    assert_eq!(primary.opcode.get(), independent.body.opcode() as u16);
+                    assert_eq!(primary.request_id.get(), independent.request_id);
+                    independent.encode(&mut independent_bytes).unwrap();
+                }
+                "response" => {
+                    let primary =
+                        read_exact::<ResponseHeader>(&bytes[..size_of::<ResponseHeader>()])
+                            .unwrap();
+                    let context = cleanroom_response_context(name);
+                    let independent = cleanroom::decode_response(&bytes, context).unwrap();
+                    assert_eq!(primary.status.get(), independent.status);
+                    assert_eq!(primary.request_id.get(), independent.request_id);
+                    independent.encode(context, &mut independent_bytes).unwrap();
+                }
+                other => panic!("unknown frame kind {other}"),
+            }
+
+            assert_eq!(independent_bytes, bytes, "{name}");
+        }
     }
 
     #[test]

--- a/crates/virtio-accel-proto/tests/semantic_interop.rs
+++ b/crates/virtio-accel-proto/tests/semantic_interop.rs
@@ -1,0 +1,659 @@
+use virtio_accel_cleanroom as clean;
+use virtio_accel_proto::{
+    AllocateBufferRequest, CreateContextRequest, CreateQueueRequest, KnownEventState, KnownOpcode,
+    Le16, Le32, Le64, LoadProgramRequest, ObjectPayload, RequestFlags, RequestHeader,
+    ResponseHeader, StatusCode, SubmitRequest, SubmitResponse, TransferBufferRequest, WireBinding,
+    WireConfig, WireDeviceInfo, WireEventState, read_exact,
+};
+use zerocopy::IntoBytes;
+
+const REQUEST_ID: u64 = 0x1020_3040_5060_7080;
+const CONTEXT_ID: u64 = 0x1112_1314_1516_1718;
+const BUFFER_ID: u64 = 0x2122_2324_2526_2728;
+const PROGRAM_ID: u64 = 0x3132_3334_3536_3738;
+const QUEUE_ID: u64 = 0x4142_4344_4546_4748;
+const EVENT_ID: u64 = 0x5152_5354_5556_5758;
+
+fn primary_request(opcode: KnownOpcode, payload: &[u8]) -> Vec<u8> {
+    let header = RequestHeader::new(
+        opcode,
+        RequestFlags::empty(),
+        u32::try_from(payload.len()).unwrap(),
+        REQUEST_ID,
+    );
+    let mut bytes = Vec::from(header.as_bytes());
+    bytes.extend_from_slice(payload);
+    bytes
+}
+
+fn primary_response(status: StatusCode, payload: &[u8]) -> Vec<u8> {
+    let header = ResponseHeader::new(status, u32::try_from(payload.len()).unwrap(), REQUEST_ID);
+    let mut bytes = Vec::from(header.as_bytes());
+    bytes.extend_from_slice(payload);
+    bytes
+}
+
+fn clean_request(body: clean::RequestBody<'_>) -> Vec<u8> {
+    let request = clean::Request {
+        request_id: REQUEST_ID,
+        body,
+    };
+    let mut bytes = vec![0_u8; request.encoded_len().unwrap()];
+    let written = request.encode(&mut bytes).unwrap();
+    assert_eq!(written, bytes.len());
+    bytes
+}
+
+fn clean_response(
+    status: u16,
+    body: clean::ResponseBody<'_>,
+    context: clean::ResponseContext,
+) -> Vec<u8> {
+    let response = clean::Response {
+        status,
+        request_id: REQUEST_ID,
+        body,
+    };
+    let mut bytes = vec![0_u8; response.encoded_len(context).unwrap()];
+    let written = response.encode(context, &mut bytes).unwrap();
+    assert_eq!(written, bytes.len());
+    bytes
+}
+
+fn response_context(opcode: clean::Opcode, read_bytes: Option<usize>) -> clean::ResponseContext {
+    clean::ResponseContext {
+        opcode: Some(opcode),
+        request_id: REQUEST_ID,
+        read_bytes,
+    }
+}
+
+fn assert_primary_header(bytes: &[u8], opcode: KnownOpcode, payload_bytes: usize) {
+    let header = read_exact::<RequestHeader>(&bytes[..16]).unwrap();
+    assert_eq!(header.opcode.get(), opcode as u16);
+    assert_eq!(header.flags.get(), 0);
+    assert_eq!(header.payload_bytes.get() as usize, payload_bytes);
+    assert_eq!(header.request_id.get(), REQUEST_ID);
+}
+
+fn assert_primary_response_header(bytes: &[u8], status: u16, payload_bytes: usize) {
+    let header = read_exact::<ResponseHeader>(&bytes[..16]).unwrap();
+    assert_eq!(header.status.get(), status);
+    assert_eq!(header.flags.get(), 0);
+    assert_eq!(header.payload_bytes.get() as usize, payload_bytes);
+    assert_eq!(header.request_id.get(), REQUEST_ID);
+}
+
+#[test]
+fn primary_wire_types_decode_to_independent_semantics_for_every_layout() {
+    let config = WireConfig {
+        protocol_major: Le16::new(1),
+        protocol_minor: Le16::new(0),
+        command_queue_count: Le16::new(1),
+        max_chain_descriptors: Le16::new(64),
+        max_request_bytes: Le32::new(1_048_576),
+        max_response_bytes: Le32::new(2_097_152),
+    };
+    assert_eq!(
+        clean::decode_config(config.as_bytes(), 128).unwrap(),
+        clean::Config {
+            protocol_major: 1,
+            protocol_minor: 0,
+            command_queue_count: 1,
+            max_chain_descriptors: 64,
+            max_request_bytes: 1_048_576,
+            max_response_bytes: 2_097_152,
+        }
+    );
+
+    let get_info_bytes = primary_request(KnownOpcode::GetDeviceInfo, &[]);
+    let get_info = clean::decode_request(&get_info_bytes).unwrap();
+    assert_eq!(get_info.request_id, REQUEST_ID);
+    assert_eq!(get_info.body, clean::RequestBody::GetDeviceInfo);
+
+    let create_context = CreateContextRequest {
+        flags: Le32::new(0),
+        reserved: Le32::new(0),
+    };
+    assert_eq!(
+        clean::decode_request(&primary_request(
+            KnownOpcode::CreateContext,
+            create_context.as_bytes(),
+        ))
+        .unwrap()
+        .body,
+        clean::RequestBody::CreateContext
+    );
+
+    let object = ObjectPayload {
+        object_id: Le64::new(CONTEXT_ID),
+    };
+    assert_eq!(
+        clean::decode_request(&primary_request(
+            KnownOpcode::DestroyContext,
+            object.as_bytes(),
+        ))
+        .unwrap()
+        .body,
+        clean::RequestBody::DestroyContext {
+            context_id: CONTEXT_ID,
+        }
+    );
+
+    let allocate = AllocateBufferRequest {
+        context_id: Le64::new(CONTEXT_ID),
+        bytes: Le64::new(65_536),
+        alignment: Le64::new(4_096),
+        memory_domain: 2,
+        reserved0: [0; 7],
+        usage: Le32::new(0x15),
+        reserved1: Le32::new(0),
+    };
+    assert_eq!(
+        clean::decode_request(&primary_request(
+            KnownOpcode::AllocateBuffer,
+            allocate.as_bytes(),
+        ))
+        .unwrap()
+        .body,
+        clean::RequestBody::AllocateBuffer(clean::AllocateBuffer {
+            context_id: CONTEXT_ID,
+            bytes: 65_536,
+            alignment: 4_096,
+            memory_domain: 2,
+            usage: 0x15,
+        })
+    );
+
+    let transfer = TransferBufferRequest {
+        buffer_id: Le64::new(BUFFER_ID),
+        offset: Le64::new(128),
+        bytes: Le64::new(4),
+    };
+    assert_eq!(
+        clean::decode_request(&primary_request(
+            KnownOpcode::ReadBuffer,
+            transfer.as_bytes(),
+        ))
+        .unwrap()
+        .body,
+        clean::RequestBody::ReadBuffer(clean::TransferBuffer {
+            buffer_id: BUFFER_ID,
+            offset: 128,
+            bytes: 4,
+        })
+    );
+    let mut write_payload = Vec::from(transfer.as_bytes());
+    write_payload.extend_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
+    assert_eq!(
+        clean::decode_request(&primary_request(KnownOpcode::WriteBuffer, &write_payload,))
+            .unwrap()
+            .body,
+        clean::RequestBody::WriteBuffer {
+            transfer: clean::TransferBuffer {
+                buffer_id: BUFFER_ID,
+                offset: 128,
+                bytes: 4,
+            },
+            data: &[0xde, 0xad, 0xbe, 0xef],
+        }
+    );
+
+    let load = LoadProgramRequest {
+        context_id: Le64::new(CONTEXT_ID),
+        format: Le32::new(0x1122_3344),
+        flags: Le32::new(0),
+        target: core::array::from_fn(|index| Le32::new(100 + index as u32)),
+        payload_bytes: Le64::new(3),
+        resident_bytes: Le64::new(98_304),
+    };
+    let mut load_payload = Vec::from(load.as_bytes());
+    load_payload.extend_from_slice(&[0xa1, 0xb2, 0xc3]);
+    let load_bytes = primary_request(KnownOpcode::LoadProgram, &load_payload);
+    let decoded_load = clean::decode_request(&load_bytes).unwrap();
+    let clean::RequestBody::LoadProgram(decoded_load) = decoded_load.body else {
+        panic!("LOAD_PROGRAM decoded as the wrong independent request");
+    };
+    assert_eq!(decoded_load.context_id, CONTEXT_ID);
+    assert_eq!(decoded_load.format, 0x1122_3344);
+    assert_eq!(
+        decoded_load.target,
+        core::array::from_fn(|index| 100 + index as u32)
+    );
+    assert_eq!(decoded_load.resident_bytes, 98_304);
+    assert_eq!(decoded_load.artifact, &[0xa1, 0xb2, 0xc3]);
+
+    let create_queue = CreateQueueRequest {
+        context_id: Le64::new(CONTEXT_ID),
+        flags: Le32::new(0),
+        reserved: Le32::new(0),
+    };
+    assert_eq!(
+        clean::decode_request(&primary_request(
+            KnownOpcode::CreateQueue,
+            create_queue.as_bytes(),
+        ))
+        .unwrap()
+        .body,
+        clean::RequestBody::CreateQueue {
+            context_id: CONTEXT_ID,
+        }
+    );
+
+    let submit = SubmitRequest {
+        queue_id: Le64::new(QUEUE_ID),
+        program_id: Le64::new(PROGRAM_ID),
+        binding_count: Le32::new(2),
+        flags: Le32::new(0),
+        timeout_ns: Le64::new(7_500_000),
+    };
+    let bindings = [
+        WireBinding {
+            buffer_id: Le64::new(BUFFER_ID),
+            offset: Le64::new(64),
+            bytes: Le64::new(1_024),
+            slot: Le32::new(3),
+            access: 1,
+            reserved: [0; 3],
+        },
+        WireBinding {
+            buffer_id: Le64::new(BUFFER_ID + 1),
+            offset: Le64::new(128),
+            bytes: Le64::new(2_048),
+            slot: Le32::new(9),
+            access: 3,
+            reserved: [0; 3],
+        },
+    ];
+    let mut submit_payload = Vec::from(submit.as_bytes());
+    for binding in &bindings {
+        submit_payload.extend_from_slice(binding.as_bytes());
+    }
+    let submit_bytes = primary_request(KnownOpcode::Submit, &submit_payload);
+    let decoded_submit = clean::decode_request(&submit_bytes).unwrap();
+    let clean::RequestBody::Submit(decoded_submit) = decoded_submit.body else {
+        panic!("SUBMIT decoded as the wrong independent request");
+    };
+    assert_eq!(decoded_submit.queue_id, QUEUE_ID);
+    assert_eq!(decoded_submit.program_id, PROGRAM_ID);
+    assert_eq!(decoded_submit.timeout_ns, 7_500_000);
+    assert_eq!(decoded_submit.bindings.count(), Ok(2));
+    assert_eq!(
+        decoded_submit.bindings.get(0),
+        Ok(clean::Binding {
+            buffer_id: BUFFER_ID,
+            offset: 64,
+            bytes: 1_024,
+            slot: 3,
+            access: 1,
+        })
+    );
+    assert_eq!(
+        decoded_submit.bindings.get(1),
+        Ok(clean::Binding {
+            buffer_id: BUFFER_ID + 1,
+            offset: 128,
+            bytes: 2_048,
+            slot: 9,
+            access: 3,
+        })
+    );
+
+    let device_info = WireDeviceInfo {
+        uuid: *b"semantic-interop",
+        class: Le16::new(1),
+        reserved: Le16::new(0),
+        vendor_id: Le32::new(0x1234_5678),
+        device_id: Le32::new(0x9abc_def0),
+        capabilities: Le64::new(0x1020_3040_5060_7080),
+        max_contexts: Le32::new(4),
+        max_buffers_per_context: Le32::new(16),
+        max_programs_per_context: Le32::new(8),
+        max_queues_per_context: Le32::new(2),
+        max_events_per_context: Le32::new(32),
+        max_bindings_per_submission: Le32::new(64),
+        max_buffer_bytes: Le64::new(1 << 28),
+        max_artifact_bytes: Le64::new(1 << 20),
+    };
+    let context = response_context(clean::Opcode::GetDeviceInfo, None);
+    let info_bytes = primary_response(StatusCode::OK, device_info.as_bytes());
+    let decoded_info = clean::decode_response(&info_bytes, context).unwrap();
+    assert_eq!(
+        decoded_info.body,
+        clean::ResponseBody::DeviceInfo(clean::DeviceInfo {
+            uuid: *b"semantic-interop",
+            class: 1,
+            vendor_id: 0x1234_5678,
+            device_id: 0x9abc_def0,
+            capabilities: 0x1020_3040_5060_7080,
+            max_contexts: 4,
+            max_buffers_per_context: 16,
+            max_programs_per_context: 8,
+            max_queues_per_context: 2,
+            max_events_per_context: 32,
+            max_bindings_per_submission: 64,
+            max_buffer_bytes: 1 << 28,
+            max_artifact_bytes: 1 << 20,
+        })
+    );
+
+    let object_response = ObjectPayload {
+        object_id: Le64::new(CONTEXT_ID),
+    };
+    assert_eq!(
+        clean::decode_response(
+            &primary_response(StatusCode::OK, object_response.as_bytes()),
+            response_context(clean::Opcode::CreateContext, None),
+        )
+        .unwrap()
+        .body,
+        clean::ResponseBody::Object(CONTEXT_ID)
+    );
+    assert_eq!(
+        clean::decode_response(
+            &primary_response(StatusCode::OK, &[]),
+            response_context(clean::Opcode::DestroyContext, None),
+        )
+        .unwrap()
+        .body,
+        clean::ResponseBody::Empty
+    );
+    assert_eq!(
+        clean::decode_response(
+            &primary_response(StatusCode::OK, &[1, 2, 3, 4]),
+            response_context(clean::Opcode::ReadBuffer, Some(4)),
+        )
+        .unwrap()
+        .body,
+        clean::ResponseBody::Data(&[1, 2, 3, 4])
+    );
+
+    let event = SubmitResponse {
+        event_id: Le64::new(EVENT_ID),
+    };
+    assert_eq!(
+        clean::decode_response(
+            &primary_response(StatusCode::DEVICE_LOST, event.as_bytes()),
+            response_context(clean::Opcode::Submit, None),
+        )
+        .unwrap()
+        .body,
+        clean::ResponseBody::EventId(EVENT_ID)
+    );
+
+    let event_state = WireEventState {
+        state: Le16::new(KnownEventState::Failed as u16),
+        error: Le16::new(StatusCode::DEADLINE_EXPIRED.0),
+        reserved: Le32::new(0),
+    };
+    assert_eq!(
+        clean::decode_response(
+            &primary_response(StatusCode::OK, event_state.as_bytes()),
+            response_context(clean::Opcode::PollEvent, None),
+        )
+        .unwrap()
+        .body,
+        clean::ResponseBody::EventState(clean::EventState {
+            kind: clean::EventKind::Failed,
+            error: StatusCode::DEADLINE_EXPIRED.0,
+        })
+    );
+}
+
+#[test]
+fn independent_semantics_decode_to_primary_wire_types_for_every_layout() {
+    let config = clean::Config {
+        protocol_major: 1,
+        protocol_minor: 0,
+        command_queue_count: 1,
+        max_chain_descriptors: 96,
+        max_request_bytes: 3_145_728,
+        max_response_bytes: 4_194_304,
+    };
+    let mut config_bytes = [0_u8; clean::Config::ENCODED_BYTES];
+    config.encode(128, &mut config_bytes).unwrap();
+    let primary_config = read_exact::<WireConfig>(&config_bytes).unwrap();
+    assert_eq!(primary_config.protocol_major.get(), 1);
+    assert_eq!(primary_config.protocol_minor.get(), 0);
+    assert_eq!(primary_config.command_queue_count.get(), 1);
+    assert_eq!(primary_config.max_chain_descriptors.get(), 96);
+    assert_eq!(primary_config.max_request_bytes.get(), 3_145_728);
+    assert_eq!(primary_config.max_response_bytes.get(), 4_194_304);
+
+    let get_info = clean_request(clean::RequestBody::GetDeviceInfo);
+    assert_primary_header(&get_info, KnownOpcode::GetDeviceInfo, 0);
+
+    let create_context = clean_request(clean::RequestBody::CreateContext);
+    assert_primary_header(&create_context, KnownOpcode::CreateContext, 8);
+    let primary_create = read_exact::<CreateContextRequest>(&create_context[16..]).unwrap();
+    assert_eq!(primary_create.flags.get(), 0);
+    assert_eq!(primary_create.reserved.get(), 0);
+
+    let destroy_context = clean_request(clean::RequestBody::DestroyContext {
+        context_id: CONTEXT_ID,
+    });
+    assert_primary_header(&destroy_context, KnownOpcode::DestroyContext, 8);
+    assert_eq!(
+        read_exact::<ObjectPayload>(&destroy_context[16..])
+            .unwrap()
+            .object_id
+            .get(),
+        CONTEXT_ID
+    );
+
+    let allocate = clean_request(clean::RequestBody::AllocateBuffer(clean::AllocateBuffer {
+        context_id: CONTEXT_ID,
+        bytes: 131_072,
+        alignment: 8_192,
+        memory_domain: 3,
+        usage: 0x0c,
+    }));
+    assert_primary_header(&allocate, KnownOpcode::AllocateBuffer, 40);
+    let primary_allocate = read_exact::<AllocateBufferRequest>(&allocate[16..]).unwrap();
+    assert_eq!(primary_allocate.context_id.get(), CONTEXT_ID);
+    assert_eq!(primary_allocate.bytes.get(), 131_072);
+    assert_eq!(primary_allocate.alignment.get(), 8_192);
+    assert_eq!(primary_allocate.memory_domain, 3);
+    assert_eq!(primary_allocate.reserved0, [0; 7]);
+    assert_eq!(primary_allocate.usage.get(), 0x0c);
+    assert_eq!(primary_allocate.reserved1.get(), 0);
+
+    let read = clean_request(clean::RequestBody::ReadBuffer(clean::TransferBuffer {
+        buffer_id: BUFFER_ID,
+        offset: 256,
+        bytes: 8,
+    }));
+    assert_primary_header(&read, KnownOpcode::ReadBuffer, 24);
+    let primary_read = read_exact::<TransferBufferRequest>(&read[16..]).unwrap();
+    assert_eq!(primary_read.buffer_id.get(), BUFFER_ID);
+    assert_eq!(primary_read.offset.get(), 256);
+    assert_eq!(primary_read.bytes.get(), 8);
+
+    let write_data = [8_u8, 7, 6, 5, 4, 3, 2, 1];
+    let write = clean_request(clean::RequestBody::WriteBuffer {
+        transfer: clean::TransferBuffer {
+            buffer_id: BUFFER_ID,
+            offset: 512,
+            bytes: 8,
+        },
+        data: &write_data,
+    });
+    assert_primary_header(&write, KnownOpcode::WriteBuffer, 32);
+    let primary_write = read_exact::<TransferBufferRequest>(&write[16..40]).unwrap();
+    assert_eq!(primary_write.buffer_id.get(), BUFFER_ID);
+    assert_eq!(primary_write.offset.get(), 512);
+    assert_eq!(primary_write.bytes.get(), 8);
+    assert_eq!(&write[40..], &write_data);
+
+    let target = core::array::from_fn(|index| 200 + index as u32);
+    let artifact = [0x10_u8, 0x20, 0x30, 0x40, 0x50];
+    let load = clean_request(clean::RequestBody::LoadProgram(clean::LoadProgram {
+        context_id: CONTEXT_ID,
+        format: 0x5566_7788,
+        target,
+        resident_bytes: 262_144,
+        artifact: &artifact,
+    }));
+    assert_primary_header(&load, KnownOpcode::LoadProgram, 85);
+    let primary_load = read_exact::<LoadProgramRequest>(&load[16..96]).unwrap();
+    assert_eq!(primary_load.context_id.get(), CONTEXT_ID);
+    assert_eq!(primary_load.format.get(), 0x5566_7788);
+    assert_eq!(primary_load.flags.get(), 0);
+    assert_eq!(
+        primary_load.target.map(|word| word.get()),
+        core::array::from_fn(|index| 200 + index as u32)
+    );
+    assert_eq!(primary_load.payload_bytes.get(), 5);
+    assert_eq!(primary_load.resident_bytes.get(), 262_144);
+    assert_eq!(&load[96..], &artifact);
+
+    let create_queue = clean_request(clean::RequestBody::CreateQueue {
+        context_id: CONTEXT_ID,
+    });
+    assert_primary_header(&create_queue, KnownOpcode::CreateQueue, 16);
+    let primary_queue = read_exact::<CreateQueueRequest>(&create_queue[16..]).unwrap();
+    assert_eq!(primary_queue.context_id.get(), CONTEXT_ID);
+    assert_eq!(primary_queue.flags.get(), 0);
+    assert_eq!(primary_queue.reserved.get(), 0);
+
+    let clean_bindings = [
+        clean::Binding {
+            buffer_id: BUFFER_ID,
+            offset: 32,
+            bytes: 512,
+            slot: 4,
+            access: 1,
+        },
+        clean::Binding {
+            buffer_id: BUFFER_ID + 2,
+            offset: 64,
+            bytes: 1_024,
+            slot: 12,
+            access: 2,
+        },
+    ];
+    let submit = clean_request(clean::RequestBody::Submit(clean::Submit {
+        queue_id: QUEUE_ID,
+        program_id: PROGRAM_ID,
+        timeout_ns: 9_000_000,
+        bindings: clean::Bindings::Values(&clean_bindings),
+    }));
+    assert_primary_header(&submit, KnownOpcode::Submit, 96);
+    let primary_submit = read_exact::<SubmitRequest>(&submit[16..48]).unwrap();
+    assert_eq!(primary_submit.queue_id.get(), QUEUE_ID);
+    assert_eq!(primary_submit.program_id.get(), PROGRAM_ID);
+    assert_eq!(primary_submit.binding_count.get(), 2);
+    assert_eq!(primary_submit.flags.get(), 0);
+    assert_eq!(primary_submit.timeout_ns.get(), 9_000_000);
+    let primary_binding0 = read_exact::<WireBinding>(&submit[48..80]).unwrap();
+    let primary_binding1 = read_exact::<WireBinding>(&submit[80..112]).unwrap();
+    assert_eq!(primary_binding0.buffer_id.get(), BUFFER_ID);
+    assert_eq!(primary_binding0.offset.get(), 32);
+    assert_eq!(primary_binding0.bytes.get(), 512);
+    assert_eq!(primary_binding0.slot.get(), 4);
+    assert_eq!(primary_binding0.access, 1);
+    assert_eq!(primary_binding0.reserved, [0; 3]);
+    assert_eq!(primary_binding1.buffer_id.get(), BUFFER_ID + 2);
+    assert_eq!(primary_binding1.offset.get(), 64);
+    assert_eq!(primary_binding1.bytes.get(), 1_024);
+    assert_eq!(primary_binding1.slot.get(), 12);
+    assert_eq!(primary_binding1.access, 2);
+    assert_eq!(primary_binding1.reserved, [0; 3]);
+
+    let clean_info = clean::DeviceInfo {
+        uuid: *b"clean-to-primary",
+        class: 3,
+        vendor_id: 0xaabb_ccdd,
+        device_id: 0x1122_3344,
+        capabilities: 0x8877_6655_4433_2211,
+        max_contexts: 7,
+        max_buffers_per_context: 33,
+        max_programs_per_context: 11,
+        max_queues_per_context: 5,
+        max_events_per_context: 66,
+        max_bindings_per_submission: 99,
+        max_buffer_bytes: 1 << 29,
+        max_artifact_bytes: 1 << 21,
+    };
+    let info_context = response_context(clean::Opcode::GetDeviceInfo, None);
+    let info = clean_response(
+        StatusCode::OK.0,
+        clean::ResponseBody::DeviceInfo(clean_info),
+        info_context,
+    );
+    assert_primary_response_header(&info, StatusCode::OK.0, 76);
+    let primary_info = read_exact::<WireDeviceInfo>(&info[16..]).unwrap();
+    assert_eq!(primary_info.uuid, *b"clean-to-primary");
+    assert_eq!(primary_info.class.get(), 3);
+    assert_eq!(primary_info.reserved.get(), 0);
+    assert_eq!(primary_info.vendor_id.get(), 0xaabb_ccdd);
+    assert_eq!(primary_info.device_id.get(), 0x1122_3344);
+    assert_eq!(primary_info.capabilities.get(), 0x8877_6655_4433_2211);
+    assert_eq!(primary_info.max_contexts.get(), 7);
+    assert_eq!(primary_info.max_buffers_per_context.get(), 33);
+    assert_eq!(primary_info.max_programs_per_context.get(), 11);
+    assert_eq!(primary_info.max_queues_per_context.get(), 5);
+    assert_eq!(primary_info.max_events_per_context.get(), 66);
+    assert_eq!(primary_info.max_bindings_per_submission.get(), 99);
+    assert_eq!(primary_info.max_buffer_bytes.get(), 1 << 29);
+    assert_eq!(primary_info.max_artifact_bytes.get(), 1 << 21);
+
+    let object_context = response_context(clean::Opcode::CreateContext, None);
+    let object = clean_response(
+        StatusCode::OK.0,
+        clean::ResponseBody::Object(CONTEXT_ID),
+        object_context,
+    );
+    assert_primary_response_header(&object, StatusCode::OK.0, 8);
+    assert_eq!(
+        read_exact::<ObjectPayload>(&object[16..])
+            .unwrap()
+            .object_id
+            .get(),
+        CONTEXT_ID
+    );
+
+    let empty_context = response_context(clean::Opcode::DestroyContext, None);
+    let empty = clean_response(StatusCode::OK.0, clean::ResponseBody::Empty, empty_context);
+    assert_primary_response_header(&empty, StatusCode::OK.0, 0);
+
+    let read_data = [0xc0_u8, 0xff, 0xee];
+    let data_context = response_context(clean::Opcode::ReadBuffer, Some(read_data.len()));
+    let data = clean_response(
+        StatusCode::OK.0,
+        clean::ResponseBody::Data(&read_data),
+        data_context,
+    );
+    assert_primary_response_header(&data, StatusCode::OK.0, read_data.len());
+    assert_eq!(&data[16..], &read_data);
+
+    let submit_context = response_context(clean::Opcode::Submit, None);
+    let event = clean_response(
+        StatusCode::DEVICE_LOST.0,
+        clean::ResponseBody::EventId(EVENT_ID),
+        submit_context,
+    );
+    assert_primary_response_header(&event, StatusCode::DEVICE_LOST.0, 8);
+    assert_eq!(
+        read_exact::<SubmitResponse>(&event[16..])
+            .unwrap()
+            .event_id
+            .get(),
+        EVENT_ID
+    );
+
+    let event_context = response_context(clean::Opcode::PollEvent, None);
+    let event_state = clean_response(
+        StatusCode::OK.0,
+        clean::ResponseBody::EventState(clean::EventState {
+            kind: clean::EventKind::Cancelled,
+            error: StatusCode::OK.0,
+        }),
+        event_context,
+    );
+    assert_primary_response_header(&event_state, StatusCode::OK.0, 8);
+    let primary_event = read_exact::<WireEventState>(&event_state[16..]).unwrap();
+    assert_eq!(primary_event.state.get(), KnownEventState::Cancelled as u16);
+    assert_eq!(primary_event.error.get(), StatusCode::OK.0);
+    assert_eq!(primary_event.reserved.get(), 0);
+}

--- a/docs/portability.md
+++ b/docs/portability.md
@@ -10,7 +10,7 @@ Rust 2024 edition selected by the workspace. Every package inherits the same `ru
 
 | Job | Toolchain and targets | Contract enforced |
 |---|---|---|
-| `style-and-api` | Current stable on Ubuntu | Formatting, Clippy with warnings denied, and warning-free public docs |
+| `style-and-api` | Current stable on Ubuntu | Formatting, complete normative-requirement ledger, Clippy with warnings denied, and warning-free public docs |
 | `native-test` | Current stable on Ubuntu, macOS, and Windows | All workspace unit, integration, target, feature, and documentation tests plus release-profile checking |
 | `msrv` | Rust 1.85.0 on Ubuntu | Every workspace target and test continues to compile at the declared MSRV |
 | `portable-target` | Stable `aarch64-unknown-none`, `riscv64gc-unknown-none-elf`, and `wasm32-unknown-unknown` | `cleanroom`, `proto`, and `core` remain `no_std`; device/facade layers require at most `alloc`; Wasm also checks the std reference crates |
@@ -68,6 +68,7 @@ The host-independent checks can be reproduced with:
 
 ```sh
 cargo fmt --all -- --check
+python3 ci/check-normative-requirements.py --check
 cargo clippy --workspace --all-targets --all-features -- -D warnings
 RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps
 cargo test --workspace --all-targets --all-features

--- a/docs/portability.md
+++ b/docs/portability.md
@@ -13,8 +13,8 @@ Rust 2024 edition selected by the workspace. Every package inherits the same `ru
 | `style-and-api` | Current stable on Ubuntu | Formatting, Clippy with warnings denied, and warning-free public docs |
 | `native-test` | Current stable on Ubuntu, macOS, and Windows | All workspace unit, integration, target, feature, and documentation tests plus release-profile checking |
 | `msrv` | Rust 1.85.0 on Ubuntu | Every workspace target and test continues to compile at the declared MSRV |
-| `portable-target` | Stable `aarch64-unknown-none`, `riscv64gc-unknown-none-elf`, and `wasm32-unknown-unknown` | `proto` and `core` remain `no_std`; device/facade layers require at most `alloc`; Wasm also checks the std reference crates |
-| `feature-sets-and-dependencies` | Stable on Ubuntu | Every Cargo feature combination plus a guard against `std`/`alloc` feature leakage into `proto` and `core` |
+| `portable-target` | Stable `aarch64-unknown-none`, `riscv64gc-unknown-none-elf`, and `wasm32-unknown-unknown` | `cleanroom`, `proto`, and `core` remain `no_std`; device/facade layers require at most `alloc`; Wasm also checks the std reference crates |
+| `feature-sets-and-dependencies` | Stable on Ubuntu | Every Cargo feature combination plus dependency and `std`/`alloc` leakage guards for the portable codecs and core |
 | `dependency-policy` | Cargo-deny with Rust 1.85.0 | Advisories, yanked crates, duplicate versions, wildcard requirements, licenses, and dependency sources |
 | `fuzz-smoke` | Nightly on Ubuntu when `fuzz/Cargo.toml` exists | Every fuzz target gets bounded smoke iterations; issue #26 activates the job by adding the fuzz workspace |
 
@@ -26,7 +26,7 @@ the concrete runner versions used for the release.
 
 | Tier | Crates | Allowed runtime surface |
 |---|---|---|
-| `core-only` | `virtio-accel-proto`, `virtio-accel-core` | `core`; proc-macros may execute with `std` on the build host, but target dependencies may not enable `std` or `alloc` |
+| `core-only` | `virtio-accel-cleanroom`, `virtio-accel-proto`, `virtio-accel-core` | `core`; the clean-room codec has no normal/build dependencies, while proc-macros used by other crates may execute with `std` on the build host |
 | `alloc-portable` | `virtio-accel-device`, `virtio-accel` | `core + alloc`; no OS, filesystem, sockets, threads, or host synchronization |
 | `std-reference` | `virtio-accel-mock` | Portable `std`; no host-OS or vendor-specific API |
 
@@ -40,10 +40,12 @@ CI runs `cargo hack check --feature-powerset --no-dev-deps` across the workspace
 additive: disabling default features may remove convenience behavior but must not select a different
 protocol interpretation.
 
-The portable dependency guard inspects normal and build target features for `virtio-accel-proto`
-and `virtio-accel-core`; test-only development dependencies are intentionally outside the target
-runtime graph. A dependency’s host-side derive macro may use `std`, but the target graph for these
-crates must not enable a dependency feature named `std` or `alloc`.
+The portable dependency guard inspects normal and build target features for
+`virtio-accel-cleanroom`, `virtio-accel-proto`, and `virtio-accel-core`; test-only development
+dependencies are intentionally outside the target runtime graph. It additionally proves that the
+clean-room codec has no normal or build dependencies at all. A dependency’s host-side derive macro
+may use `std`, but the target graph for these crates must not enable a dependency feature named
+`std` or `alloc`.
 
 ## Dependency policy
 
@@ -81,6 +83,7 @@ Target checks require the corresponding Rust standard libraries:
 ```sh
 rustup target add aarch64-unknown-none riscv64gc-unknown-none-elf wasm32-unknown-unknown
 cargo check \
+  -p virtio-accel-cleanroom \
   -p virtio-accel-proto \
   -p virtio-accel-core \
   -p virtio-accel-device \


### PR DESCRIPTION
## What changed

- Adds `virtio-accel-cleanroom`, a dependency-free `no_std` Rust implementation of the protocol 1.0 candidate byte contract.
- Implements manual little-endian config, request, response, payload, binding, status, event, and validation logic without importing `virtio-accel-proto`, `zerocopy`, or shared wire types.
- Decodes and re-encodes both configurations, all 15 request opcodes, all 20 canonical response shapes, and every reviewed adversarial vector.
- Adds a byte-level bridge test in `virtio-accel-proto` that runs both implementations over the same canonical frames.
- Adds bidirectional semantic interoperability tests for every distinct config, request, and response layout: each implementation constructs values, crosses only bytes, and has every field decoded and checked by the other implementation.
- Adds a generated 113-entry normative requirement ledger with content-derived IDs, source lines, evidence paths, deferred issues, and rationale.
- Adds a CI guard that fails when a normative requirement is added, removed, moved, reworded, or mapped to missing evidence without reviewing and regenerating the ledger.
- Extends portable-target CI and dependency policy so the clean-room codec remains `no_std` and has no normal/build dependencies.

## Why

Epic #2 requires two implementations to interoperate without sharing Rust types and requires every normative requirement to have executable evidence or an explicitly tracked rationale.

The existing primary codec and golden vectors proved ABI stability, but vector round-tripping alone could miss a symmetric semantic mistake. The new field-by-field tests independently construct and decode every distinct layout in both directions. The exact requirement ledger replaces broad section-level claims with one auditable record per RFC keyword occurrence.

## Invariants and performance

- Protocol constants, layouts, and canonical vectors are unchanged.
- The primary production crates gain only a test-only dependency on the clean-room crate.
- The clean-room codec is caller-buffered, allocation-free, and portable across the existing bare-metal and Wasm targets.
- Duplicate binding-slot validation is intentionally O(n²) to remain dependency- and allocation-free. This is conformance code, not the command-engine hot path; production resource accounting remains tracked by #20.
- Queue, reset, and response-atomicity behaviors remain explicitly assigned to #17-#20, backend semantics to #21, and resource/threat limits to #25.

## Validation

Local checks pass:

- formatting and the complete 113-entry normative requirement ledger;
- Clippy with warnings denied and rustdoc warnings denied;
- all workspace unit, integration, semantic interoperability, and documentation tests;
- Rust 1.85.0 MSRV checks and tests;
- release-profile and Cargo feature-powerset checks;
- dependency independence and feature-leakage guards;
- cargo-deny advisories, licenses, bans, and sources policy;
- actionlint; and
- AArch64/RISC-V bare-metal, Wasm, x86_64 Linux, Windows MSVC, and Apple target checks.

Closes #2
