### PR TITLE
Define direct buffer and segmented byte contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 name = "virtio-accel"
 version = "0.1.0"
 dependencies = [
+ "serde_json",
  "virtio-accel-core",
  "virtio-accel-device",
  "virtio-accel-mock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,4 +39,5 @@ virtio-accel-device.workspace = true
 virtio-accel-proto.workspace = true
 
 [dev-dependencies]
+serde_json.workspace = true
 virtio-accel-mock.workspace = true

--- a/ci/check-normative-requirements.py
+++ b/ci/check-normative-requirements.py
@@ -66,8 +66,8 @@ COVERAGE: Final[dict[tuple[str, int], Coverage]] = {
             "crates/virtio-accel-device/src/object_table.rs",
             "crates/virtio-accel-mock/src/lib.rs",
         ),
-        ("#20", "#21"),
-        "Core ownership types and lifecycle tests exist; the command engine and complete backend policy remain tracked.",
+        ("#20", "#21", "#25"),
+        "Core ownership types and lifecycle tests exist; command-engine enforcement, complete backend policy, and retained-byte accounting remain tracked.",
     ),
     ("SPEC", 5): coverage(
         "mixed",

--- a/conformance/v1.0/layout.json
+++ b/conformance/v1.0/layout.json
@@ -24,6 +24,18 @@
       "SECURE_CONTEXTS": "0x0000000000000010"
     }
   },
+  "capabilities": {
+    "assigned": {
+      "HOST_VISIBLE_MEMORY": "0x0000000000000001",
+      "DEVICE_LOCAL_MEMORY": "0x0000000000000002",
+      "EVENT_CANCELLATION": "0x0000000000000004",
+      "SHARED_MEMORY": "0x0000000000000020"
+    },
+    "reserved": {
+      "EXTERNAL_MEMORY": "0x0000000000000008",
+      "SECURE_CONTEXTS": "0x0000000000000010"
+    }
+  },
   "opcodes": {
     "GET_DEVICE_INFO": "0x0001",
     "CREATE_CONTEXT": "0x0100",

--- a/conformance/v1.0/requirements.json
+++ b/conformance/v1.0/requirements.json
@@ -1,7 +1,7 @@
 {
   "schema": "virtio-accel-normative-requirements-1",
   "generated_by": "ci/check-normative-requirements.py",
-  "requirement_count": 113,
+  "requirement_count": 126,
   "requirements": [
     {
       "id": "REQ-SPEC-A29885B44214",
@@ -243,9 +243,10 @@
         ],
         "issues": [
           "#20",
-          "#21"
+          "#21",
+          "#25"
         ],
-        "rationale": "Core ownership types and lifecycle tests exist; the command engine and complete backend policy remain tracked."
+        "rationale": "Core ownership types and lifecycle tests exist; command-engine enforcement, complete backend policy, and retained-byte accounting remain tracked."
       }
     },
     {
@@ -264,9 +265,10 @@
         ],
         "issues": [
           "#20",
-          "#21"
+          "#21",
+          "#25"
         ],
-        "rationale": "Core ownership types and lifecycle tests exist; the command engine and complete backend policy remain tracked."
+        "rationale": "Core ownership types and lifecycle tests exist; command-engine enforcement, complete backend policy, and retained-byte accounting remain tracked."
       }
     },
     {
@@ -285,15 +287,214 @@
         ],
         "issues": [
           "#20",
-          "#21"
+          "#21",
+          "#25"
         ],
-        "rationale": "Core ownership types and lifecycle tests exist; the command engine and complete backend policy remain tracked."
+        "rationale": "Core ownership types and lifecycle tests exist; command-engine enforcement, complete backend policy, and retained-byte accounting remain tracked."
       }
     },
     {
-      "id": "REQ-SPEC-56AF235C5973",
+      "id": "REQ-SPEC-2ADD413E2C54",
       "source": "docs/specification.md",
-      "line": 143,
+      "line": 149,
+      "section": "4. Terminology and object model",
+      "keyword": "MUST",
+      "statement": "An allocation result **MUST** report the requested descriptor, actual retained allocation bytes,",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/src/object_table.rs",
+          "crates/virtio-accel-mock/src/lib.rs"
+        ],
+        "issues": [
+          "#20",
+          "#21",
+          "#25"
+        ],
+        "rationale": "Core ownership types and lifecycle tests exist; command-engine enforcement, complete backend policy, and retained-byte accounting remain tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-9C940B6CA84A",
+      "source": "docs/specification.md",
+      "line": 150,
+      "section": "4. Terminology and object model",
+      "keyword": "MUST NOT",
+      "statement": "actual guaranteed alignment, and honest backing properties. Actual bytes **MUST NOT** be smaller",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/src/object_table.rs",
+          "crates/virtio-accel-mock/src/lib.rs"
+        ],
+        "issues": [
+          "#20",
+          "#21",
+          "#25"
+        ],
+        "rationale": "Core ownership types and lifecycle tests exist; command-engine enforcement, complete backend policy, and retained-byte accounting remain tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-6356A0CC67A3",
+      "source": "docs/specification.md",
+      "line": 151,
+      "section": "4. Terminology and object model",
+      "keyword": "MUST NOT",
+      "statement": "than the logical buffer and actual alignment **MUST NOT** be weaker than requested. Device resource",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/src/object_table.rs",
+          "crates/virtio-accel-mock/src/lib.rs"
+        ],
+        "issues": [
+          "#20",
+          "#21",
+          "#25"
+        ],
+        "rationale": "Core ownership types and lifecycle tests exist; command-engine enforcement, complete backend policy, and retained-byte accounting remain tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-8F8A0C569B92",
+      "source": "docs/specification.md",
+      "line": 153,
+      "section": "4. Terminology and object model",
+      "keyword": "MUST NOT",
+      "statement": "A provider **MUST NOT** return an allocation whose reported placement can be achieved only by",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/src/object_table.rs",
+          "crates/virtio-accel-mock/src/lib.rs"
+        ],
+        "issues": [
+          "#20",
+          "#21",
+          "#25"
+        ],
+        "rationale": "Core ownership types and lifecycle tests exist; command-engine enforcement, complete backend policy, and retained-byte accounting remain tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-9D56D3A7B4DB",
+      "source": "docs/specification.md",
+      "line": 156,
+      "section": "4. Terminology and object model",
+      "keyword": "MUST",
+      "statement": "A buffer whose usage includes program input, program output, or mutable state **MUST** report direct",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/src/object_table.rs",
+          "crates/virtio-accel-mock/src/lib.rs"
+        ],
+        "issues": [
+          "#20",
+          "#21",
+          "#25"
+        ],
+        "rationale": "Core ownership types and lifecycle tests exist; command-engine enforcement, complete backend policy, and retained-byte accounting remain tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-6DD165FA9420",
+      "source": "docs/specification.md",
+      "line": 157,
+      "section": "4. Terminology and object model",
+      "keyword": "MUST",
+      "statement": "binding. A compatible submission **MUST** bind the exact provider allocation without copying the",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/src/object_table.rs",
+          "crates/virtio-accel-mock/src/lib.rs"
+        ],
+        "issues": [
+          "#20",
+          "#21",
+          "#25"
+        ],
+        "rationale": "Core ownership types and lifecycle tests exist; command-engine enforcement, complete backend policy, and retained-byte accounting remain tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-F386A9C7B476",
+      "source": "docs/specification.md",
+      "line": 159,
+      "section": "4. Terminology and object model",
+      "keyword": "MUST",
+      "statement": "**MUST** reject allocation. If a particular program is incompatible with an otherwise valid buffer,",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/src/object_table.rs",
+          "crates/virtio-accel-mock/src/lib.rs"
+        ],
+        "issues": [
+          "#20",
+          "#21",
+          "#25"
+        ],
+        "rationale": "Core ownership types and lifecycle tests exist; command-engine enforcement, complete backend policy, and retained-byte accounting remain tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-B164581301C6",
+      "source": "docs/specification.md",
+      "line": 160,
+      "section": "4. Terminology and object model",
+      "keyword": "MUST",
+      "statement": "submission **MUST** be rejected as `INCOMPATIBLE`; the provider **MUST NOT** silently stage it.",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/src/object_table.rs",
+          "crates/virtio-accel-mock/src/lib.rs"
+        ],
+        "issues": [
+          "#20",
+          "#21",
+          "#25"
+        ],
+        "rationale": "Core ownership types and lifecycle tests exist; command-engine enforcement, complete backend policy, and retained-byte accounting remain tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-0178C1494E1C",
+      "source": "docs/specification.md",
+      "line": 160,
+      "section": "4. Terminology and object model",
+      "keyword": "MUST NOT",
+      "statement": "submission **MUST** be rejected as `INCOMPATIBLE`; the provider **MUST NOT** silently stage it.",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/src/object_table.rs",
+          "crates/virtio-accel-mock/src/lib.rs"
+        ],
+        "issues": [
+          "#20",
+          "#21",
+          "#25"
+        ],
+        "rationale": "Core ownership types and lifecycle tests exist; command-engine enforcement, complete backend policy, and retained-byte accounting remain tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-A7BAAE96F374",
+      "source": "docs/specification.md",
+      "line": 177,
       "section": "4. Terminology and object model",
       "keyword": "MUST NOT",
       "statement": "The transport **MUST NOT** interpret vendor artifact contents. Artifact-format adapters own their",
@@ -306,15 +507,16 @@
         ],
         "issues": [
           "#20",
-          "#21"
+          "#21",
+          "#25"
         ],
-        "rationale": "Core ownership types and lifecycle tests exist; the command engine and complete backend policy remain tracked."
+        "rationale": "Core ownership types and lifecycle tests exist; command-engine enforcement, complete backend policy, and retained-byte accounting remain tracked."
       }
     },
     {
-      "id": "REQ-SPEC-99785E39EE23",
+      "id": "REQ-SPEC-DE29CAFF6637",
       "source": "docs/specification.md",
-      "line": 152,
+      "line": 190,
       "section": "4. Terminology and object model",
       "keyword": "SHOULD",
       "statement": "It is unrelated to a Virtio queue index. Documentation and APIs **SHOULD** use \u201cexecution queue\u201d",
@@ -327,15 +529,16 @@
         ],
         "issues": [
           "#20",
-          "#21"
+          "#21",
+          "#25"
         ],
-        "rationale": "Core ownership types and lifecycle tests exist; the command engine and complete backend policy remain tracked."
+        "rationale": "Core ownership types and lifecycle tests exist; command-engine enforcement, complete backend policy, and retained-byte accounting remain tracked."
       }
     },
     {
-      "id": "REQ-SPEC-446BAC519DC5",
+      "id": "REQ-SPEC-62401FEF59A7",
       "source": "docs/specification.md",
-      "line": 160,
+      "line": 198,
       "section": "4. Terminology and object model",
       "keyword": "MUST",
       "statement": "Binding slot numbers **MUST** be unique within a submission. A binding does not transfer ownership",
@@ -348,15 +551,16 @@
         ],
         "issues": [
           "#20",
-          "#21"
+          "#21",
+          "#25"
         ],
-        "rationale": "Core ownership types and lifecycle tests exist; the command engine and complete backend policy remain tracked."
+        "rationale": "Core ownership types and lifecycle tests exist; command-engine enforcement, complete backend policy, and retained-byte accounting remain tracked."
       }
     },
     {
-      "id": "REQ-SPEC-B509E77DB3D3",
+      "id": "REQ-SPEC-616928D3ABA3",
       "source": "docs/specification.md",
-      "line": 161,
+      "line": 199,
       "section": "4. Terminology and object model",
       "keyword": "MUST",
       "statement": "of its buffer, but the device **MUST** retain the buffer until the resulting event is safely",
@@ -369,15 +573,16 @@
         ],
         "issues": [
           "#20",
-          "#21"
+          "#21",
+          "#25"
         ],
-        "rationale": "Core ownership types and lifecycle tests exist; the command engine and complete backend policy remain tracked."
+        "rationale": "Core ownership types and lifecycle tests exist; command-engine enforcement, complete backend policy, and retained-byte accounting remain tracked."
       }
     },
     {
-      "id": "REQ-SPEC-B71B5452BE12",
+      "id": "REQ-SPEC-50EC74C4B4A6",
       "source": "docs/specification.md",
-      "line": 177,
+      "line": 215,
       "section": "4. Terminology and object model",
       "keyword": "MUST NOT",
       "statement": "The command engine **MUST NOT** convert an indeterminate submission into an ordinary error.",
@@ -390,15 +595,16 @@
         ],
         "issues": [
           "#20",
-          "#21"
+          "#21",
+          "#25"
         ],
-        "rationale": "Core ownership types and lifecycle tests exist; the command engine and complete backend policy remain tracked."
+        "rationale": "Core ownership types and lifecycle tests exist; command-engine enforcement, complete backend policy, and retained-byte accounting remain tracked."
       }
     },
     {
-      "id": "REQ-SPEC-66AFC1A94561",
+      "id": "REQ-SPEC-B45FEED8ABA7",
       "source": "docs/specification.md",
-      "line": 184,
+      "line": 222,
       "section": "4. Terminology and object model",
       "keyword": "MUST",
       "statement": "An event **MUST** retain its execution queue, program, buffers, and per-invocation backend state until",
@@ -411,15 +617,16 @@
         ],
         "issues": [
           "#20",
-          "#21"
+          "#21",
+          "#25"
         ],
-        "rationale": "Core ownership types and lifecycle tests exist; the command engine and complete backend policy remain tracked."
+        "rationale": "Core ownership types and lifecycle tests exist; command-engine enforcement, complete backend policy, and retained-byte accounting remain tracked."
       }
     },
     {
-      "id": "REQ-SPEC-10FC985A68FF",
+      "id": "REQ-SPEC-E8F4BC935D93",
       "source": "docs/specification.md",
-      "line": 185,
+      "line": 223,
       "section": "4. Terminology and object model",
       "keyword": "MUST NOT",
       "statement": "it is terminal and successfully destroyed. A pending event **MUST NOT** be destroyed.",
@@ -432,15 +639,16 @@
         ],
         "issues": [
           "#20",
-          "#21"
+          "#21",
+          "#25"
         ],
-        "rationale": "Core ownership types and lifecycle tests exist; the command engine and complete backend policy remain tracked."
+        "rationale": "Core ownership types and lifecycle tests exist; command-engine enforcement, complete backend policy, and retained-byte accounting remain tracked."
       }
     },
     {
-      "id": "REQ-SPEC-5BB719500123",
+      "id": "REQ-SPEC-68CFBB9C2D41",
       "source": "docs/specification.md",
-      "line": 206,
+      "line": 244,
       "section": "5. Baseline capabilities and feature policy",
       "keyword": "MUST",
       "statement": "The portable v1 baseline **MUST** provide:",
@@ -458,9 +666,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-47C10706DD08",
+      "id": "REQ-SPEC-6A5CA92B1CFE",
       "source": "docs/specification.md",
-      "line": 221,
+      "line": 259,
       "section": "5. Baseline capabilities and feature policy",
       "keyword": "MUST",
       "statement": "advertise semantic event-cancellation capability, the device **MUST** return `UNSUPPORTED` without",
@@ -478,9 +686,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-6AE883563CDE",
+      "id": "REQ-SPEC-FD0B52B87A47",
       "source": "docs/specification.md",
-      "line": 230,
+      "line": 268,
       "section": "5. Baseline capabilities and feature policy",
       "keyword": "MUST NOT",
       "statement": "`TIMELINE_FENCES`, and `SECURE_CONTEXTS` reserve numeric positions only. A baseline device **MUST NOT**",
@@ -498,9 +706,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-0451EDD49C74",
+      "id": "REQ-SPEC-A7094E01E82E",
       "source": "docs/specification.md",
-      "line": 231,
+      "line": 269,
       "section": "5. Baseline capabilities and feature policy",
       "keyword": "MUST NOT",
       "statement": "advertise them and a baseline driver **MUST NOT** accept them. Protocol 1.0 assigns no semantics to",
@@ -518,9 +726,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-4790D362BFD9",
+      "id": "REQ-SPEC-26AB1F1F0970",
       "source": "docs/specification.md",
-      "line": 234,
+      "line": 272,
       "section": "5. Baseline capabilities and feature policy",
       "keyword": "MUST NOT",
       "statement": "Unknown device-specific feature bits **MUST NOT** be accepted by a driver. A device **MUST NOT**",
@@ -538,9 +746,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-4F438014BEF4",
+      "id": "REQ-SPEC-899753DD52D4",
       "source": "docs/specification.md",
-      "line": 234,
+      "line": 272,
       "section": "5. Baseline capabilities and feature policy",
       "keyword": "MUST NOT",
       "statement": "Unknown device-specific feature bits **MUST NOT** be accepted by a driver. A device **MUST NOT**",
@@ -558,9 +766,49 @@
       }
     },
     {
-      "id": "REQ-SPEC-F04C99D52AC3",
+      "id": "REQ-SPEC-AE542DCB3D68",
       "source": "docs/specification.md",
-      "line": 243,
+      "line": 290,
+      "section": "5. Baseline capabilities and feature policy",
+      "keyword": "MUST NOT",
+      "statement": "ownership, synchronization, and isolation rules are specified. A protocol 1.0 device **MUST NOT**",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "crates/virtio-accel-proto/src/lib.rs"
+        ],
+        "issues": [
+          "#20",
+          "#32"
+        ],
+        "rationale": "Namespaces and reserved values are executable; runtime negotiation and future evolution remain tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-7807653A3F9F",
+      "source": "docs/specification.md",
+      "line": 293,
+      "section": "5. Baseline capabilities and feature policy",
+      "keyword": "MUST",
+      "statement": "The device **MUST** reject an allocation for an unsupported memory domain before invoking the",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "crates/virtio-accel-proto/src/lib.rs"
+        ],
+        "issues": [
+          "#20",
+          "#32"
+        ],
+        "rationale": "Namespaces and reserved values are executable; runtime negotiation and future evolution remain tracked."
+      }
+    },
+    {
+      "id": "REQ-SPEC-86369B5E9589",
+      "source": "docs/specification.md",
+      "line": 299,
       "section": "5. Baseline capabilities and feature policy",
       "keyword": "MUST",
       "statement": "new synchronization, or changed lifetime rules, the device **MUST** also negotiate an appropriate",
@@ -578,12 +826,12 @@
       }
     },
     {
-      "id": "REQ-SPEC-8B2416B7246F",
+      "id": "REQ-SPEC-EADCE4F0A8A9",
       "source": "docs/specification.md",
-      "line": 248,
+      "line": 304,
       "section": "5. Baseline capabilities and feature policy",
       "keyword": "MUST NOT",
-      "statement": "listed in [wire-abi.md](wire-abi.md); the reference implementation **MUST NOT** translate an",
+      "statement": "implementation **MUST NOT** translate an underspecified capability into additional wire behavior.",
       "coverage": {
         "status": "mixed",
         "evidence": [
@@ -598,9 +846,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-13AAF8D4B1EE",
+      "id": "REQ-SPEC-C4C81B1D7BB6",
       "source": "docs/specification.md",
-      "line": 254,
+      "line": 309,
       "section": "5. Baseline capabilities and feature policy",
       "keyword": "MUST",
       "statement": "reserved and **MUST** be zero.",
@@ -618,9 +866,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-7A71D9423437",
+      "id": "REQ-SPEC-C679BCADAAEA",
       "source": "docs/specification.md",
-      "line": 257,
+      "line": 312,
       "section": "5. Baseline capabilities and feature policy",
       "keyword": "MUST",
       "statement": "**MUST** be rejected before backend invocation. Reserved fields **MUST** be zero.",
@@ -638,9 +886,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-7FAC1C244457",
+      "id": "REQ-SPEC-D861A636A153",
       "source": "docs/specification.md",
-      "line": 257,
+      "line": 312,
       "section": "5. Baseline capabilities and feature policy",
       "keyword": "MUST",
       "statement": "**MUST** be rejected before backend invocation. Reserved fields **MUST** be zero.",
@@ -658,9 +906,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-30B9B112E166",
+      "id": "REQ-SPEC-BB680E1A0B79",
       "source": "docs/specification.md",
-      "line": 264,
+      "line": 319,
       "section": "6. Versioning and compatibility",
       "keyword": "MUST",
       "statement": "Candidate implementations **MUST** expose major `1` and minor `0` in device-specific configuration",
@@ -679,9 +927,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-2BF6F42BB323",
+      "id": "REQ-SPEC-8597E84F67FD",
       "source": "docs/specification.md",
-      "line": 265,
+      "line": 320,
       "section": "6. Versioning and compatibility",
       "keyword": "MUST NOT",
       "statement": "and **MUST NOT** claim candidate protocol 1.0 conformance unless they satisfy the normative wire,",
@@ -700,9 +948,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-ED6E6EBD406D",
+      "id": "REQ-SPEC-CE119CF28472",
       "source": "docs/specification.md",
-      "line": 269,
+      "line": 324,
       "section": "6. Versioning and compatibility",
       "keyword": "MUST",
       "statement": "#33. Before that audit, an intentional candidate revision **MUST** follow the coordinated procedure",
@@ -721,9 +969,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-5687B484D7C0",
+      "id": "REQ-SPEC-6875C63115F8",
       "source": "docs/specification.md",
-      "line": 270,
+      "line": 325,
       "section": "6. Versioning and compatibility",
       "keyword": "MUST NOT",
       "statement": "in [wire-abi.md](wire-abi.md) and **MUST NOT** be described as a frozen or stable release.",
@@ -742,9 +990,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-C559442F7881",
+      "id": "REQ-SPEC-00BB7B9A2B4C",
       "source": "docs/specification.md",
-      "line": 276,
+      "line": 331,
       "section": "6. Versioning and compatibility",
       "keyword": "MUST",
       "statement": "- a driver **MUST** reject a device with an unsupported major version;",
@@ -763,9 +1011,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-97B5F1905B00",
+      "id": "REQ-SPEC-8FCB39B7C119",
       "source": "docs/specification.md",
-      "line": 278,
+      "line": 333,
       "section": "6. Versioning and compatibility",
       "keyword": "MUST NOT",
       "statement": "- a driver **MUST NOT** use behavior newer than the device minor version it observed; and",
@@ -784,9 +1032,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-3C80B5950333",
+      "id": "REQ-SPEC-FE18F408035C",
       "source": "docs/specification.md",
-      "line": 287,
+      "line": 342,
       "section": "6. Versioning and compatibility",
       "keyword": "MUST NOT",
       "statement": "Therefore a minor version alone **MUST NOT** append fields to an existing response that an older",
@@ -805,9 +1053,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-C606EBB6B424",
+      "id": "REQ-SPEC-6C45506F15E8",
       "source": "docs/specification.md",
-      "line": 291,
+      "line": 346,
       "section": "6. Versioning and compatibility",
       "keyword": "SHOULD",
       "statement": "negotiated feature explicitly selects a different layout. Extensions **SHOULD** use a new opcode or",
@@ -826,9 +1074,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-5D0FF22C6F7F",
+      "id": "REQ-SPEC-754533E01919",
       "source": "docs/specification.md",
-      "line": 294,
+      "line": 349,
       "section": "6. Versioning and compatibility",
       "keyword": "MUST",
       "statement": "Without such a feature, a receiver **MUST** require the exact payload length for the opcode and",
@@ -847,9 +1095,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-9EE8CA6EE4D0",
+      "id": "REQ-SPEC-D1E971E43B4A",
       "source": "docs/specification.md",
-      "line": 295,
+      "line": 350,
       "section": "6. Versioning and compatibility",
       "keyword": "MUST",
       "statement": "**MUST** reject trailing bytes. It **MUST NOT** silently reinterpret or ignore an unknown tail.",
@@ -868,9 +1116,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-1E2D21965135",
+      "id": "REQ-SPEC-E5BE5302740B",
       "source": "docs/specification.md",
-      "line": 295,
+      "line": 350,
       "section": "6. Versioning and compatibility",
       "keyword": "MUST NOT",
       "statement": "**MUST** reject trailing bytes. It **MUST NOT** silently reinterpret or ignore an unknown tail.",
@@ -889,9 +1137,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-5E601687AFF4",
+      "id": "REQ-SPEC-89F3C7144057",
       "source": "docs/specification.md",
-      "line": 302,
+      "line": 357,
       "section": "6. Versioning and compatibility",
       "keyword": "MUST NOT",
       "statement": "- An unknown response status is an opaque failure. A driver **MUST NOT** treat it as success or",
@@ -910,9 +1158,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-348C878520B7",
+      "id": "REQ-SPEC-75D40B718E67",
       "source": "docs/specification.md",
-      "line": 309,
+      "line": 364,
       "section": "7. Ownership and destruction",
       "keyword": "MUST",
       "statement": "The device owns the mapping from opaque object IDs to backend handles. The mapping **MUST** reject:",
@@ -931,9 +1179,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-DF46FBE73D09",
+      "id": "REQ-SPEC-3FCD0B88A0D2",
       "source": "docs/specification.md",
-      "line": 317,
+      "line": 372,
       "section": "7. Ownership and destruction",
       "keyword": "MUST NOT",
       "statement": "Object-ID encoding is implementation-private. Drivers **MUST NOT** infer slot, kind, generation, or",
@@ -952,9 +1200,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-43660E08DAB5",
+      "id": "REQ-SPEC-2AA25E912F8B",
       "source": "docs/specification.md",
-      "line": 322,
+      "line": 377,
       "section": "7. Ownership and destruction",
       "keyword": "MUST",
       "statement": "- a rejected release returns the still-live handle and the device **MUST** restore it for retry;",
@@ -973,9 +1221,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-12D875ED1FD1",
+      "id": "REQ-SPEC-98C389360C1A",
       "source": "docs/specification.md",
-      "line": 324,
+      "line": 379,
       "section": "7. Ownership and destruction",
       "keyword": "MUST NOT",
       "statement": "- an indeterminate release invalidates the guest ID and requires recovery. The device **MUST NOT**",
@@ -994,9 +1242,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-80762635C08B",
+      "id": "REQ-SPEC-58CA48105327",
       "source": "docs/specification.md",
-      "line": 327,
+      "line": 382,
       "section": "7. Ownership and destruction",
       "keyword": "MUST NOT",
       "statement": "`Drop` may provide defensive cleanup inside an implementation but **MUST NOT** be used as",
@@ -1015,9 +1263,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-133784109D00",
+      "id": "REQ-SPEC-516FEBC9DC0B",
       "source": "docs/specification.md",
-      "line": 333,
+      "line": 388,
       "section": "8. Time and progress",
       "keyword": "MUST NOT",
       "statement": "infinite. Absolute guest timestamps **MUST NOT** be compared with a host clock because their",
@@ -1034,9 +1282,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-1631781F77C9",
+      "id": "REQ-SPEC-B3DE8C0C13C8",
       "source": "docs/specification.md",
-      "line": 336,
+      "line": 391,
       "section": "8. Time and progress",
       "keyword": "MUST",
       "statement": "Polling an event **MUST** be nonblocking and bounded. The portable contract creates no background",
@@ -1053,9 +1301,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-8CD9DDF8269D",
+      "id": "REQ-SPEC-C0E2DDFC4E95",
       "source": "docs/specification.md",
-      "line": 340,
+      "line": 395,
       "section": "8. Time and progress",
       "keyword": "MUST",
       "statement": "cannot prove rejection is indeterminate and **MUST** retain an event.",
@@ -1072,9 +1320,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-8857EBAFBF73",
+      "id": "REQ-SPEC-CB3886392A30",
       "source": "docs/specification.md",
-      "line": 349,
+      "line": 404,
       "section": "9. Errors",
       "keyword": "MUST",
       "statement": "A device **MUST** map errors deterministically and **MUST NOT** expose uninitialized response bytes.",
@@ -1092,9 +1340,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-584B530155E9",
+      "id": "REQ-SPEC-D2EC5C810722",
       "source": "docs/specification.md",
-      "line": 349,
+      "line": 404,
       "section": "9. Errors",
       "keyword": "MUST NOT",
       "statement": "A device **MUST** map errors deterministically and **MUST NOT** expose uninitialized response bytes.",
@@ -1112,9 +1360,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-8DCDDFCFBAD6",
+      "id": "REQ-SPEC-063210EF2C88",
       "source": "docs/specification.md",
-      "line": 353,
+      "line": 408,
       "section": "9. Errors",
       "keyword": "MUST NOT",
       "statement": "An error response **MUST NOT** imply that a backend operation was rejected when acceptance was",
@@ -1132,9 +1380,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-400D30242C2D",
+      "id": "REQ-SPEC-48AE033662E2",
       "source": "docs/specification.md",
-      "line": 358,
+      "line": 413,
       "section": "10. Portability requirements",
       "keyword": "MUST NOT",
       "statement": "Portable crates **MUST NOT** select an operating system, VMM, kernel, vendor API, or global runtime.",
@@ -1150,9 +1398,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-A74AA2573F34",
+      "id": "REQ-SPEC-38AC895175F0",
       "source": "docs/specification.md",
-      "line": 365,
+      "line": 420,
       "section": "10. Portability requirements",
       "keyword": "MUST NOT",
       "statement": "Platform adapters depend inward on the portable layers. A portable layer **MUST NOT** conditionally",
@@ -1168,9 +1416,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-7224582FFB9A",
+      "id": "REQ-SPEC-E90D593ED0AD",
       "source": "docs/specification.md",
-      "line": 381,
+      "line": 436,
       "section": "11. Tracked completion work",
       "keyword": "MAY",
       "statement": "No implementation **MAY** advertise a reserved optional feature merely because a Rust constant",
@@ -1554,9 +1802,29 @@
       }
     },
     {
-      "id": "REQ-WIRE-0824A8EE98CA",
+      "id": "REQ-WIRE-4B8751C702D4",
       "source": "docs/wire-abi.md",
-      "line": 201,
+      "line": 208,
+      "section": "5. Opcodes and payloads",
+      "keyword": "MUST NOT",
+      "statement": "Bits 3 (`EXTERNAL_MEMORY`) and 4 (`SECURE_CONTEXTS`) are reserved and **MUST NOT** be advertised by a",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "crates/virtio-accel-proto/tests/semantic_interop.rs"
+        ],
+        "issues": [
+          "#20",
+          "#25"
+        ],
+        "rationale": "Every payload layout and scalar invariant is cross-decoded; live-object and advertised-quota checks are tracked."
+      }
+    },
+    {
+      "id": "REQ-WIRE-580C3DD285D4",
+      "source": "docs/wire-abi.md",
+      "line": 213,
       "section": "5. Opcodes and payloads",
       "keyword": "MUST",
       "statement": "`CreateContextRequest` is eight bytes: `flags: u32` followed by `reserved: u32`. Both fields **MUST**",
@@ -1574,9 +1842,29 @@
       }
     },
     {
-      "id": "REQ-WIRE-83B1B42B6991",
+      "id": "REQ-WIRE-4EAD37AC39A4",
       "source": "docs/wire-abi.md",
-      "line": 220,
+      "line": 232,
+      "section": "5. Opcodes and payloads",
+      "keyword": "MUST",
+      "statement": "The device **MUST** reject a memory domain whose corresponding semantic capability is absent before",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "crates/virtio-accel-proto/tests/semantic_interop.rs"
+        ],
+        "issues": [
+          "#20",
+          "#25"
+        ],
+        "rationale": "Every payload layout and scalar invariant is cross-decoded; live-object and advertised-quota checks are tracked."
+      }
+    },
+    {
+      "id": "REQ-WIRE-87BB31FD5813",
+      "source": "docs/wire-abi.md",
+      "line": 238,
       "section": "5. Opcodes and payloads",
       "keyword": "MUST",
       "statement": "`TransferBufferRequest` is 24 bytes containing `buffer_id`, `offset`, and `bytes`. `bytes` **MUST**",
@@ -1594,9 +1882,9 @@
       }
     },
     {
-      "id": "REQ-WIRE-AB348136DD8D",
+      "id": "REQ-WIRE-E017FD0EEA20",
       "source": "docs/wire-abi.md",
-      "line": 221,
+      "line": 239,
       "section": "5. Opcodes and payloads",
       "keyword": "MUST NOT",
       "statement": "be nonzero. `offset + bytes` **MUST NOT** overflow and **MUST** fit in the buffer.",
@@ -1614,9 +1902,9 @@
       }
     },
     {
-      "id": "REQ-WIRE-49564F60EF8C",
+      "id": "REQ-WIRE-271DD2086E42",
       "source": "docs/wire-abi.md",
-      "line": 221,
+      "line": 239,
       "section": "5. Opcodes and payloads",
       "keyword": "MUST",
       "statement": "be nonzero. `offset + bytes` **MUST NOT** overflow and **MUST** fit in the buffer.",
@@ -1634,9 +1922,9 @@
       }
     },
     {
-      "id": "REQ-WIRE-AC75C61B84D8",
+      "id": "REQ-WIRE-8008071E0526",
       "source": "docs/wire-abi.md",
-      "line": 223,
+      "line": 241,
       "section": "5. Opcodes and payloads",
       "keyword": "MUST",
       "statement": "For `WRITE_BUFFER`, the request payload length **MUST** be `24 + bytes`, and bytes following the",
@@ -1654,9 +1942,9 @@
       }
     },
     {
-      "id": "REQ-WIRE-A70C3D08E0BB",
+      "id": "REQ-WIRE-4EF44E350137",
       "source": "docs/wire-abi.md",
-      "line": 241,
+      "line": 263,
       "section": "5. Opcodes and payloads",
       "keyword": "MUST",
       "statement": "`80 + payload_bytes` **MUST** fit the request payload and configured frame limit.",
@@ -1674,9 +1962,9 @@
       }
     },
     {
-      "id": "REQ-WIRE-43560D158BB8",
+      "id": "REQ-WIRE-9444BF78467A",
       "source": "docs/wire-abi.md",
-      "line": 246,
+      "line": 268,
       "section": "5. Opcodes and payloads",
       "keyword": "MUST",
       "statement": "reserved words **MUST** be zero in protocol 1.0.",
@@ -1694,9 +1982,9 @@
       }
     },
     {
-      "id": "REQ-WIRE-5E3A3B34D5A7",
+      "id": "REQ-WIRE-F9B8603BE34B",
       "source": "docs/wire-abi.md",
-      "line": 253,
+      "line": 275,
       "section": "5. Opcodes and payloads",
       "keyword": "MUST",
       "statement": "- `binding_count` **MUST** be 1 through both advertised `max_bindings_per_submission` and 4096.",
@@ -1714,9 +2002,9 @@
       }
     },
     {
-      "id": "REQ-WIRE-3DB7CD56ECB9",
+      "id": "REQ-WIRE-47AC091DB502",
       "source": "docs/wire-abi.md",
-      "line": 254,
+      "line": 276,
       "section": "5. Opcodes and payloads",
       "keyword": "MUST",
       "statement": "- `flags` **MUST** be zero.",
@@ -1734,9 +2022,9 @@
       }
     },
     {
-      "id": "REQ-WIRE-372ACF609966",
+      "id": "REQ-WIRE-219F0562BE70",
       "source": "docs/wire-abi.md",
-      "line": 256,
+      "line": 278,
       "section": "5. Opcodes and payloads",
       "keyword": "MUST",
       "statement": "- The payload length **MUST** be `32 + binding_count * 32`.",
@@ -1754,9 +2042,9 @@
       }
     },
     {
-      "id": "REQ-WIRE-2A6C55913B50",
+      "id": "REQ-WIRE-6E7783E86053",
       "source": "docs/wire-abi.md",
-      "line": 301,
+      "line": 323,
       "section": "7. Response atomicity",
       "keyword": "MUST",
       "statement": "Before backend invocation, the device **MUST** validate the complete readable frame and enough",
@@ -1773,9 +2061,9 @@
       }
     },
     {
-      "id": "REQ-WIRE-9A07069A80BA",
+      "id": "REQ-WIRE-464698253A6B",
       "source": "docs/wire-abi.md",
-      "line": 302,
+      "line": 324,
       "section": "7. Response atomicity",
       "keyword": "MUST",
       "statement": "writable capacity for every possible response shape of that command. It **MUST** initialize every",
@@ -1792,9 +2080,9 @@
       }
     },
     {
-      "id": "REQ-WIRE-F97FF8EB6E93",
+      "id": "REQ-WIRE-38CDAB01C914",
       "source": "docs/wire-abi.md",
-      "line": 306,
+      "line": 328,
       "section": "7. Response atomicity",
       "keyword": "MUST",
       "statement": "occurs after semantic mutation, or a release becomes indeterminate, the device **MUST** enter",
@@ -1811,9 +2099,9 @@
       }
     },
     {
-      "id": "REQ-WIRE-236296B59AB4",
+      "id": "REQ-WIRE-50389481EBC0",
       "source": "docs/wire-abi.md",
-      "line": 307,
+      "line": 329,
       "section": "7. Response atomicity",
       "keyword": "MUST NOT",
       "statement": "recovery and expose the Virtio `DEVICE_NEEDS_RESET` condition. It **MUST NOT** report an ordinary",
@@ -1830,9 +2118,9 @@
       }
     },
     {
-      "id": "REQ-WIRE-CEF7A35F46A4",
+      "id": "REQ-WIRE-C6BCD8DA20D3",
       "source": "docs/wire-abi.md",
-      "line": 321,
+      "line": 343,
       "section": "9. Candidate and post-freeze change procedure",
       "keyword": "MUST",
       "statement": "A proposed wire change **MUST** be classified before code is merged:",
@@ -1849,9 +2137,9 @@
       }
     },
     {
-      "id": "REQ-WIRE-A595D1D65047",
+      "id": "REQ-WIRE-0AD257A3D59E",
       "source": "docs/wire-abi.md",
-      "line": 334,
+      "line": 356,
       "section": "9. Candidate and post-freeze change procedure",
       "keyword": "MUST",
       "statement": "The same reviewed change **MUST** update the normative documents, Rust constants/layout assertions,",

--- a/crates/virtio-accel-core/src/lib.rs
+++ b/crates/virtio-accel-core/src/lib.rs
@@ -63,11 +63,28 @@ bitflags! {
     /// capability would change descriptor framing or any other device/driver protocol behavior.
     #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
     pub struct Capabilities: u64 {
+        /// Supports [`MemoryDomain::Host`] allocations.
         const HOST_VISIBLE_MEMORY = 1 << 0;
+        /// Supports [`MemoryDomain::Device`] allocations.
         const DEVICE_LOCAL_MEMORY = 1 << 1;
         const EVENT_CANCELLATION = 1 << 2;
+        /// Reserved for post-v1 external-allocation import/export semantics.
         const EXTERNAL_MEMORY = 1 << 3;
+        /// Reserved until secure-context isolation requirements are specified.
         const SECURE_CONTEXTS = 1 << 4;
+        /// Supports provider-owned [`MemoryDomain::Shared`] allocations.
+        const SHARED_MEMORY = 1 << 5;
+    }
+}
+
+impl Capabilities {
+    /// Whether the backend can allocate the requested provider-owned memory domain.
+    pub const fn supports_memory_domain(self, domain: MemoryDomain) -> bool {
+        match domain {
+            MemoryDomain::Host => self.contains(Self::HOST_VISIBLE_MEMORY),
+            MemoryDomain::Device => self.contains(Self::DEVICE_LOCAL_MEMORY),
+            MemoryDomain::Shared => self.contains(Self::SHARED_MEMORY),
+        }
     }
 }
 
@@ -113,8 +130,19 @@ pub struct ContextDesc {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]
 pub enum MemoryDomain {
+    /// Provider memory optimized for host transfers.
+    ///
+    /// If the usage includes program access, the returned allocation is still directly bindable;
+    /// this value never permits per-submission staging.
     Host = 1,
+    /// Provider memory optimized for accelerator access.
+    ///
+    /// Explicit read/write transfers may stage through provider-owned temporary memory.
     Device = 2,
+    /// One provider-owned allocation that is host visible and directly accelerator bindable.
+    ///
+    /// This does not imply cross-process export, guest-memory import, cache coherence, or any
+    /// platform external-memory handle.
     Shared = 3,
 }
 
@@ -134,7 +162,9 @@ impl TryFrom<u8> for MemoryDomain {
 bitflags! {
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]
     pub struct BufferUsage: u32 {
+        /// The buffer may be the source of an explicit [`Accelerator::read_buffer`] transfer.
         const TRANSFER_SOURCE = 1 << 0;
+        /// The buffer may be the destination of an explicit [`Accelerator::write_buffer`] transfer.
         const TRANSFER_DESTINATION = 1 << 1;
         const PROGRAM_INPUT = 1 << 2;
         const PROGRAM_OUTPUT = 1 << 3;
@@ -159,7 +189,10 @@ impl BufferDesc {
     ) -> Result<Self, BackendError> {
         let bytes = NonZeroU64::new(bytes).ok_or(BackendError::InvalidArgument)?;
         let alignment = NonZeroU64::new(alignment).ok_or(BackendError::InvalidArgument)?;
-        if !alignment.get().is_power_of_two() {
+        if !alignment.get().is_power_of_two()
+            || usage.is_empty()
+            || !BufferUsage::all().contains(usage)
+        {
             return Err(BackendError::InvalidArgument);
         }
         Ok(Self {
@@ -176,6 +209,161 @@ impl BufferDesc {
 
     pub const fn alignment(self) -> u64 {
         self.alignment.get()
+    }
+
+    /// Whether this allocation can appear in a program binding.
+    pub const fn is_program_visible(self) -> bool {
+        self.usage.intersects(
+            BufferUsage::PROGRAM_INPUT
+                .union(BufferUsage::PROGRAM_OUTPUT)
+                .union(BufferUsage::MUTABLE_STATE),
+        )
+    }
+}
+
+bitflags! {
+    /// Properties of the actual provider allocation returned for a [`BufferDesc`].
+    ///
+    /// These properties describe the backing allocation, not an aspirational fast path. A backend
+    /// must reject allocation rather than advertise a property that it can satisfy only by
+    /// allocating and copying a full-size bounce buffer during submission.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    pub struct BufferProperties: u32 {
+        /// The provider can access the allocation through a host mapping.
+        const HOST_VISIBLE = 1 << 0;
+        /// The allocation uses the provider's accelerator-local placement class.
+        const DEVICE_LOCAL = 1 << 1;
+        /// Compatible program submissions bind this exact allocation without copying the bound
+        /// byte range into or out of a different allocation.
+        const DIRECT_BINDING = 1 << 2;
+    }
+}
+
+/// Verified properties of one provider allocation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct BufferInfo {
+    desc: BufferDesc,
+    allocation_bytes: NonZeroU64,
+    alignment: NonZeroU64,
+    properties: BufferProperties,
+}
+
+impl BufferInfo {
+    /// Validate that actual allocation properties honestly satisfy the requested descriptor.
+    pub fn new(
+        desc: BufferDesc,
+        allocation_bytes: u64,
+        alignment: u64,
+        properties: BufferProperties,
+    ) -> Result<Self, BackendError> {
+        let allocation_bytes =
+            NonZeroU64::new(allocation_bytes).ok_or(BackendError::InvalidArgument)?;
+        let alignment = NonZeroU64::new(alignment).ok_or(BackendError::InvalidArgument)?;
+        if !BufferProperties::all().contains(properties) {
+            return Err(BackendError::InvalidArgument);
+        }
+        if allocation_bytes.get() < desc.bytes()
+            || !alignment.get().is_power_of_two()
+            || alignment.get() < desc.alignment()
+        {
+            return Err(BackendError::Incompatible);
+        }
+
+        let required = match desc.domain {
+            MemoryDomain::Host => BufferProperties::HOST_VISIBLE,
+            MemoryDomain::Device => BufferProperties::DEVICE_LOCAL,
+            MemoryDomain::Shared => {
+                BufferProperties::HOST_VISIBLE.union(BufferProperties::DIRECT_BINDING)
+            }
+        };
+        if !properties.contains(required)
+            || (desc.is_program_visible() && !properties.contains(BufferProperties::DIRECT_BINDING))
+        {
+            return Err(BackendError::Incompatible);
+        }
+
+        Ok(Self {
+            desc,
+            allocation_bytes,
+            alignment,
+            properties,
+        })
+    }
+
+    pub const fn desc(self) -> BufferDesc {
+        self.desc
+    }
+
+    /// Physical/provider backing bytes retained for this logical buffer.
+    pub const fn allocation_bytes(self) -> u64 {
+        self.allocation_bytes.get()
+    }
+
+    /// Alignment guaranteed by the actual provider allocation.
+    pub const fn alignment(self) -> u64 {
+        self.alignment.get()
+    }
+
+    pub const fn properties(self) -> BufferProperties {
+        self.properties
+    }
+}
+
+impl DeviceInfo {
+    /// Validate allocation size and memory-domain support before backend invocation.
+    pub fn validate_buffer_desc(self, desc: BufferDesc) -> Result<(), BackendError> {
+        if desc.bytes() > self.limits.max_buffer_bytes {
+            return Err(BackendError::ResourceLimit);
+        }
+        if !self.capabilities.supports_memory_domain(desc.domain) {
+            return Err(BackendError::Unsupported);
+        }
+        Ok(())
+    }
+
+    /// Validate that a backend allocation describes the request it was asked to satisfy.
+    pub fn validate_buffer_info(
+        self,
+        requested: BufferDesc,
+        actual: BufferInfo,
+    ) -> Result<(), BackendError> {
+        self.validate_buffer_desc(requested)?;
+        if actual.desc() != requested {
+            return Err(BackendError::Incompatible);
+        }
+        Ok(())
+    }
+}
+
+/// A newly allocated native buffer handle and its verified backing properties.
+///
+/// Device implementations should retain `info` in their object record and pass only `buffer` to
+/// backend hot paths.
+#[derive(Debug)]
+pub struct AllocatedBuffer<B> {
+    buffer: B,
+    info: BufferInfo,
+}
+
+impl<B> AllocatedBuffer<B> {
+    pub const fn new(buffer: B, info: BufferInfo) -> Self {
+        Self { buffer, info }
+    }
+
+    pub const fn buffer(&self) -> &B {
+        &self.buffer
+    }
+
+    pub fn buffer_mut(&mut self) -> &mut B {
+        &mut self.buffer
+    }
+
+    pub const fn info(&self) -> BufferInfo {
+        self.info
+    }
+
+    pub fn into_parts(self) -> (B, BufferInfo) {
+        (self.buffer, self.info)
     }
 }
 
@@ -224,6 +412,123 @@ impl TryFrom<u8> for AccessMode {
     }
 }
 
+/// A bounded byte source that may be physically segmented.
+///
+/// Transport adapters can implement this trait over validated descriptor-backed regions so
+/// providers can read directly into final program or buffer storage without first coalescing the
+/// complete payload. Every range fully contained in `0..len()` must be readable for the duration of
+/// the backend call. The optional contiguous view preserves the single-slice fast path.
+pub trait ByteSource: fmt::Debug {
+    /// Stable logical length of this source.
+    fn len(&self) -> u64;
+
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Fill `target` from the exact logical range beginning at `offset`.
+    fn read_at(&self, offset: u64, target: &mut [u8]) -> Result<(), BackendError>;
+
+    /// Borrow the complete logical source when it is one contiguous region.
+    ///
+    /// A returned slice has length [`Self::len`] and contains the same bytes as `read_at`.
+    fn as_contiguous(&self) -> Option<&[u8]> {
+        None
+    }
+}
+
+impl ByteSource for [u8] {
+    fn len(&self) -> u64 {
+        self.len() as u64
+    }
+
+    fn read_at(&self, offset: u64, target: &mut [u8]) -> Result<(), BackendError> {
+        let start = usize::try_from(offset).map_err(|_| BackendError::OutOfBounds)?;
+        let end = start
+            .checked_add(target.len())
+            .filter(|end| *end <= self.len())
+            .ok_or(BackendError::OutOfBounds)?;
+        target.copy_from_slice(&self[start..end]);
+        Ok(())
+    }
+
+    fn as_contiguous(&self) -> Option<&[u8]> {
+        Some(self)
+    }
+}
+
+impl<const N: usize> ByteSource for [u8; N] {
+    fn len(&self) -> u64 {
+        N as u64
+    }
+
+    fn read_at(&self, offset: u64, target: &mut [u8]) -> Result<(), BackendError> {
+        self.as_slice().read_at(offset, target)
+    }
+
+    fn as_contiguous(&self) -> Option<&[u8]> {
+        Some(self)
+    }
+}
+
+/// A bounded byte destination that may be physically segmented.
+///
+/// Providers can write buffer contents directly into validated response regions. The optional
+/// contiguous view avoids callback overhead when the destination is already one slice. Every range
+/// fully contained in `0..len()` must be writable for the duration of the backend call.
+pub trait ByteSink: fmt::Debug {
+    /// Stable logical length of this destination.
+    fn len(&self) -> u64;
+
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Write `source` to the exact logical range beginning at `offset`.
+    fn write_at(&mut self, offset: u64, source: &[u8]) -> Result<(), BackendError>;
+
+    /// Mutably borrow the complete logical destination when it is one contiguous region.
+    ///
+    /// A returned slice has length [`Self::len`] and represents the same bytes as `write_at`.
+    fn as_contiguous_mut(&mut self) -> Option<&mut [u8]> {
+        None
+    }
+}
+
+impl ByteSink for [u8] {
+    fn len(&self) -> u64 {
+        self.len() as u64
+    }
+
+    fn write_at(&mut self, offset: u64, source: &[u8]) -> Result<(), BackendError> {
+        let start = usize::try_from(offset).map_err(|_| BackendError::OutOfBounds)?;
+        let end = start
+            .checked_add(source.len())
+            .filter(|end| *end <= self.len())
+            .ok_or(BackendError::OutOfBounds)?;
+        self[start..end].copy_from_slice(source);
+        Ok(())
+    }
+
+    fn as_contiguous_mut(&mut self) -> Option<&mut [u8]> {
+        Some(self)
+    }
+}
+
+impl<const N: usize> ByteSink for [u8; N] {
+    fn len(&self) -> u64 {
+        N as u64
+    }
+
+    fn write_at(&mut self, offset: u64, source: &[u8]) -> Result<(), BackendError> {
+        self.as_mut_slice().write_at(offset, source)
+    }
+
+    fn as_contiguous_mut(&mut self) -> Option<&mut [u8]> {
+        Some(self)
+    }
+}
+
 /// Opaque, provider-owned executable format identifier.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(transparent)]
@@ -247,11 +552,15 @@ impl ArtifactFormat {
 #[repr(transparent)]
 pub struct TargetIdentity(pub [u32; 12]);
 
+/// Borrowed program artifact envelope.
+///
+/// Payload bytes may be segmented; providers should stream them into final resident storage or use
+/// [`ByteSource::as_contiguous`] when a borrowed slice is available.
 #[derive(Clone, Copy, Debug)]
 pub struct ArtifactRef<'a> {
     pub format: ArtifactFormat,
     pub target: TargetIdentity,
-    pub payload: &'a [u8],
+    pub payload: &'a dyn ByteSource,
     pub resident_bytes: u64,
 }
 
@@ -295,6 +604,10 @@ impl Timeout {
 }
 
 /// One validated binding. The referenced buffer must remain alive until its event is reclaimed.
+///
+/// Program-visible buffers carry [`BufferProperties::DIRECT_BINDING`]. A backend must reject an
+/// incompatible buffer/program combination instead of copying the range into a hidden bounce
+/// allocation.
 #[derive(Debug)]
 pub struct BindingRef<'a, B> {
     pub slot: u32,
@@ -360,6 +673,11 @@ impl<R> ReleaseFailure<R> {
 /// Destructive methods consume handles. A transport adapter must reject parent destruction while
 /// child objects or in-flight events still exist; it must not use `Drop` timing as protocol state.
 ///
+/// The only baseline operations that explicitly transfer buffer contents are [`Self::write_buffer`]
+/// and [`Self::read_buffer`]. Allocation, submission, polling, and release must not hide full-range
+/// staging copies. In particular, `submit` binds the provider allocation directly or rejects it as
+/// [`BackendError::Incompatible`].
+///
 /// [`Self::Queue`] is an accelerator execution queue. It must not be confused with the command
 /// virtqueue used by a transport adapter to deliver protocol requests.
 pub trait Accelerator {
@@ -377,18 +695,29 @@ pub trait Accelerator {
         &self,
         context: &Self::Context,
         desc: BufferDesc,
-    ) -> Result<Self::Buffer, BackendError>;
+    ) -> Result<AllocatedBuffer<Self::Buffer>, BackendError>;
+    /// Perform one explicit host-to-buffer transfer.
+    ///
+    /// The command engine calls this only for buffers with [`BufferUsage::TRANSFER_DESTINATION`].
+    /// The provider must not retain `data`. A segmented source should be read directly into final
+    /// backing rather than coalesced. Host-visible allocations should copy directly into their
+    /// final backing; device-local allocations may use bounded temporary staging during this
+    /// explicit transfer.
     fn write_buffer(
         &self,
-        buffer: &Self::Buffer,
+        buffer: &mut Self::Buffer,
         offset: u64,
-        data: &[u8],
+        data: &dyn ByteSource,
     ) -> Result<(), BackendError>;
+    /// Perform one explicit buffer-to-host transfer.
+    ///
+    /// The command engine calls this only for buffers with [`BufferUsage::TRANSFER_SOURCE`]. The
+    /// provider must not retain `data` and should write directly across segmented destinations.
     fn read_buffer(
         &self,
         buffer: &Self::Buffer,
         offset: u64,
-        data: &mut [u8],
+        data: &mut dyn ByteSink,
     ) -> Result<(), BackendError>;
     fn free_buffer(&self, buffer: Self::Buffer) -> Result<(), ReleaseFailure<Self::Buffer>>;
 
@@ -427,13 +756,66 @@ mod tests {
     #[test]
     fn buffer_descriptors_reject_invalid_alignment() {
         assert!(BufferDesc::new(1, 0, MemoryDomain::Host, BufferUsage::empty()).is_err());
-        assert!(BufferDesc::new(1, 3, MemoryDomain::Host, BufferUsage::empty()).is_err());
+        assert!(BufferDesc::new(1, 3, MemoryDomain::Host, BufferUsage::TRANSFER_SOURCE).is_err());
+        assert!(BufferDesc::new(1, 1, MemoryDomain::Host, BufferUsage::empty()).is_err());
         assert_eq!(
             BufferDesc::new(64, 16, MemoryDomain::Shared, BufferUsage::PROGRAM_INPUT)
                 .unwrap()
                 .alignment(),
             16
         );
+    }
+
+    #[test]
+    fn allocation_properties_reject_hidden_submission_staging() {
+        let host_input =
+            BufferDesc::new(64, 16, MemoryDomain::Host, BufferUsage::PROGRAM_INPUT).unwrap();
+        assert_eq!(
+            BufferInfo::new(host_input, 64, 16, BufferProperties::HOST_VISIBLE),
+            Err(BackendError::Incompatible)
+        );
+        assert!(
+            BufferInfo::new(
+                host_input,
+                64,
+                16,
+                BufferProperties::HOST_VISIBLE | BufferProperties::DIRECT_BINDING
+            )
+            .is_ok()
+        );
+
+        let shared =
+            BufferDesc::new(64, 16, MemoryDomain::Shared, BufferUsage::TRANSFER_SOURCE).unwrap();
+        assert_eq!(
+            BufferInfo::new(shared, 64, 16, BufferProperties::HOST_VISIBLE),
+            Err(BackendError::Incompatible)
+        );
+        assert_eq!(
+            BufferInfo::new(
+                shared,
+                63,
+                16,
+                BufferProperties::HOST_VISIBLE | BufferProperties::DIRECT_BINDING
+            ),
+            Err(BackendError::Incompatible)
+        );
+        assert_eq!(
+            BufferInfo::new(
+                shared,
+                64,
+                8,
+                BufferProperties::HOST_VISIBLE | BufferProperties::DIRECT_BINDING
+            ),
+            Err(BackendError::Incompatible)
+        );
+    }
+
+    #[test]
+    fn capabilities_report_memory_domains_independently() {
+        let capabilities = Capabilities::HOST_VISIBLE_MEMORY | Capabilities::SHARED_MEMORY;
+        assert!(capabilities.supports_memory_domain(MemoryDomain::Host));
+        assert!(capabilities.supports_memory_domain(MemoryDomain::Shared));
+        assert!(!capabilities.supports_memory_domain(MemoryDomain::Device));
     }
 
     #[test]

--- a/crates/virtio-accel-mock/src/lib.rs
+++ b/crates/virtio-accel-mock/src/lib.rs
@@ -5,13 +5,14 @@
 
 #![forbid(unsafe_code)]
 
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU8, AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
 use std::vec::Vec;
 use virtio_accel_core::{
-    Accelerator, AcceleratorClass, ArtifactFormat, ArtifactRef, BackendError, BindingRef,
-    BufferDesc, Capabilities, ContextDesc, DeviceIdentity, DeviceInfo, DeviceLimits, EventState,
-    QueueDesc, ReleaseFailure, SubmitFailure, TargetIdentity, Timeout, validate_bindings,
+    Accelerator, AcceleratorClass, AllocatedBuffer, ArtifactFormat, ArtifactRef, BackendError,
+    BindingRef, BufferDesc, BufferInfo, BufferProperties, ByteSink, ByteSource, Capabilities,
+    ContextDesc, DeviceIdentity, DeviceInfo, DeviceLimits, EventState, MemoryDomain, QueueDesc,
+    ReleaseFailure, SubmitFailure, TargetIdentity, Timeout, validate_bindings,
 };
 
 const EVENT_PENDING: u8 = 0;
@@ -23,11 +24,11 @@ pub struct MockContext {
     id: u64,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct MockBuffer {
     context_id: u64,
     desc: BufferDesc,
-    data: Arc<Mutex<Vec<u8>>>,
+    data: Vec<u8>,
 }
 
 #[derive(Clone, Debug)]
@@ -80,6 +81,7 @@ impl Default for MockAccelerator {
                 },
                 capabilities: Capabilities::HOST_VISIBLE_MEMORY
                     | Capabilities::DEVICE_LOCAL_MEMORY
+                    | Capabilities::SHARED_MEMORY
                     | Capabilities::EVENT_CANCELLATION,
                 limits: DeviceLimits {
                     max_contexts: 64,
@@ -160,31 +162,59 @@ impl Accelerator for MockAccelerator {
         &self,
         context: &Self::Context,
         desc: BufferDesc,
-    ) -> Result<Self::Buffer, BackendError> {
-        if desc.bytes() > self.info.limits.max_buffer_bytes {
-            return Err(BackendError::ResourceLimit);
-        }
+    ) -> Result<AllocatedBuffer<Self::Buffer>, BackendError> {
+        self.info.validate_buffer_desc(desc)?;
+        let properties = match desc.domain {
+            MemoryDomain::Host => BufferProperties::HOST_VISIBLE,
+            MemoryDomain::Device => BufferProperties::DEVICE_LOCAL,
+            MemoryDomain::Shared => BufferProperties::HOST_VISIBLE,
+        } | if desc.is_program_visible() || desc.domain == MemoryDomain::Shared {
+            BufferProperties::DIRECT_BINDING
+        } else {
+            BufferProperties::empty()
+        };
+        let info = BufferInfo::new(desc, desc.bytes(), desc.alignment(), properties)?;
         let bytes = usize::try_from(desc.bytes()).map_err(|_| BackendError::OutOfMemory)?;
         let mut data = Vec::new();
         data.try_reserve_exact(bytes)
             .map_err(|_| BackendError::OutOfMemory)?;
         data.resize(bytes, 0);
-        Ok(MockBuffer {
-            context_id: context.id,
-            desc,
-            data: Arc::new(Mutex::new(data)),
-        })
+        Ok(AllocatedBuffer::new(
+            MockBuffer {
+                context_id: context.id,
+                desc,
+                data,
+            },
+            info,
+        ))
     }
 
     fn write_buffer(
         &self,
-        buffer: &Self::Buffer,
+        buffer: &mut Self::Buffer,
         offset: u64,
-        data: &[u8],
+        data: &dyn ByteSource,
     ) -> Result<(), BackendError> {
-        let mut target = buffer.data.lock().map_err(|_| BackendError::DeviceLost)?;
-        let range = Self::checked_range(target.len(), offset, data.len())?;
-        target[range].copy_from_slice(data);
+        if !buffer
+            .desc
+            .usage
+            .contains(virtio_accel_core::BufferUsage::TRANSFER_DESTINATION)
+        {
+            return Err(BackendError::PermissionDenied);
+        }
+        let bytes = usize::try_from(data.len()).map_err(|_| BackendError::OutOfBounds)?;
+        if bytes == 0 {
+            return Err(BackendError::InvalidArgument);
+        }
+        let range = Self::checked_range(buffer.data.len(), offset, bytes)?;
+        if let Some(source) = data.as_contiguous() {
+            if source.len() != bytes {
+                return Err(BackendError::InvalidArgument);
+            }
+            buffer.data[range].copy_from_slice(source);
+        } else {
+            data.read_at(0, &mut buffer.data[range])?;
+        }
         Ok(())
     }
 
@@ -192,11 +222,28 @@ impl Accelerator for MockAccelerator {
         &self,
         buffer: &Self::Buffer,
         offset: u64,
-        data: &mut [u8],
+        data: &mut dyn ByteSink,
     ) -> Result<(), BackendError> {
-        let source = buffer.data.lock().map_err(|_| BackendError::DeviceLost)?;
-        let range = Self::checked_range(source.len(), offset, data.len())?;
-        data.copy_from_slice(&source[range]);
+        if !buffer
+            .desc
+            .usage
+            .contains(virtio_accel_core::BufferUsage::TRANSFER_SOURCE)
+        {
+            return Err(BackendError::PermissionDenied);
+        }
+        let bytes = usize::try_from(data.len()).map_err(|_| BackendError::OutOfBounds)?;
+        if bytes == 0 {
+            return Err(BackendError::InvalidArgument);
+        }
+        let range = Self::checked_range(buffer.data.len(), offset, bytes)?;
+        if let Some(target) = data.as_contiguous_mut() {
+            if target.len() != bytes {
+                return Err(BackendError::InvalidArgument);
+            }
+            target.copy_from_slice(&buffer.data[range]);
+        } else {
+            data.write_at(0, &buffer.data[range])?;
+        }
         Ok(())
     }
 
@@ -209,14 +256,16 @@ impl Accelerator for MockAccelerator {
         context: &Self::Context,
         artifact: ArtifactRef<'_>,
     ) -> Result<Self::Program, BackendError> {
-        if artifact.payload.len() as u64 > self.info.limits.max_artifact_bytes {
+        if artifact.payload.len() > self.info.limits.max_artifact_bytes {
             return Err(BackendError::ResourceLimit);
         }
+        let payload_bytes =
+            usize::try_from(artifact.payload.len()).map_err(|_| BackendError::ResourceLimit)?;
         Ok(MockProgram {
             context_id: context.id,
             format: artifact.format,
             target: artifact.target,
-            payload_bytes: artifact.payload.len(),
+            payload_bytes,
         })
     }
 
@@ -303,25 +352,94 @@ impl Accelerator for MockAccelerator {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use virtio_accel_core::{AccessMode, BindingRef, BufferRange, BufferUsage, MemoryDomain};
+    use virtio_accel_core::{AccessMode, BindingRef, BufferRange, BufferUsage};
+
+    #[derive(Debug)]
+    struct SplitSource<'a> {
+        first: &'a [u8],
+        second: &'a [u8],
+    }
+
+    impl ByteSource for SplitSource<'_> {
+        fn len(&self) -> u64 {
+            (self.first.len() + self.second.len()) as u64
+        }
+
+        fn read_at(&self, offset: u64, target: &mut [u8]) -> Result<(), BackendError> {
+            let start = usize::try_from(offset).map_err(|_| BackendError::OutOfBounds)?;
+            let end = start
+                .checked_add(target.len())
+                .filter(|end| *end <= self.first.len() + self.second.len())
+                .ok_or(BackendError::OutOfBounds)?;
+            for (segment_start, segment) in [(0, self.first), (self.first.len(), self.second)] {
+                let overlap_start = start.max(segment_start);
+                let overlap_end = end.min(segment_start + segment.len());
+                if overlap_start < overlap_end {
+                    target[overlap_start - start..overlap_end - start].copy_from_slice(
+                        &segment[overlap_start - segment_start..overlap_end - segment_start],
+                    );
+                }
+            }
+            Ok(())
+        }
+    }
+
+    #[derive(Debug)]
+    struct SplitSink<'a> {
+        first: &'a mut [u8],
+        second: &'a mut [u8],
+    }
+
+    impl ByteSink for SplitSink<'_> {
+        fn len(&self) -> u64 {
+            (self.first.len() + self.second.len()) as u64
+        }
+
+        fn write_at(&mut self, offset: u64, source: &[u8]) -> Result<(), BackendError> {
+            let start = usize::try_from(offset).map_err(|_| BackendError::OutOfBounds)?;
+            let end = start
+                .checked_add(source.len())
+                .filter(|end| *end <= self.first.len() + self.second.len())
+                .ok_or(BackendError::OutOfBounds)?;
+            let first_len = self.first.len();
+            for (segment_start, segment) in [(0, &mut *self.first), (first_len, &mut *self.second)]
+            {
+                let overlap_start = start.max(segment_start);
+                let overlap_end = end.min(segment_start + segment.len());
+                if overlap_start < overlap_end {
+                    segment[overlap_start - segment_start..overlap_end - segment_start]
+                        .copy_from_slice(&source[overlap_start - start..overlap_end - start]);
+                }
+            }
+            Ok(())
+        }
+    }
 
     #[test]
     fn reference_backend_exercises_the_complete_lifecycle() {
         let backend = MockAccelerator::default();
         let context = backend.create_context(ContextDesc::default()).unwrap();
-        let buffer = backend
-            .allocate_buffer(
-                &context,
-                BufferDesc::new(
-                    16,
-                    8,
-                    MemoryDomain::Shared,
-                    BufferUsage::TRANSFER_SOURCE | BufferUsage::PROGRAM_INPUT,
-                )
-                .unwrap(),
-            )
-            .unwrap();
-        backend.write_buffer(&buffer, 4, &[1, 2, 3, 4]).unwrap();
+        let desc = BufferDesc::new(
+            16,
+            8,
+            MemoryDomain::Shared,
+            BufferUsage::TRANSFER_SOURCE
+                | BufferUsage::TRANSFER_DESTINATION
+                | BufferUsage::PROGRAM_INPUT,
+        )
+        .unwrap();
+        let allocation = backend.allocate_buffer(&context, desc).unwrap();
+        assert_eq!(allocation.info().desc(), desc);
+        assert_eq!(allocation.info().allocation_bytes(), 16);
+        assert_eq!(allocation.info().alignment(), 8);
+        assert!(
+            allocation
+                .info()
+                .properties()
+                .contains(BufferProperties::DIRECT_BINDING)
+        );
+        let (mut buffer, _) = allocation.into_parts();
+        backend.write_buffer(&mut buffer, 4, &[1, 2, 3, 4]).unwrap();
         let mut output = [0; 4];
         backend.read_buffer(&buffer, 4, &mut output).unwrap();
         assert_eq!(output, [1, 2, 3, 4]);
@@ -371,16 +489,75 @@ mod tests {
     }
 
     #[test]
+    fn explicit_transfers_enforce_declared_direction() {
+        let backend = MockAccelerator::default();
+        let context = backend.create_context(ContextDesc::default()).unwrap();
+        let allocation = backend
+            .allocate_buffer(
+                &context,
+                BufferDesc::new(4, 1, MemoryDomain::Host, BufferUsage::TRANSFER_SOURCE).unwrap(),
+            )
+            .unwrap();
+        let (mut buffer, _) = allocation.into_parts();
+        assert_eq!(
+            backend.write_buffer(&mut buffer, 0, &[1]),
+            Err(BackendError::PermissionDenied)
+        );
+
+        backend.free_buffer(buffer).unwrap();
+        backend.destroy_context(context).unwrap();
+    }
+
+    #[test]
+    fn segmented_transfers_do_not_require_coalescing() {
+        let backend = MockAccelerator::default();
+        let context = backend.create_context(ContextDesc::default()).unwrap();
+        let allocation = backend
+            .allocate_buffer(
+                &context,
+                BufferDesc::new(
+                    4,
+                    1,
+                    MemoryDomain::Host,
+                    BufferUsage::TRANSFER_SOURCE | BufferUsage::TRANSFER_DESTINATION,
+                )
+                .unwrap(),
+            )
+            .unwrap();
+        let (mut buffer, _) = allocation.into_parts();
+
+        let source = SplitSource {
+            first: &[1, 2],
+            second: &[3, 4],
+        };
+        backend.write_buffer(&mut buffer, 0, &source).unwrap();
+
+        let mut first = [0; 1];
+        let mut second = [0; 3];
+        let mut sink = SplitSink {
+            first: &mut first,
+            second: &mut second,
+        };
+        backend.read_buffer(&buffer, 0, &mut sink).unwrap();
+        assert_eq!(first, [1]);
+        assert_eq!(second, [2, 3, 4]);
+
+        backend.free_buffer(buffer).unwrap();
+        backend.destroy_context(context).unwrap();
+    }
+
+    #[test]
     fn cross_context_submission_is_rejected_before_acceptance() {
         let backend = MockAccelerator::default();
         let context_a = backend.create_context(ContextDesc::default()).unwrap();
         let context_b = backend.create_context(ContextDesc::default()).unwrap();
-        let buffer = backend
+        let allocation = backend
             .allocate_buffer(
                 &context_b,
                 BufferDesc::new(1, 1, MemoryDomain::Host, BufferUsage::PROGRAM_INPUT).unwrap(),
             )
             .unwrap();
+        let (buffer, _) = allocation.into_parts();
         let program = backend
             .load_program(
                 &context_a,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -64,6 +64,23 @@ shared mappings, and fences are optional features because their ownership, cache
 synchronization rules differ by transport and host OS. Adding them requires a separate invariant
 and threat-model pass.
 
+Provider-owned shared memory is distinct from external memory. `MemoryDomain::Shared` requests one
+allocation that the provider can access through a host mapping and bind directly for accelerator
+execution. It does not expose a guest address or platform handle and does not imply cross-process
+sharing or implicit cache coherence.
+
+The allocation result reports verified backing properties, actual retained bytes, and actual
+alignment separately from the provider-native handle. Logical buffer bytes may be smaller than a
+page-, section-, or device-aligned backing allocation. The command engine retains those facts in its
+buffer record for compatibility checks and resource accounting, while submission passes only
+borrowed native handles. This lets the device reject a dishonest or degraded allocation before it
+becomes guest-visible without adding metadata lookup or boxing to the execution hot path.
+
+Bulk byte payloads cross the semantic boundary through `ByteSource` and `ByteSink`. Both abstractions
+support checked random access over segmented storage and an optional contiguous view. A command
+engine can therefore expose validated descriptor-backed regions directly: a provider streams them
+into final storage, while an already contiguous payload remains one borrowed slice.
+
 ## Queue model
 
 Command virtqueue zero is the baseline bidirectional transport queue. One descriptor chain contains
@@ -84,9 +101,48 @@ The semantic hot path uses associated handle types and borrowed binding slices, 
 dispatch and per-binding boxing. Wire decoding will operate directly over validated descriptor-backed
 regions. Object lookup is constant time and bounded by advertised limits.
 
-The initial buffer transfer path permits copies because it is the compatibility baseline. Zero-copy
-imports are deliberately deferred rather than pretending that DMA-BUF, Windows shared handles, and
-other mechanisms have identical lifetime or coherency semantics.
+`WRITE_BUFFER` and `READ_BUFFER` are the baseline's explicit content-copy boundaries. Device-local
+memory may require bounded staging during those operations. Allocation, submission, polling, and
+release do not receive permission to copy a bound buffer merely because a native import or binding
+path is inconvenient.
+
+Every buffer declared for program input, output, or mutable state reports
+`BufferProperties::DIRECT_BINDING`. This means a compatible submission binds that exact allocation
+without copying the bound range to or from a different allocation. A backend that cannot honor the
+requested placement and direct-binding contract rejects allocation; a program-specific alignment or
+format mismatch rejects submission as `INCOMPATIBLE`. Neither path may silently degrade to a bounce
+buffer.
+
+The mutable side of an explicit write receives `&mut Buffer`, allowing implementations to use
+ordinary provider handles and mappings rather than forcing interior mutability or a lock into every
+buffer. Submission remains borrowed and allocation-free in the semantic API.
+
+Program artifacts use the same byte-source abstraction. Program loading is a slow lifecycle path,
+so an object-safe source is an acceptable dispatch cost; forcing a frame-sized allocation and copy
+for every segmented artifact is not. Providers can parse a contiguous borrowed artifact in place or
+read segmented bytes directly into final resident storage.
+
+Zero-copy guest-memory imports are deliberately deferred rather than pretending that DMA-BUF,
+Windows shared handles, and other mechanisms have identical lifetime or coherency semantics. When
+external memory is specified, fallback staging will require explicit negotiation and copy
+accounting; it will not weaken the provider-owned direct-binding rule.
+
+### Backend fast-path checklist
+
+A provider implementation should make the native buffer handle own or reference everything needed
+to reuse the allocation efficiently: the final backing object, device address or import, host
+mapping when present, alignment facts, and synchronization state. Native mapping or import setup
+belongs at allocation or another amortized lifecycle boundary, not in every submission.
+
+The intended steady-state submission path is a bounded walk over the borrowed binding slice,
+validation of program-specific compatibility, native handle/address binding, and queue admission. It
+does not allocate per binding, assemble a second binding array with owned payloads, or copy tensor
+contents. Small command and metadata writes are not buffer staging and remain provider-specific.
+
+Issue #29 owns quantitative evidence: explicit-transfer bytes, staged bytes and allocations,
+submission allocations, retained memory, and host preparation versus device execution time. A
+backend should be diagnosable when it misses the intended path rather than requiring a profiler to
+discover an undocumented copy.
 
 ## Next implementation boundary
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -135,6 +135,40 @@ A **buffer** is a bounded backend allocation with:
 The buffer’s guest-visible object ID is not an address. Every transfer and binding range **MUST** fit
 within the buffer without integer overflow.
 
+Memory domains are strict allocation requirements:
+
+- `Host` requests provider memory optimized for host transfers;
+- `Device` requests the provider's accelerator-local placement class; and
+- `Shared` requests one provider-owned allocation that is both host visible and directly bindable
+  by the accelerator.
+
+`Shared` does not mean guest-memory import, cross-process export, a platform shared handle, or
+implicit cache coherence. Those operations require the reserved external-memory feature and have no
+protocol 1.0 semantics.
+
+An allocation result **MUST** report the requested descriptor, actual retained allocation bytes,
+actual guaranteed alignment, and honest backing properties. Actual bytes **MUST NOT** be smaller
+than the logical buffer and actual alignment **MUST NOT** be weaker than requested. Device resource
+accounting uses actual retained bytes rather than assuming logical bytes include provider padding.
+A provider **MUST NOT** return an allocation whose reported placement can be achieved only by
+copying through another full-size allocation during submission.
+
+A buffer whose usage includes program input, program output, or mutable state **MUST** report direct
+binding. A compatible submission **MUST** bind the exact provider allocation without copying the
+bound range into or out of another allocation. If the provider cannot satisfy that invariant, it
+**MUST** reject allocation. If a particular program is incompatible with an otherwise valid buffer,
+submission **MUST** be rejected as `INCOMPATIBLE`; the provider **MUST NOT** silently stage it.
+
+`WRITE_BUFFER` and `READ_BUFFER` are the only baseline operations that explicitly transfer buffer
+contents. A write requires `TRANSFER_DESTINATION`; a read requires `TRANSFER_SOURCE`. Device-local
+memory may use bounded provider staging during these explicit transfers, but no transfer may retain
+the request or response byte region after the backend call returns.
+
+The semantic transfer API accepts bounded byte sources and sinks that may be segmented. This avoids
+requiring the command engine to allocate a contiguous copy of a valid transfer payload or response
+before calling the backend. A contiguous region remains available to providers as an optional fast
+path.
+
 ### 4.5 Program
 
 A **program** is a resident backend object created from an opaque artifact format, opaque target
@@ -142,6 +176,10 @@ identity, payload, and declared resident-byte requirement.
 
 The transport **MUST NOT** interpret vendor artifact contents. Artifact-format adapters own their
 validation beyond the portable envelope fields.
+
+The semantic artifact payload is a bounded byte source rather than a required contiguous slice.
+Providers may inspect an available contiguous view or read segmented payload bytes directly into
+final resident storage.
 
 ### 4.6 Accelerator execution queue
 
@@ -239,14 +277,31 @@ offer a feature it cannot honor if accepted.
 Backend `Capabilities` report whether a semantic operation or resource class is supported. They do
 not independently change wire framing.
 
+Protocol 1.0 assigns these semantic capability bits:
+
+| Bit | Name | Meaning |
+|---:|---|---|
+| 0 | `HOST_VISIBLE_MEMORY` | `MemoryDomain::Host` allocation is supported |
+| 1 | `DEVICE_LOCAL_MEMORY` | `MemoryDomain::Device` allocation is supported |
+| 2 | `EVENT_CANCELLATION` | Pending events may support `CANCEL_EVENT` |
+| 5 | `SHARED_MEMORY` | Provider-owned `MemoryDomain::Shared` allocation is supported |
+
+Semantic bits 3 (`EXTERNAL_MEMORY`) and 4 (`SECURE_CONTEXTS`) are reserved until their transport,
+ownership, synchronization, and isolation rules are specified. A protocol 1.0 device **MUST NOT**
+advertise either bit.
+
+The device **MUST** reject an allocation for an unsupported memory domain before invoking the
+backend. Advertising a memory-domain capability commits the backend to the corresponding allocation
+properties and direct-binding rules from section 4.4; capability reporting is not permission to
+substitute a staged implementation.
+
 If enabling a backend capability would require different descriptor direction, additional queues,
 new synchronization, or changed lifetime rules, the device **MUST** also negotiate an appropriate
 transport feature.
 
-The exact backend meanings of host-visible memory, device-local memory, secure contexts, and
-execution-queue flags are tracked by issue #21. Protocol 1.0 accepts only the wire values explicitly
-listed in [wire-abi.md](wire-abi.md); the reference implementation **MUST NOT** translate an
-underspecified capability into additional wire behavior.
+The exact secure-context and execution-queue-flag semantics remain tracked by issue #21. Protocol
+1.0 accepts only the wire values explicitly listed in [wire-abi.md](wire-abi.md); the reference
+implementation **MUST NOT** translate an underspecified capability into additional wire behavior.
 
 ### 5.4 Request and object flags
 
@@ -395,10 +450,12 @@ model or is identified as an implementation helper.
 | `DeviceLimits` | Context, buffer, program, execution-queue, event, binding, and byte limits enforced before backend invocation |
 | `DeviceInfo` | Device identity, semantic capabilities, and limits |
 | `ContextFlags`, `ContextDesc` | Context creation intent; protocol 1.0 accepts only empty context flags |
-| `MemoryDomain` | Requested buffer placement class |
+| `MemoryDomain` | Strict provider-owned buffer placement requirement |
 | `BufferUsage`, `BufferDesc`, `BufferRange` | Buffer allocation intent and checked byte range |
+| `BufferProperties`, `BufferInfo`, `AllocatedBuffer` | Verified backing properties kept out of the backend hot path |
 | `AccessMode` | Binding read/write intent |
-| `ArtifactFormat`, `TargetIdentity`, `ArtifactRef` | Opaque program artifact description |
+| `ByteSource`, `ByteSink` | Bounded contiguous-or-segmented bulk byte ports |
+| `ArtifactFormat`, `TargetIdentity`, `ArtifactRef` | Opaque program artifact description over a byte source |
 | `QueueFlags`, `QueueDesc` | Accelerator execution-queue creation intent, not a Virtio queue |
 | `Timeout` | Relative admission timeout; zero on wire means infinite |
 | `BindingRef`, `validate_bindings` | Validated semantic binding and implementation helper |

--- a/docs/wire-abi.md
+++ b/docs/wire-abi.md
@@ -196,6 +196,18 @@ Capability bits are semantic reports, not Virtio feature bits. A capability **MU
 framing without a separately negotiated feature. Unknown capability bits are ignored for operation
 selection and preserved by diagnostic tooling.
 
+Assigned protocol 1.0 semantic capability bits are:
+
+| Bit | Name |
+|---:|---|
+| 0 | `HOST_VISIBLE_MEMORY` |
+| 1 | `DEVICE_LOCAL_MEMORY` |
+| 2 | `EVENT_CANCELLATION` |
+| 5 | `SHARED_MEMORY` |
+
+Bits 3 (`EXTERNAL_MEMORY`) and 4 (`SECURE_CONTEXTS`) are reserved and **MUST NOT** be advertised by a
+protocol 1.0 device.
+
 ### 5.2 Context
 
 `CreateContextRequest` is eight bytes: `flags: u32` followed by `reserved: u32`. Both fields **MUST**
@@ -217,6 +229,12 @@ Context destruction uses an eight-byte `ObjectPayload`.
 | `usage` | Nonempty subset of assigned usage bits |
 | `reserved1` | Zero |
 
+The device **MUST** reject a memory domain whose corresponding semantic capability is absent before
+backend invocation. `Host`, `Device`, and provider-owned `Shared` allocations use capability bits 0,
+1, and 5 respectively. Successful allocation commits the backend to the placement and direct-binding
+rules in [specification.md](specification.md); it may not silently substitute a staged submission
+path.
+
 `TransferBufferRequest` is 24 bytes containing `buffer_id`, `offset`, and `bytes`. `bytes` **MUST**
 be nonzero. `offset + bytes` **MUST NOT** overflow and **MUST** fit in the buffer.
 
@@ -224,6 +242,10 @@ For `WRITE_BUFFER`, the request payload length **MUST** be `24 + bytes`, and byt
 prefix are copied to the buffer. For `READ_BUFFER`, the request payload is exactly 24 bytes and the
 success response payload contains exactly `bytes` bytes. Transfers must also fit the configured
 request or response frame maximum.
+
+`WRITE_BUFFER` requires buffer usage `TRANSFER_DESTINATION`; `READ_BUFFER` requires
+`TRANSFER_SOURCE`. These commands are explicit copy boundaries. Their existence does not permit
+allocation or submission to copy program bindings through hidden bounce buffers.
 
 ### 5.4 Programs
 

--- a/tests/semantic_manifest.rs
+++ b/tests/semantic_manifest.rs
@@ -1,0 +1,25 @@
+use virtio_accel::core::Capabilities;
+
+#[test]
+fn semantic_capabilities_match_the_versioned_manifest() {
+    let manifest: serde_json::Value =
+        serde_json::from_str(include_str!("../conformance/v1.0/layout.json")).unwrap();
+    let assigned = &manifest["capabilities"]["assigned"];
+    let reserved = &manifest["capabilities"]["reserved"];
+
+    for (name, value) in [
+        ("HOST_VISIBLE_MEMORY", Capabilities::HOST_VISIBLE_MEMORY),
+        ("DEVICE_LOCAL_MEMORY", Capabilities::DEVICE_LOCAL_MEMORY),
+        ("EVENT_CANCELLATION", Capabilities::EVENT_CANCELLATION),
+        ("SHARED_MEMORY", Capabilities::SHARED_MEMORY),
+    ] {
+        assert_eq!(assigned[name], format!("0x{:016x}", value.bits()));
+    }
+
+    for (name, value) in [
+        ("EXTERNAL_MEMORY", Capabilities::EXTERNAL_MEMORY),
+        ("SECURE_CONTEXTS", Capabilities::SECURE_CONTEXTS),
+    ] {
+        assert_eq!(reserved[name], format!("0x{:016x}", value.bits()));
+    }
+}


### PR DESCRIPTION
## Summary

- make memory-domain capabilities strict and assign provider-owned `SHARED_MEMORY`
- return verified allocation metadata with actual retained bytes, alignment, and backing properties
- require direct binding of program-visible buffers and reject incompatible paths instead of silently staging
- make explicit writes exclusively borrow the native buffer, removing the reference backend's per-buffer mutex
- add object-safe segmented `ByteSource`/`ByteSink` ports for transfers and artifact loading, with a contiguous fast path
- version the semantic capability namespace and update the normative specification/evidence ledger

## Performance contract

`WRITE_BUFFER` and `READ_BUFFER` are explicit copy boundaries. Device-local implementations may use bounded staging there. Allocation and submission do not gain permission to copy program buffers: a compatible submission binds the exact provider allocation, and an incompatible one is rejected.

The submit hot path remains statically dispatched native handles plus a borrowed binding slice. Object-safe dispatch is limited to slow bulk-byte lifecycle paths where it removes frame-sized coalescing allocations.

External guest-memory import/export and cache/fence semantics remain deferred; this PR does not pretend platform handles are portable.

## Verification

- `cargo fmt --all -- --check`
- `python3 ci/check-normative-requirements.py --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps`
- `cargo test --workspace --all-targets --all-features`
- `cargo test --workspace --doc --all-features`
- `cargo check --workspace --release --all-features`
- `cargo +1.85.0 check --workspace --all-targets --all-features`
- `cargo +1.85.0 test --workspace --all-features`
- portable checks for `aarch64-unknown-none`, `riscv64gc-unknown-none-elf`, and `wasm32-unknown-unknown`
- `cargo hack check --workspace --feature-powerset --no-dev-deps`
- `cargo deny check`
- `ci/check-portable-dependencies.sh`

## Follow-ups

Issue #21 still owns the complete method-by-method blocking/concurrency and extension audit. #12/#20 will wire segmented regions through the command engine, #24 will make the rules reusable backend conformance tests, and #29 will add staged-byte/allocation telemetry and regression budgets.

Refs #12, #21, #24, #25, #29.
