### PR TITLE
Add bounded byte-region ports and command-frame decoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,8 +126,10 @@ dependencies = [
 name = "virtio-accel-device"
 version = "0.1.0"
 dependencies = [
+ "serde_json",
  "virtio-accel-core",
  "virtio-accel-proto",
+ "zerocopy",
 ]
 
 [[package]]

--- a/crates/virtio-accel-device/Cargo.toml
+++ b/crates/virtio-accel-device/Cargo.toml
@@ -10,3 +10,7 @@ publish = false
 [dependencies]
 virtio-accel-core.workspace = true
 virtio-accel-proto.workspace = true
+zerocopy.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true

--- a/crates/virtio-accel-device/src/decoder.rs
+++ b/crates/virtio-accel-device/src/decoder.rs
@@ -1,0 +1,1064 @@
+//! Incremental validation for one untrusted command frame.
+//!
+//! Fixed wire values use an 80-byte stack scratch area. Transfer and artifact tails remain
+//! borrowed views over the original [`ByteSource`]. `SUBMIT` is the only allocating decode path:
+//! it retains one [`DecodedBinding`] per advertised binding and temporarily uses two `u32` arrays
+//! per binding for four-pass radix duplicate detection. All three allocations are bounded by the
+//! configured binding limit and use fallible reservation.
+
+use alloc::vec::Vec;
+use core::mem::size_of;
+
+use virtio_accel_core::{
+    AccessMode, ArtifactFormat, BufferDesc, BufferRange, BufferUsage, ByteSource, Capabilities,
+    ContextDesc, DeviceInfo, MemoryDomain, QueueDesc, TargetIdentity, Timeout,
+};
+use virtio_accel_proto::{
+    AllocateBufferRequest, ConfigError, CreateContextRequest, CreateQueueRequest,
+    HARD_MAX_BINDINGS, KnownOpcode, LoadProgramRequest, ObjectPayload, RequestHeader, StatusCode,
+    SubmitRequest, SubmitResponse, TransferBufferRequest, WireBinding, WireConfig, WireDeviceInfo,
+    WireEventState, read_exact,
+};
+use zerocopy::FromBytes;
+
+use crate::{ObjectId, ReadableRegion};
+
+const REQUEST_HEADER_BYTES: u64 = size_of::<RequestHeader>() as u64;
+const RESPONSE_HEADER_BYTES: u64 = 16;
+const MAX_FIXED_PREFIX_BYTES: usize = size_of::<LoadProgramRequest>();
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DecoderLimitsError {
+    Config(ConfigError),
+    BindingLimit,
+    BufferLimit,
+    ArtifactLimit,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DecoderLimits {
+    max_chain_descriptors: u16,
+    max_request_bytes: u32,
+    max_response_bytes: u32,
+    max_bindings: u32,
+    max_buffer_bytes: u64,
+    max_artifact_bytes: u64,
+    capabilities: Capabilities,
+}
+
+impl DecoderLimits {
+    pub fn new(config: &WireConfig, info: DeviceInfo) -> Result<Self, DecoderLimitsError> {
+        config.validate().map_err(DecoderLimitsError::Config)?;
+        if !(1..=HARD_MAX_BINDINGS).contains(&info.limits.max_bindings_per_submission) {
+            return Err(DecoderLimitsError::BindingLimit);
+        }
+        if info.limits.max_buffer_bytes == 0 {
+            return Err(DecoderLimitsError::BufferLimit);
+        }
+        if info.limits.max_artifact_bytes == 0 {
+            return Err(DecoderLimitsError::ArtifactLimit);
+        }
+        Ok(Self {
+            max_chain_descriptors: config.max_chain_descriptors.get(),
+            max_request_bytes: config.max_request_bytes.get(),
+            max_response_bytes: config.max_response_bytes.get(),
+            max_bindings: info.limits.max_bindings_per_submission,
+            max_buffer_bytes: info.limits.max_buffer_bytes,
+            max_artifact_bytes: info.limits.max_artifact_bytes,
+            capabilities: info.capabilities,
+        })
+    }
+
+    pub const fn max_chain_descriptors(self) -> u16 {
+        self.max_chain_descriptors
+    }
+
+    pub const fn max_request_bytes(self) -> u32 {
+        self.max_request_bytes
+    }
+
+    pub const fn max_response_bytes(self) -> u32 {
+        self.max_response_bytes
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum UnrecoverableDecodeError {
+    RequestHeader,
+    RequestAccess,
+    ResponseHeader,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FrameDecodeError {
+    Unrecoverable(UnrecoverableDecodeError),
+    Protocol {
+        request_id: u64,
+        status: StatusCode,
+    },
+    InsufficientResponse {
+        request_id: u64,
+        required: u64,
+        available: u64,
+    },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DecodedBinding {
+    pub buffer_id: ObjectId,
+    pub range: BufferRange,
+    pub slot: u32,
+    pub access: AccessMode,
+}
+
+#[derive(Debug)]
+pub enum DecodedRequestBody<'a> {
+    GetDeviceInfo,
+    CreateContext(ContextDesc),
+    DestroyContext {
+        context_id: ObjectId,
+    },
+    AllocateBuffer {
+        context_id: ObjectId,
+        desc: BufferDesc,
+    },
+    FreeBuffer {
+        buffer_id: ObjectId,
+    },
+    WriteBuffer {
+        buffer_id: ObjectId,
+        range: BufferRange,
+        data: ReadableRegion<'a>,
+    },
+    ReadBuffer {
+        buffer_id: ObjectId,
+        range: BufferRange,
+    },
+    LoadProgram {
+        context_id: ObjectId,
+        format: ArtifactFormat,
+        target: TargetIdentity,
+        payload: ReadableRegion<'a>,
+        resident_bytes: u64,
+    },
+    UnloadProgram {
+        program_id: ObjectId,
+    },
+    CreateQueue {
+        context_id: ObjectId,
+        desc: QueueDesc,
+    },
+    DestroyQueue {
+        queue_id: ObjectId,
+    },
+    Submit {
+        queue_id: ObjectId,
+        program_id: ObjectId,
+        bindings: Vec<DecodedBinding>,
+        timeout: Timeout,
+    },
+    PollEvent {
+        event_id: ObjectId,
+    },
+    CancelEvent {
+        event_id: ObjectId,
+    },
+    DestroyEvent {
+        event_id: ObjectId,
+    },
+}
+
+impl DecodedRequestBody<'_> {
+    pub const fn opcode(&self) -> KnownOpcode {
+        match self {
+            Self::GetDeviceInfo => KnownOpcode::GetDeviceInfo,
+            Self::CreateContext(_) => KnownOpcode::CreateContext,
+            Self::DestroyContext { .. } => KnownOpcode::DestroyContext,
+            Self::AllocateBuffer { .. } => KnownOpcode::AllocateBuffer,
+            Self::FreeBuffer { .. } => KnownOpcode::FreeBuffer,
+            Self::WriteBuffer { .. } => KnownOpcode::WriteBuffer,
+            Self::ReadBuffer { .. } => KnownOpcode::ReadBuffer,
+            Self::LoadProgram { .. } => KnownOpcode::LoadProgram,
+            Self::UnloadProgram { .. } => KnownOpcode::UnloadProgram,
+            Self::CreateQueue { .. } => KnownOpcode::CreateQueue,
+            Self::DestroyQueue { .. } => KnownOpcode::DestroyQueue,
+            Self::Submit { .. } => KnownOpcode::Submit,
+            Self::PollEvent { .. } => KnownOpcode::PollEvent,
+            Self::CancelEvent { .. } => KnownOpcode::CancelEvent,
+            Self::DestroyEvent { .. } => KnownOpcode::DestroyEvent,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct DecodedRequest<'a> {
+    request_id: u64,
+    required_response_bytes: u32,
+    body: DecodedRequestBody<'a>,
+}
+
+impl<'a> DecodedRequest<'a> {
+    pub const fn request_id(&self) -> u64 {
+        self.request_id
+    }
+
+    pub const fn required_response_bytes(&self) -> u32 {
+        self.required_response_bytes
+    }
+
+    pub const fn body(&self) -> &DecodedRequestBody<'a> {
+        &self.body
+    }
+
+    pub fn into_body(self) -> DecodedRequestBody<'a> {
+        self.body
+    }
+}
+
+/// Stateless decoder configured with protocol and backend-advertised limits.
+///
+/// A successful return means the complete frame, every fixed field, every binding, and the maximum
+/// success-response capacity have been validated. No backend operation is reachable through this
+/// type.
+#[derive(Clone, Copy, Debug)]
+pub struct FrameDecoder {
+    limits: DecoderLimits,
+}
+
+impl FrameDecoder {
+    pub const fn new(limits: DecoderLimits) -> Self {
+        Self { limits }
+    }
+
+    pub fn decode<'a>(
+        &self,
+        request: &'a dyn ByteSource,
+        response_capacity: u64,
+    ) -> Result<DecodedRequest<'a>, FrameDecodeError> {
+        if response_capacity < RESPONSE_HEADER_BYTES {
+            return Err(FrameDecodeError::Unrecoverable(
+                UnrecoverableDecodeError::ResponseHeader,
+            ));
+        }
+        if request.len() < REQUEST_HEADER_BYTES {
+            return Err(FrameDecodeError::Unrecoverable(
+                UnrecoverableDecodeError::RequestHeader,
+            ));
+        }
+
+        let header = read_wire(
+            request,
+            0,
+            size_of::<RequestHeader>(),
+            read_exact::<RequestHeader>,
+        )
+        .map_err(|_| FrameDecodeError::Unrecoverable(UnrecoverableDecodeError::RequestAccess))?;
+        let request_id = header.request_id.get();
+        let expected_frame_bytes = REQUEST_HEADER_BYTES + u64::from(header.payload_bytes.get());
+
+        if request.len() > u64::from(self.limits.max_request_bytes) {
+            return Err(protocol(request_id, StatusCode::RESOURCE_LIMIT));
+        }
+        if request.len() != expected_frame_bytes {
+            return Err(protocol(request_id, StatusCode::INVALID_ARGUMENT));
+        }
+        if request_id == 0 {
+            return Err(protocol(request_id, StatusCode::INVALID_ARGUMENT));
+        }
+        if header.flags.get() != 0 {
+            return Err(protocol(request_id, StatusCode::UNSUPPORTED));
+        }
+        let opcode = header
+            .known_opcode()
+            .map_err(|_| protocol(request_id, StatusCode::UNSUPPORTED))?;
+
+        let (body, required_response_bytes) = self
+            .decode_body(request, header.payload_bytes.get(), opcode)
+            .map_err(|error| match error {
+                BodyDecodeError::Protocol(status) => protocol(request_id, status),
+                BodyDecodeError::Access => {
+                    FrameDecodeError::Unrecoverable(UnrecoverableDecodeError::RequestAccess)
+                }
+            })?;
+
+        if required_response_bytes > u64::from(self.limits.max_response_bytes) {
+            return Err(protocol(request_id, StatusCode::RESOURCE_LIMIT));
+        }
+        if response_capacity < required_response_bytes {
+            return Err(FrameDecodeError::InsufficientResponse {
+                request_id,
+                required: required_response_bytes,
+                available: response_capacity,
+            });
+        }
+
+        Ok(DecodedRequest {
+            request_id,
+            required_response_bytes: required_response_bytes as u32,
+            body,
+        })
+    }
+
+    fn decode_body<'a>(
+        &self,
+        request: &'a dyn ByteSource,
+        payload_bytes: u32,
+        opcode: KnownOpcode,
+    ) -> Result<(DecodedRequestBody<'a>, u64), BodyDecodeError> {
+        match opcode {
+            KnownOpcode::GetDeviceInfo => {
+                expect_payload_bytes(payload_bytes, 0)?;
+                Ok((
+                    DecodedRequestBody::GetDeviceInfo,
+                    RESPONSE_HEADER_BYTES + size_of::<WireDeviceInfo>() as u64,
+                ))
+            }
+            KnownOpcode::CreateContext => {
+                expect_payload_bytes(payload_bytes, size_of::<CreateContextRequest>())?;
+                let value = read_payload::<CreateContextRequest>(request)?;
+                if value.flags.get() != 0 {
+                    return Err(BodyDecodeError::Protocol(StatusCode::UNSUPPORTED));
+                }
+                if value.reserved.get() != 0 {
+                    return Err(invalid());
+                }
+                Ok((
+                    DecodedRequestBody::CreateContext(ContextDesc::default()),
+                    RESPONSE_HEADER_BYTES + size_of::<ObjectPayload>() as u64,
+                ))
+            }
+            KnownOpcode::DestroyContext => Ok((
+                DecodedRequestBody::DestroyContext {
+                    context_id: decode_object(request, payload_bytes)?,
+                },
+                RESPONSE_HEADER_BYTES,
+            )),
+            KnownOpcode::AllocateBuffer => {
+                expect_payload_bytes(payload_bytes, size_of::<AllocateBufferRequest>())?;
+                let value = read_payload::<AllocateBufferRequest>(request)?;
+                let context_id = object_id(value.context_id.get())?;
+                if value.reserved0 != [0; 7] || value.reserved1.get() != 0 {
+                    return Err(invalid());
+                }
+
+                let domain = MemoryDomain::try_from(value.memory_domain).map_err(|_| invalid())?;
+                let usage = BufferUsage::from_bits(value.usage.get())
+                    .ok_or(BodyDecodeError::Protocol(StatusCode::UNSUPPORTED))?;
+                if usage.is_empty() {
+                    return Err(invalid());
+                }
+                let desc = BufferDesc::new(value.bytes.get(), value.alignment.get(), domain, usage)
+                    .map_err(|_| invalid())?;
+                if desc.bytes() > self.limits.max_buffer_bytes {
+                    return Err(BodyDecodeError::Protocol(StatusCode::RESOURCE_LIMIT));
+                }
+                if !self.limits.capabilities.supports_memory_domain(domain) {
+                    return Err(BodyDecodeError::Protocol(StatusCode::UNSUPPORTED));
+                }
+
+                Ok((
+                    DecodedRequestBody::AllocateBuffer { context_id, desc },
+                    RESPONSE_HEADER_BYTES + size_of::<ObjectPayload>() as u64,
+                ))
+            }
+            KnownOpcode::FreeBuffer => Ok((
+                DecodedRequestBody::FreeBuffer {
+                    buffer_id: decode_object(request, payload_bytes)?,
+                },
+                RESPONSE_HEADER_BYTES,
+            )),
+            KnownOpcode::WriteBuffer => {
+                let (buffer_id, range) = decode_transfer(request, payload_bytes, true)?;
+                let data = ReadableRegion::new(
+                    request,
+                    REQUEST_HEADER_BYTES + size_of::<TransferBufferRequest>() as u64,
+                    range.bytes(),
+                )
+                .map_err(|_| BodyDecodeError::Access)?;
+                Ok((
+                    DecodedRequestBody::WriteBuffer {
+                        buffer_id,
+                        range,
+                        data,
+                    },
+                    RESPONSE_HEADER_BYTES,
+                ))
+            }
+            KnownOpcode::ReadBuffer => {
+                let (buffer_id, range) = decode_transfer(request, payload_bytes, false)?;
+                let required_response_bytes = RESPONSE_HEADER_BYTES
+                    .checked_add(range.bytes())
+                    .ok_or_else(resource_limit)?;
+                Ok((
+                    DecodedRequestBody::ReadBuffer { buffer_id, range },
+                    required_response_bytes,
+                ))
+            }
+            KnownOpcode::LoadProgram => {
+                if u64::from(payload_bytes) < size_of::<LoadProgramRequest>() as u64 {
+                    return Err(invalid());
+                }
+                let value = read_payload::<LoadProgramRequest>(request)?;
+                if value.flags.get() != 0 {
+                    return Err(BodyDecodeError::Protocol(StatusCode::UNSUPPORTED));
+                }
+                let context_id = object_id(value.context_id.get())?;
+                let format = ArtifactFormat::new(value.format.get()).ok_or_else(invalid)?;
+                let payload_len = value.payload_bytes.get();
+                if payload_len == 0 || value.resident_bytes.get() == 0 {
+                    return Err(invalid());
+                }
+                let expected = (size_of::<LoadProgramRequest>() as u64)
+                    .checked_add(payload_len)
+                    .ok_or_else(resource_limit)?;
+                if expected != u64::from(payload_bytes) {
+                    return Err(invalid());
+                }
+                if payload_len > self.limits.max_artifact_bytes {
+                    return Err(BodyDecodeError::Protocol(StatusCode::RESOURCE_LIMIT));
+                }
+                let payload = ReadableRegion::new(
+                    request,
+                    REQUEST_HEADER_BYTES + size_of::<LoadProgramRequest>() as u64,
+                    payload_len,
+                )
+                .map_err(|_| BodyDecodeError::Access)?;
+                let target =
+                    TargetIdentity(core::array::from_fn(|index| value.target[index].get()));
+                Ok((
+                    DecodedRequestBody::LoadProgram {
+                        context_id,
+                        format,
+                        target,
+                        payload,
+                        resident_bytes: value.resident_bytes.get(),
+                    },
+                    RESPONSE_HEADER_BYTES + size_of::<ObjectPayload>() as u64,
+                ))
+            }
+            KnownOpcode::UnloadProgram => Ok((
+                DecodedRequestBody::UnloadProgram {
+                    program_id: decode_object(request, payload_bytes)?,
+                },
+                RESPONSE_HEADER_BYTES,
+            )),
+            KnownOpcode::CreateQueue => {
+                expect_payload_bytes(payload_bytes, size_of::<CreateQueueRequest>())?;
+                let value = read_payload::<CreateQueueRequest>(request)?;
+                if value.flags.get() != 0 {
+                    return Err(BodyDecodeError::Protocol(StatusCode::UNSUPPORTED));
+                }
+                if value.reserved.get() != 0 {
+                    return Err(invalid());
+                }
+                Ok((
+                    DecodedRequestBody::CreateQueue {
+                        context_id: object_id(value.context_id.get())?,
+                        desc: QueueDesc::default(),
+                    },
+                    RESPONSE_HEADER_BYTES + size_of::<ObjectPayload>() as u64,
+                ))
+            }
+            KnownOpcode::DestroyQueue => Ok((
+                DecodedRequestBody::DestroyQueue {
+                    queue_id: decode_object(request, payload_bytes)?,
+                },
+                RESPONSE_HEADER_BYTES,
+            )),
+            KnownOpcode::Submit => {
+                let (queue_id, program_id, bindings, timeout) =
+                    self.decode_submit(request, payload_bytes)?;
+                Ok((
+                    DecodedRequestBody::Submit {
+                        queue_id,
+                        program_id,
+                        bindings,
+                        timeout,
+                    },
+                    RESPONSE_HEADER_BYTES + size_of::<SubmitResponse>() as u64,
+                ))
+            }
+            KnownOpcode::PollEvent => Ok((
+                DecodedRequestBody::PollEvent {
+                    event_id: decode_object(request, payload_bytes)?,
+                },
+                RESPONSE_HEADER_BYTES + size_of::<WireEventState>() as u64,
+            )),
+            KnownOpcode::CancelEvent => Ok((
+                DecodedRequestBody::CancelEvent {
+                    event_id: decode_object(request, payload_bytes)?,
+                },
+                RESPONSE_HEADER_BYTES,
+            )),
+            KnownOpcode::DestroyEvent => Ok((
+                DecodedRequestBody::DestroyEvent {
+                    event_id: decode_object(request, payload_bytes)?,
+                },
+                RESPONSE_HEADER_BYTES,
+            )),
+        }
+    }
+
+    fn decode_submit(
+        &self,
+        request: &dyn ByteSource,
+        payload_bytes: u32,
+    ) -> Result<(ObjectId, ObjectId, Vec<DecodedBinding>, Timeout), BodyDecodeError> {
+        if u64::from(payload_bytes) < size_of::<SubmitRequest>() as u64 {
+            return Err(invalid());
+        }
+        let value = read_payload::<SubmitRequest>(request)?;
+        if value.flags.get() != 0 {
+            return Err(BodyDecodeError::Protocol(StatusCode::UNSUPPORTED));
+        }
+
+        let binding_count = value.binding_count.get();
+        if binding_count == 0 {
+            return Err(invalid());
+        }
+        if binding_count > self.limits.max_bindings || binding_count > HARD_MAX_BINDINGS {
+            return Err(BodyDecodeError::Protocol(StatusCode::RESOURCE_LIMIT));
+        }
+        let binding_bytes = u64::from(binding_count)
+            .checked_mul(size_of::<WireBinding>() as u64)
+            .ok_or_else(resource_limit)?;
+        let expected = (size_of::<SubmitRequest>() as u64)
+            .checked_add(binding_bytes)
+            .ok_or_else(resource_limit)?;
+        if expected != u64::from(payload_bytes) {
+            return Err(invalid());
+        }
+
+        let count = binding_count as usize;
+        let mut bindings = Vec::new();
+        bindings
+            .try_reserve_exact(count)
+            .map_err(|_| BodyDecodeError::Protocol(StatusCode::OUT_OF_MEMORY))?;
+        let mut slots = Vec::new();
+        slots
+            .try_reserve_exact(count)
+            .map_err(|_| BodyDecodeError::Protocol(StatusCode::OUT_OF_MEMORY))?;
+
+        let binding_base = REQUEST_HEADER_BYTES + size_of::<SubmitRequest>() as u64;
+        for index in 0..count {
+            let offset = binding_base + (index * size_of::<WireBinding>()) as u64;
+            let binding = read_wire(
+                request,
+                offset,
+                size_of::<WireBinding>(),
+                read_exact::<WireBinding>,
+            )?;
+            if binding.reserved != [0; 3] {
+                return Err(invalid());
+            }
+            let bytes = binding.bytes.get();
+            if bytes == 0 || binding.offset.get().checked_add(bytes).is_none() {
+                return Err(invalid());
+            }
+            let range = BufferRange::new(binding.offset.get(), bytes).map_err(|_| invalid())?;
+            let access = AccessMode::try_from(binding.access).map_err(|_| invalid())?;
+            slots.push(binding.slot.get());
+            bindings.push(DecodedBinding {
+                buffer_id: object_id(binding.buffer_id.get())?,
+                range,
+                slot: binding.slot.get(),
+                access,
+            });
+        }
+
+        if has_duplicate_slots(&mut slots)? {
+            return Err(invalid());
+        }
+
+        Ok((
+            object_id(value.queue_id.get())?,
+            object_id(value.program_id.get())?,
+            bindings,
+            Timeout::from_wire_ns(value.timeout_ns.get()),
+        ))
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum BodyDecodeError {
+    Protocol(StatusCode),
+    Access,
+}
+
+fn protocol(request_id: u64, status: StatusCode) -> FrameDecodeError {
+    FrameDecodeError::Protocol { request_id, status }
+}
+
+fn invalid() -> BodyDecodeError {
+    BodyDecodeError::Protocol(StatusCode::INVALID_ARGUMENT)
+}
+
+fn resource_limit() -> BodyDecodeError {
+    BodyDecodeError::Protocol(StatusCode::RESOURCE_LIMIT)
+}
+
+fn expect_payload_bytes(payload_bytes: u32, expected: usize) -> Result<(), BodyDecodeError> {
+    if u64::from(payload_bytes) != expected as u64 {
+        return Err(invalid());
+    }
+    Ok(())
+}
+
+fn read_payload<T>(request: &dyn ByteSource) -> Result<T, BodyDecodeError>
+where
+    T: FromBytes,
+{
+    read_wire(
+        request,
+        REQUEST_HEADER_BYTES,
+        size_of::<T>(),
+        read_exact::<T>,
+    )
+}
+
+fn read_wire<T>(
+    source: &dyn ByteSource,
+    offset: u64,
+    bytes: usize,
+    decode: impl FnOnce(&[u8]) -> Result<T, virtio_accel_proto::DecodeError>,
+) -> Result<T, BodyDecodeError> {
+    if bytes > MAX_FIXED_PREFIX_BYTES {
+        return Err(BodyDecodeError::Protocol(StatusCode::INTERNAL_ERROR));
+    }
+    let mut scratch = [0_u8; MAX_FIXED_PREFIX_BYTES];
+    source
+        .read_at(offset, &mut scratch[..bytes])
+        .map_err(|_| BodyDecodeError::Access)?;
+    decode(&scratch[..bytes]).map_err(|_| invalid())
+}
+
+fn decode_object(
+    request: &dyn ByteSource,
+    payload_bytes: u32,
+) -> Result<ObjectId, BodyDecodeError> {
+    expect_payload_bytes(payload_bytes, size_of::<ObjectPayload>())?;
+    object_id(read_payload::<ObjectPayload>(request)?.object_id.get())
+}
+
+fn object_id(raw: u64) -> Result<ObjectId, BodyDecodeError> {
+    ObjectId::from_raw(raw).ok_or_else(invalid)
+}
+
+fn decode_transfer(
+    request: &dyn ByteSource,
+    payload_bytes: u32,
+    has_data: bool,
+) -> Result<(ObjectId, BufferRange), BodyDecodeError> {
+    if u64::from(payload_bytes) < size_of::<TransferBufferRequest>() as u64 {
+        return Err(invalid());
+    }
+    let value = read_payload::<TransferBufferRequest>(request)?;
+    let bytes = value.bytes.get();
+    if bytes == 0 || value.offset.get().checked_add(bytes).is_none() {
+        return Err(invalid());
+    }
+    let expected = if has_data {
+        (size_of::<TransferBufferRequest>() as u64)
+            .checked_add(bytes)
+            .ok_or_else(resource_limit)?
+    } else {
+        size_of::<TransferBufferRequest>() as u64
+    };
+    if expected != u64::from(payload_bytes) {
+        return Err(invalid());
+    }
+    Ok((
+        object_id(value.buffer_id.get())?,
+        BufferRange::new(value.offset.get(), bytes).map_err(|_| invalid())?,
+    ))
+}
+
+fn has_duplicate_slots(slots: &mut [u32]) -> Result<bool, BodyDecodeError> {
+    if slots.len() < 2 {
+        return Ok(false);
+    }
+
+    let mut scratch = Vec::new();
+    scratch
+        .try_reserve_exact(slots.len())
+        .map_err(|_| BodyDecodeError::Protocol(StatusCode::OUT_OF_MEMORY))?;
+    scratch.resize(slots.len(), 0);
+
+    radix_pass(slots, &mut scratch, 0);
+    radix_pass(&scratch, slots, 8);
+    radix_pass(slots, &mut scratch, 16);
+    radix_pass(&scratch, slots, 24);
+    Ok(slots.windows(2).any(|window| window[0] == window[1]))
+}
+
+fn radix_pass(input: &[u32], output: &mut [u32], shift: u32) {
+    let mut counts = [0_usize; 256];
+    for value in input {
+        counts[((value >> shift) & 0xff) as usize] += 1;
+    }
+
+    let mut next = 0;
+    for count in &mut counts {
+        let start = next;
+        next += *count;
+        *count = start;
+    }
+
+    for value in input {
+        let bucket = ((value >> shift) & 0xff) as usize;
+        output[counts[bucket]] = *value;
+        counts[bucket] += 1;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use super::*;
+    use crate::SegmentedSource;
+    use serde_json::Value;
+    use std::vec::Vec;
+    use virtio_accel_core::{AcceleratorClass, Capabilities, DeviceIdentity, DeviceLimits};
+    use virtio_accel_proto::{
+        BASELINE_COMMAND_QUEUES, HARD_MAX_CHAIN_DESCRIPTORS, HARD_MAX_REQUEST_BYTES,
+        HARD_MAX_RESPONSE_BYTES, Le16, Le32, PROTOCOL_MAJOR, PROTOCOL_MINOR,
+    };
+
+    const REQUEST_ID: u64 = 0x0102_0304_0506_0708;
+
+    fn corpus() -> Value {
+        serde_json::from_str(include_str!("../../../conformance/v1.0/vectors.json")).unwrap()
+    }
+
+    fn vector(section: &str, name: &str) -> Vec<u8> {
+        let corpus = corpus();
+        let entry = corpus[section]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|entry| entry["name"] == name)
+            .unwrap();
+        decode_hex(entry["hex"].as_str().unwrap())
+    }
+
+    fn decode_hex(hex: &str) -> Vec<u8> {
+        hex.as_bytes()
+            .chunks_exact(2)
+            .map(|pair| {
+                let high = (pair[0] as char).to_digit(16).unwrap() as u8;
+                let low = (pair[1] as char).to_digit(16).unwrap() as u8;
+                (high << 4) | low
+            })
+            .collect()
+    }
+
+    fn decoder() -> FrameDecoder {
+        let config = WireConfig {
+            protocol_major: Le16::new(PROTOCOL_MAJOR),
+            protocol_minor: Le16::new(PROTOCOL_MINOR),
+            command_queue_count: Le16::new(BASELINE_COMMAND_QUEUES),
+            max_chain_descriptors: Le16::new(HARD_MAX_CHAIN_DESCRIPTORS),
+            max_request_bytes: Le32::new(HARD_MAX_REQUEST_BYTES),
+            max_response_bytes: Le32::new(HARD_MAX_RESPONSE_BYTES),
+        };
+        let info = DeviceInfo {
+            identity: DeviceIdentity {
+                uuid: [0; 16],
+                class: AcceleratorClass::OTHER,
+                vendor_id: 0,
+                device_id: 0,
+            },
+            capabilities: Capabilities::HOST_VISIBLE_MEMORY
+                | Capabilities::DEVICE_LOCAL_MEMORY
+                | Capabilities::SHARED_MEMORY,
+            limits: DeviceLimits {
+                max_contexts: 64,
+                max_buffers_per_context: 1024,
+                max_programs_per_context: 256,
+                max_queues_per_context: 16,
+                max_events_per_context: 4096,
+                max_bindings_per_submission: HARD_MAX_BINDINGS,
+                max_buffer_bytes: 1 << 30,
+                max_artifact_bytes: 1 << 28,
+            },
+        };
+        FrameDecoder::new(DecoderLimits::new(&config, info).unwrap())
+    }
+
+    fn opcode(name: &str) -> KnownOpcode {
+        match name {
+            "GET_DEVICE_INFO" => KnownOpcode::GetDeviceInfo,
+            "CREATE_CONTEXT" => KnownOpcode::CreateContext,
+            "DESTROY_CONTEXT" => KnownOpcode::DestroyContext,
+            "ALLOCATE_BUFFER" => KnownOpcode::AllocateBuffer,
+            "FREE_BUFFER" => KnownOpcode::FreeBuffer,
+            "WRITE_BUFFER" => KnownOpcode::WriteBuffer,
+            "READ_BUFFER" => KnownOpcode::ReadBuffer,
+            "LOAD_PROGRAM" => KnownOpcode::LoadProgram,
+            "UNLOAD_PROGRAM" => KnownOpcode::UnloadProgram,
+            "CREATE_QUEUE" => KnownOpcode::CreateQueue,
+            "DESTROY_QUEUE" => KnownOpcode::DestroyQueue,
+            "SUBMIT" => KnownOpcode::Submit,
+            "POLL_EVENT" => KnownOpcode::PollEvent,
+            "CANCEL_EVENT" => KnownOpcode::CancelEvent,
+            "DESTROY_EVENT" => KnownOpcode::DestroyEvent,
+            other => panic!("unknown opcode name {other}"),
+        }
+    }
+
+    #[test]
+    fn every_canonical_request_decodes_across_every_byte_split() {
+        let decoder = decoder();
+        let corpus = corpus();
+        for frame in corpus["frames"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|frame| frame["kind"] == "request")
+        {
+            let bytes = decode_hex(frame["hex"].as_str().unwrap());
+            let expected_opcode = opcode(frame["opcode"].as_str().unwrap());
+
+            let contiguous_segments = [bytes.as_slice()];
+            let contiguous = SegmentedSource::new(&contiguous_segments).unwrap();
+            let decoded = decoder
+                .decode(&contiguous, u64::from(HARD_MAX_RESPONSE_BYTES))
+                .unwrap();
+            assert_eq!(decoded.request_id(), REQUEST_ID);
+            assert_eq!(decoded.body().opcode(), expected_opcode);
+
+            for split in 1..bytes.len() {
+                let segments = [&bytes[..split], &bytes[split..]];
+                let segmented = SegmentedSource::new(&segments).unwrap();
+                let decoded = decoder
+                    .decode(&segmented, u64::from(HARD_MAX_RESPONSE_BYTES))
+                    .unwrap_or_else(|error| {
+                        panic!(
+                            "{} failed at split {split}: {error:?}",
+                            frame["name"].as_str().unwrap()
+                        )
+                    });
+                assert_eq!(decoded.request_id(), REQUEST_ID);
+                assert_eq!(decoded.body().opcode(), expected_opcode);
+            }
+        }
+    }
+
+    #[test]
+    fn transfer_and_artifact_tails_remain_borrowed_segmented_sources() {
+        let decoder = decoder();
+
+        let write = vector("frames", "request_write_buffer");
+        let write_segments = [&write[..41], &write[41..43], &write[43..]];
+        let write_source = SegmentedSource::new(&write_segments).unwrap();
+        let decoded = decoder
+            .decode(&write_source, u64::from(HARD_MAX_RESPONSE_BYTES))
+            .unwrap();
+        let DecodedRequestBody::WriteBuffer { data, range, .. } = decoded.body() else {
+            panic!("write request decoded as wrong body");
+        };
+        assert_eq!(range.bytes(), 4);
+        assert!(data.as_contiguous().is_none());
+        let mut write_payload = [0_u8; 4];
+        data.read_at(0, &mut write_payload).unwrap();
+        assert_eq!(write_payload, [0xde, 0xad, 0xbe, 0xef]);
+
+        let load = vector("frames", "request_load_program");
+        let load_segments = [&load[..97], &load[97..99], &load[99..]];
+        let load_source = SegmentedSource::new(&load_segments).unwrap();
+        let decoded = decoder
+            .decode(&load_source, u64::from(HARD_MAX_RESPONSE_BYTES))
+            .unwrap();
+        let DecodedRequestBody::LoadProgram {
+            payload,
+            resident_bytes,
+            ..
+        } = decoded.body()
+        else {
+            panic!("load request decoded as wrong body");
+        };
+        assert_eq!(*resident_bytes, 4096);
+        let mut artifact = [0_u8; 4];
+        payload.read_at(0, &mut artifact).unwrap();
+        assert_eq!(artifact, [0xa1, 0xb2, 0xc3, 0xd4]);
+    }
+
+    #[test]
+    fn malformed_conformance_vectors_map_to_defined_failures() {
+        let decoder = decoder();
+        let cases = [
+            (
+                "request_unknown_opcode",
+                FrameDecodeError::Protocol {
+                    request_id: REQUEST_ID,
+                    status: StatusCode::UNSUPPORTED,
+                },
+            ),
+            (
+                "request_reserved_flag",
+                FrameDecodeError::Protocol {
+                    request_id: REQUEST_ID,
+                    status: StatusCode::UNSUPPORTED,
+                },
+            ),
+            (
+                "request_trailing_byte",
+                FrameDecodeError::Protocol {
+                    request_id: REQUEST_ID,
+                    status: StatusCode::INVALID_ARGUMENT,
+                },
+            ),
+            (
+                "request_reserved_context_flag",
+                FrameDecodeError::Protocol {
+                    request_id: REQUEST_ID,
+                    status: StatusCode::UNSUPPORTED,
+                },
+            ),
+            (
+                "request_unknown_memory_domain",
+                FrameDecodeError::Protocol {
+                    request_id: REQUEST_ID,
+                    status: StatusCode::INVALID_ARGUMENT,
+                },
+            ),
+            (
+                "request_binding_count_overflow",
+                FrameDecodeError::Protocol {
+                    request_id: REQUEST_ID,
+                    status: StatusCode::RESOURCE_LIMIT,
+                },
+            ),
+        ];
+
+        for (name, expected) in cases {
+            let bytes = vector("edge_cases", name);
+            let segments = [bytes.as_slice()];
+            let source = SegmentedSource::new(&segments).unwrap();
+            match decoder.decode(&source, u64::from(HARD_MAX_RESPONSE_BYTES)) {
+                Err(actual) => assert_eq!(actual, expected, "{name}"),
+                Ok(_) => panic!("{name} unexpectedly decoded"),
+            }
+        }
+
+        let truncated = vector("edge_cases", "request_header_truncated");
+        let segments = [truncated.as_slice()];
+        let source = SegmentedSource::new(&segments).unwrap();
+        assert!(matches!(
+            decoder.decode(&source, u64::from(HARD_MAX_RESPONSE_BYTES)),
+            Err(FrameDecodeError::Unrecoverable(
+                UnrecoverableDecodeError::RequestHeader
+            ))
+        ));
+    }
+
+    #[test]
+    fn duplicate_submission_slots_are_rejected_before_dispatch() {
+        let mut request = vector("frames", "request_submit");
+        let binding = request[48..80].to_vec();
+        request[4..8].copy_from_slice(&96_u32.to_le_bytes());
+        request[32..36].copy_from_slice(&2_u32.to_le_bytes());
+        request.extend_from_slice(&binding);
+
+        let segments = [request.as_slice()];
+        let source = SegmentedSource::new(&segments).unwrap();
+        assert!(matches!(
+            decoder().decode(&source, u64::from(HARD_MAX_RESPONSE_BYTES)),
+            Err(FrameDecodeError::Protocol {
+                status: StatusCode::INVALID_ARGUMENT,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn transfer_range_overflow_is_a_protocol_error() {
+        let mut request = vector("frames", "request_read_buffer");
+        request[24..32].copy_from_slice(&u64::MAX.to_le_bytes());
+
+        let segments = [request.as_slice()];
+        let source = SegmentedSource::new(&segments).unwrap();
+        assert!(matches!(
+            decoder().decode(&source, u64::from(HARD_MAX_RESPONSE_BYTES)),
+            Err(FrameDecodeError::Protocol {
+                status: StatusCode::INVALID_ARGUMENT,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn short_success_capacity_writes_nothing() {
+        let request = vector("frames", "request_read_buffer");
+        let segments = [request.as_slice()];
+        let source = SegmentedSource::new(&segments).unwrap();
+        match decoder().decode(&source, 19) {
+            Err(actual) => assert_eq!(
+                actual,
+                FrameDecodeError::InsufficientResponse {
+                    request_id: REQUEST_ID,
+                    required: 20,
+                    available: 19,
+                }
+            ),
+            Ok(_) => panic!("short response capacity unexpectedly decoded"),
+        }
+    }
+
+    #[test]
+    fn malformed_request_needs_only_error_header_capacity() {
+        let request = vector("edge_cases", "request_reserved_context_flag");
+        let segments = [request.as_slice()];
+        let source = SegmentedSource::new(&segments).unwrap();
+        assert!(matches!(
+            decoder().decode(&source, 16),
+            Err(FrameDecodeError::Protocol {
+                status: StatusCode::UNSUPPORTED,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn unsupported_memory_domain_capability_is_rejected_before_backend_use() {
+        let config = WireConfig {
+            protocol_major: Le16::new(PROTOCOL_MAJOR),
+            protocol_minor: Le16::new(PROTOCOL_MINOR),
+            command_queue_count: Le16::new(BASELINE_COMMAND_QUEUES),
+            max_chain_descriptors: Le16::new(8),
+            max_request_bytes: Le32::new(1024),
+            max_response_bytes: Le32::new(1024),
+        };
+        let info = DeviceInfo {
+            identity: DeviceIdentity {
+                uuid: [0; 16],
+                class: AcceleratorClass::OTHER,
+                vendor_id: 0,
+                device_id: 0,
+            },
+            capabilities: Capabilities::HOST_VISIBLE_MEMORY,
+            limits: DeviceLimits {
+                max_contexts: 1,
+                max_buffers_per_context: 1,
+                max_programs_per_context: 1,
+                max_queues_per_context: 1,
+                max_events_per_context: 1,
+                max_bindings_per_submission: 1,
+                max_buffer_bytes: 1 << 20,
+                max_artifact_bytes: 1 << 20,
+            },
+        };
+        let decoder = FrameDecoder::new(DecoderLimits::new(&config, info).unwrap());
+        let request = vector("frames", "request_allocate_buffer");
+        let segments = [request.as_slice()];
+        let source = SegmentedSource::new(&segments).unwrap();
+        assert!(matches!(
+            decoder.decode(&source, 1024),
+            Err(FrameDecodeError::Protocol {
+                status: StatusCode::UNSUPPORTED,
+                ..
+            })
+        ));
+    }
+}

--- a/crates/virtio-accel-device/src/decoder.rs
+++ b/crates/virtio-accel-device/src/decoder.rs
@@ -4,7 +4,9 @@
 //! borrowed views over the original [`ByteSource`]. `SUBMIT` is the only allocating decode path:
 //! it retains one [`DecodedBinding`] per advertised binding and temporarily uses two `u32` arrays
 //! per binding for four-pass radix duplicate detection. All three allocations are bounded by the
-//! configured binding limit and use fallible reservation.
+//! configured binding limit and use fallible reservation. The decoder performs a constant number
+//! of fixed-prefix reads plus one 32-byte read and four fixed radix passes per binding, so its own
+//! work is linear in the validated payload size.
 
 use alloc::vec::Vec;
 use core::mem::size_of;
@@ -228,6 +230,10 @@ pub struct FrameDecoder {
 impl FrameDecoder {
     pub const fn new(limits: DecoderLimits) -> Self {
         Self { limits }
+    }
+
+    pub const fn limits(&self) -> DecoderLimits {
+        self.limits
     }
 
     pub fn decode<'a>(

--- a/crates/virtio-accel-device/src/decoder.rs
+++ b/crates/virtio-accel-device/src/decoder.rs
@@ -26,7 +26,7 @@ use zerocopy::FromBytes;
 use crate::{ObjectId, ReadableRegion};
 
 const REQUEST_HEADER_BYTES: u64 = size_of::<RequestHeader>() as u64;
-const RESPONSE_HEADER_BYTES: u64 = 16;
+const RESPONSE_HEADER_BYTES: u64 = size_of::<virtio_accel_proto::ResponseHeader>() as u64;
 const MAX_FIXED_PREFIX_BYTES: usize = size_of::<LoadProgramRequest>();
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/virtio-accel-device/src/frame.rs
+++ b/crates/virtio-accel-device/src/frame.rs
@@ -1,0 +1,269 @@
+//! Atomic preflight for one transport-neutral command frame.
+//!
+//! This is the only byte-oriented entry point needed by the command engine. It validates the
+//! flattened chain shape, confirms that the byte ports match the advertised totals, decodes the
+//! complete request, and writes recoverable protocol errors before returning. Only
+//! [`FramePreflight::Ready`] contains a request that semantic dispatch may act on.
+
+use virtio_accel_core::{ByteSink, ByteSource};
+use virtio_accel_proto::StatusCode;
+
+use crate::{
+    ChainLayoutError, ChainRegion, DecodedRequest, FrameDecodeError, FrameDecoder,
+    ResponseWriteError, ResponseWriter, UnrecoverableDecodeError, validate_chain_layout,
+};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum UnusableFrame {
+    ChainLayout(ChainLayoutError),
+    Request(UnrecoverableDecodeError),
+    InsufficientResponse {
+        request_id: u64,
+        required: u64,
+        available: u64,
+    },
+}
+
+#[derive(Debug)]
+pub enum FramePreflight<'a> {
+    /// The complete frame is validated and may proceed to semantic dispatch.
+    Ready(DecodedRequest<'a>),
+    /// A recoverable protocol error was written to the response port.
+    Rejected {
+        request_id: u64,
+        status: StatusCode,
+        used: u32,
+    },
+    /// No response bytes were written and the chain must complete with used length zero.
+    Unusable(UnusableFrame),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FramePreflightError {
+    ResponseWrite(ResponseWriteError),
+}
+
+/// Validate one complete chain before semantic state or a backend can be reached.
+///
+/// The function is allocation-free except for the bounded `SUBMIT` binding allocation performed
+/// by [`FrameDecoder`]. `Ready` leaves the response untouched. `Rejected` initializes exactly one
+/// 16-byte error header. `Unusable` leaves the response untouched.
+pub fn preflight_command_frame<'a>(
+    decoder: &FrameDecoder,
+    regions: &[ChainRegion],
+    request: &'a dyn ByteSource,
+    response: &mut dyn ByteSink,
+) -> Result<FramePreflight<'a>, FramePreflightError> {
+    let layout = match validate_chain_layout(regions, decoder.limits().max_chain_descriptors()) {
+        Ok(layout) => layout,
+        Err(error) => {
+            return Ok(FramePreflight::Unusable(UnusableFrame::ChainLayout(error)));
+        }
+    };
+    if let Err(error) = layout.validate_ports(request, response) {
+        return Ok(FramePreflight::Unusable(UnusableFrame::ChainLayout(error)));
+    }
+
+    match decoder.decode(request, response.len()) {
+        Ok(request) => Ok(FramePreflight::Ready(request)),
+        Err(FrameDecodeError::Protocol { request_id, status }) => {
+            let used = ResponseWriter::new(response, decoder.limits().max_response_bytes())
+                .write_empty(status, request_id)
+                .map_err(FramePreflightError::ResponseWrite)?;
+            Ok(FramePreflight::Rejected {
+                request_id,
+                status,
+                used,
+            })
+        }
+        Err(FrameDecodeError::Unrecoverable(error)) => {
+            Ok(FramePreflight::Unusable(UnusableFrame::Request(error)))
+        }
+        Err(FrameDecodeError::InsufficientResponse {
+            request_id,
+            required,
+            available,
+        }) => Ok(FramePreflight::Unusable(
+            UnusableFrame::InsufficientResponse {
+                request_id,
+                required,
+                available,
+            },
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use super::*;
+    use crate::{DecoderLimits, SegmentedSink, SegmentedSource};
+    use serde_json::Value;
+    use std::vec::Vec;
+    use virtio_accel_core::{
+        AcceleratorClass, Capabilities, DeviceIdentity, DeviceInfo, DeviceLimits,
+    };
+    use virtio_accel_proto::{
+        BASELINE_COMMAND_QUEUES, HARD_MAX_BINDINGS, HARD_MAX_REQUEST_BYTES,
+        HARD_MAX_RESPONSE_BYTES, Le16, Le32, PROTOCOL_MAJOR, PROTOCOL_MINOR, WireConfig,
+    };
+
+    const REQUEST_ID: u64 = 0x0102_0304_0506_0708;
+
+    fn corpus() -> Value {
+        serde_json::from_str(include_str!("../../../conformance/v1.0/vectors.json")).unwrap()
+    }
+
+    fn vector(section: &str, name: &str) -> Vec<u8> {
+        let corpus = corpus();
+        let entry = corpus[section]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|entry| entry["name"] == name)
+            .unwrap();
+        decode_hex(entry["hex"].as_str().unwrap())
+    }
+
+    fn decode_hex(hex: &str) -> Vec<u8> {
+        hex.as_bytes()
+            .chunks_exact(2)
+            .map(|pair| {
+                let high = (pair[0] as char).to_digit(16).unwrap() as u8;
+                let low = (pair[1] as char).to_digit(16).unwrap() as u8;
+                (high << 4) | low
+            })
+            .collect()
+    }
+
+    fn decoder() -> FrameDecoder {
+        let config = WireConfig {
+            protocol_major: Le16::new(PROTOCOL_MAJOR),
+            protocol_minor: Le16::new(PROTOCOL_MINOR),
+            command_queue_count: Le16::new(BASELINE_COMMAND_QUEUES),
+            max_chain_descriptors: Le16::new(16),
+            max_request_bytes: Le32::new(HARD_MAX_REQUEST_BYTES),
+            max_response_bytes: Le32::new(HARD_MAX_RESPONSE_BYTES),
+        };
+        let info = DeviceInfo {
+            identity: DeviceIdentity {
+                uuid: [0; 16],
+                class: AcceleratorClass::OTHER,
+                vendor_id: 0,
+                device_id: 0,
+            },
+            capabilities: Capabilities::HOST_VISIBLE_MEMORY
+                | Capabilities::DEVICE_LOCAL_MEMORY
+                | Capabilities::SHARED_MEMORY,
+            limits: DeviceLimits {
+                max_contexts: 64,
+                max_buffers_per_context: 1024,
+                max_programs_per_context: 256,
+                max_queues_per_context: 16,
+                max_events_per_context: 4096,
+                max_bindings_per_submission: HARD_MAX_BINDINGS,
+                max_buffer_bytes: 1 << 30,
+                max_artifact_bytes: 1 << 28,
+            },
+        };
+        FrameDecoder::new(DecoderLimits::new(&config, info).unwrap())
+    }
+
+    #[test]
+    fn valid_frame_is_dispatchable_without_touching_response() {
+        let request = vector("frames", "request_get_device_info");
+        let request_segments = [&request[..7], &request[7..]];
+        let request_source = SegmentedSource::new(&request_segments).unwrap();
+        let mut response = [0xaa_u8; 92];
+        let (left, right) = response.split_at_mut(31);
+        let mut response_segments: [&mut [u8]; 2] = [left, right];
+        let mut response_sink = SegmentedSink::new(&mut response_segments).unwrap();
+        let regions = [
+            ChainRegion::readable(7),
+            ChainRegion::readable((request.len() - 7) as u64),
+            ChainRegion::writable(31),
+            ChainRegion::writable(61),
+        ];
+
+        let outcome =
+            preflight_command_frame(&decoder(), &regions, &request_source, &mut response_sink)
+                .unwrap();
+        let FramePreflight::Ready(decoded) = outcome else {
+            panic!("valid frame was not dispatchable");
+        };
+        assert_eq!(decoded.request_id(), REQUEST_ID);
+        assert_eq!(response, [0xaa; 92]);
+    }
+
+    #[test]
+    fn recoverable_malformed_frame_writes_exact_error_header() {
+        let request = vector("edge_cases", "request_reserved_flag");
+        let request_segments = [request.as_slice()];
+        let request_source = SegmentedSource::new(&request_segments).unwrap();
+        let mut response = [0xaa_u8; 24];
+        let (left, right) = response.split_at_mut(5);
+        let mut response_segments: [&mut [u8]; 2] = [left, right];
+        let mut response_sink = SegmentedSink::new(&mut response_segments).unwrap();
+        let regions = [
+            ChainRegion::readable(request.len() as u64),
+            ChainRegion::writable(5),
+            ChainRegion::writable(19),
+        ];
+
+        assert!(matches!(
+            preflight_command_frame(&decoder(), &regions, &request_source, &mut response_sink,),
+            Ok(FramePreflight::Rejected {
+                request_id: REQUEST_ID,
+                status: StatusCode::UNSUPPORTED,
+                used: 16,
+            })
+        ));
+        assert_eq!(&response[0..2], &StatusCode::UNSUPPORTED.0.to_le_bytes());
+        assert_eq!(&response[4..8], &0_u32.to_le_bytes());
+        assert_eq!(&response[8..16], &REQUEST_ID.to_le_bytes());
+        assert_eq!(&response[16..], &[0xaa; 8]);
+    }
+
+    #[test]
+    fn unusable_frames_write_nothing_and_never_become_dispatchable() {
+        let request = vector("frames", "request_read_buffer");
+        let request_segments = [request.as_slice()];
+        let request_source = SegmentedSource::new(&request_segments).unwrap();
+        let mut response = [0xaa_u8; 19];
+        let mut response_segments: [&mut [u8]; 1] = [&mut response];
+        let mut response_sink = SegmentedSink::new(&mut response_segments).unwrap();
+        let regions = [
+            ChainRegion::readable(request.len() as u64),
+            ChainRegion::writable(19),
+        ];
+
+        assert!(matches!(
+            preflight_command_frame(&decoder(), &regions, &request_source, &mut response_sink,),
+            Ok(FramePreflight::Unusable(
+                UnusableFrame::InsufficientResponse { .. }
+            ))
+        ));
+        assert_eq!(response, [0xaa; 19]);
+
+        let mut response = [0xaa_u8; 20];
+        let mut response_segments: [&mut [u8]; 1] = [&mut response];
+        let mut response_sink = SegmentedSink::new(&mut response_segments).unwrap();
+        let invalid_regions = [
+            ChainRegion::writable(20),
+            ChainRegion::readable(request.len() as u64),
+        ];
+        assert!(matches!(
+            preflight_command_frame(
+                &decoder(),
+                &invalid_regions,
+                &request_source,
+                &mut response_sink,
+            ),
+            Ok(FramePreflight::Unusable(UnusableFrame::ChainLayout(
+                ChainLayoutError::Direction
+            )))
+        ));
+        assert_eq!(response, [0xaa; 20]);
+    }
+}

--- a/crates/virtio-accel-device/src/lib.rs
+++ b/crates/virtio-accel-device/src/lib.rs
@@ -8,9 +8,21 @@
 
 extern crate alloc;
 
+mod decoder;
 mod object_table;
+mod regions;
+mod response;
 
+pub use decoder::{
+    DecodedBinding, DecodedRequest, DecodedRequestBody, DecoderLimits, DecoderLimitsError,
+    FrameDecodeError, FrameDecoder, UnrecoverableDecodeError,
+};
 pub use object_table::{ObjectId, ObjectKind, ObjectTable, ObjectTableError};
+pub use regions::{
+    ChainLayout, ChainLayoutError, ChainRegion, ReadableRegion, RegionDirection,
+    SegmentedRegionError, SegmentedSink, SegmentedSource, WritableRegion, validate_chain_layout,
+};
+pub use response::{ResponseWriteError, ResponseWriter};
 use virtio_accel_core::BackendError;
 use virtio_accel_proto::StatusCode;
 

--- a/crates/virtio-accel-device/src/lib.rs
+++ b/crates/virtio-accel-device/src/lib.rs
@@ -9,6 +9,7 @@
 extern crate alloc;
 
 mod decoder;
+mod frame;
 mod object_table;
 mod regions;
 mod response;
@@ -17,12 +18,13 @@ pub use decoder::{
     DecodedBinding, DecodedRequest, DecodedRequestBody, DecoderLimits, DecoderLimitsError,
     FrameDecodeError, FrameDecoder, UnrecoverableDecodeError,
 };
+pub use frame::{FramePreflight, FramePreflightError, UnusableFrame, preflight_command_frame};
 pub use object_table::{ObjectId, ObjectKind, ObjectTable, ObjectTableError};
 pub use regions::{
     ChainLayout, ChainLayoutError, ChainRegion, ReadableRegion, RegionDirection,
     SegmentedRegionError, SegmentedSink, SegmentedSource, WritableRegion, validate_chain_layout,
 };
-pub use response::{ResponseWriteError, ResponseWriter};
+pub use response::{ResponsePayload, ResponseWriteError, ResponseWriter};
 use virtio_accel_core::BackendError;
 use virtio_accel_proto::StatusCode;
 

--- a/crates/virtio-accel-device/src/regions.rs
+++ b/crates/virtio-accel-device/src/regions.rs
@@ -374,6 +374,10 @@ mod tests {
     #[test]
     fn chain_layout_rejects_direction_and_length_errors() {
         assert_eq!(
+            validate_chain_layout(&[ChainRegion::readable(16)], 8),
+            Err(ChainLayoutError::DescriptorCount)
+        );
+        assert_eq!(
             validate_chain_layout(
                 &[
                     ChainRegion::readable(16),
@@ -398,6 +402,16 @@ mod tests {
                 8,
             ),
             Err(ChainLayoutError::LengthOverflow)
+        );
+
+        let layout =
+            validate_chain_layout(&[ChainRegion::readable(16), ChainRegion::writable(16)], 8)
+                .unwrap();
+        let request = [0_u8; 15];
+        let response = [0_u8; 16];
+        assert_eq!(
+            layout.validate_ports(&request, &response),
+            Err(ChainLayoutError::PortLengthMismatch)
         );
     }
 

--- a/crates/virtio-accel-device/src/regions.rs
+++ b/crates/virtio-accel-device/src/regions.rs
@@ -1,0 +1,437 @@
+//! Transport-neutral descriptor metadata and segmented byte ports.
+//!
+//! Layout validation is allocation-free and visits each descriptor once. Each segmented port
+//! access scans at most the segment list and copies only the requested range; constructors reject
+//! empty, zero-length, and overflowing segment collections.
+
+use core::cmp::min;
+
+use virtio_accel_core::{BackendError, ByteSink, ByteSource};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RegionDirection {
+    DeviceReadable,
+    DeviceWritable,
+}
+
+/// Direction and length of one flattened chain region, without any transport identity or address.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ChainRegion {
+    pub direction: RegionDirection,
+    pub bytes: u64,
+}
+
+impl ChainRegion {
+    pub const fn readable(bytes: u64) -> Self {
+        Self {
+            direction: RegionDirection::DeviceReadable,
+            bytes,
+        }
+    }
+
+    pub const fn writable(bytes: u64) -> Self {
+        Self {
+            direction: RegionDirection::DeviceWritable,
+            bytes,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ChainLayoutError {
+    DescriptorCount,
+    ZeroLength,
+    Direction,
+    LengthOverflow,
+    PortLengthMismatch,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ChainLayout {
+    descriptor_count: u16,
+    readable_descriptors: u16,
+    writable_descriptors: u16,
+    readable_bytes: u64,
+    writable_bytes: u64,
+}
+
+impl ChainLayout {
+    pub const fn descriptor_count(self) -> u16 {
+        self.descriptor_count
+    }
+
+    pub const fn readable_descriptors(self) -> u16 {
+        self.readable_descriptors
+    }
+
+    pub const fn writable_descriptors(self) -> u16 {
+        self.writable_descriptors
+    }
+
+    pub const fn readable_bytes(self) -> u64 {
+        self.readable_bytes
+    }
+
+    pub const fn writable_bytes(self) -> u64 {
+        self.writable_bytes
+    }
+
+    pub fn validate_ports(
+        self,
+        request: &dyn ByteSource,
+        response: &dyn ByteSink,
+    ) -> Result<(), ChainLayoutError> {
+        if request.len() != self.readable_bytes || response.len() != self.writable_bytes {
+            return Err(ChainLayoutError::PortLengthMismatch);
+        }
+        Ok(())
+    }
+}
+
+/// Validate transport-neutral descriptor metadata before any frame bytes are decoded.
+///
+/// The descriptors contain only direction and length. Guest addresses, queue indices, and mapping
+/// details remain owned by the transport adapter.
+pub fn validate_chain_layout(
+    regions: &[ChainRegion],
+    max_descriptors: u16,
+) -> Result<ChainLayout, ChainLayoutError> {
+    if regions.len() < 2 || regions.len() > usize::from(max_descriptors) {
+        return Err(ChainLayoutError::DescriptorCount);
+    }
+
+    let mut readable_descriptors = 0_u16;
+    let mut writable_descriptors = 0_u16;
+    let mut readable_bytes = 0_u64;
+    let mut writable_bytes = 0_u64;
+    let mut saw_writable = false;
+
+    for region in regions {
+        if region.bytes == 0 {
+            return Err(ChainLayoutError::ZeroLength);
+        }
+        match region.direction {
+            RegionDirection::DeviceReadable => {
+                if saw_writable {
+                    return Err(ChainLayoutError::Direction);
+                }
+                readable_descriptors += 1;
+                readable_bytes = readable_bytes
+                    .checked_add(region.bytes)
+                    .ok_or(ChainLayoutError::LengthOverflow)?;
+            }
+            RegionDirection::DeviceWritable => {
+                saw_writable = true;
+                writable_descriptors += 1;
+                writable_bytes = writable_bytes
+                    .checked_add(region.bytes)
+                    .ok_or(ChainLayoutError::LengthOverflow)?;
+            }
+        }
+    }
+
+    if readable_descriptors == 0 || writable_descriptors == 0 {
+        return Err(ChainLayoutError::Direction);
+    }
+    Ok(ChainLayout {
+        descriptor_count: regions.len() as u16,
+        readable_descriptors,
+        writable_descriptors,
+        readable_bytes,
+        writable_bytes,
+    })
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SegmentedRegionError {
+    Empty,
+    ZeroLength,
+    LengthOverflow,
+}
+
+/// Borrowed segmented source used by unit tests, fuzz targets, and simple transport adapters.
+#[derive(Debug)]
+pub struct SegmentedSource<'segments, 'bytes> {
+    segments: &'segments [&'bytes [u8]],
+    len: u64,
+}
+
+impl<'segments, 'bytes> SegmentedSource<'segments, 'bytes> {
+    pub fn new(segments: &'segments [&'bytes [u8]]) -> Result<Self, SegmentedRegionError> {
+        let len = checked_segment_len(segments.iter().map(|segment| segment.len()))?;
+        Ok(Self { segments, len })
+    }
+}
+
+impl ByteSource for SegmentedSource<'_, '_> {
+    fn len(&self) -> u64 {
+        self.len
+    }
+
+    fn read_at(&self, offset: u64, target: &mut [u8]) -> Result<(), BackendError> {
+        checked_range(offset, target.len(), self.len)?;
+        if target.is_empty() {
+            return Ok(());
+        }
+
+        let mut skip = offset;
+        let mut written = 0;
+        for segment in self.segments {
+            let segment_len = segment.len() as u64;
+            if skip >= segment_len {
+                skip -= segment_len;
+                continue;
+            }
+
+            let start = skip as usize;
+            let count = min(segment.len() - start, target.len() - written);
+            target[written..written + count].copy_from_slice(&segment[start..start + count]);
+            written += count;
+            skip = 0;
+            if written == target.len() {
+                return Ok(());
+            }
+        }
+
+        Err(BackendError::OutOfBounds)
+    }
+
+    fn as_contiguous(&self) -> Option<&[u8]> {
+        (self.segments.len() == 1).then_some(self.segments[0])
+    }
+}
+
+/// Borrowed segmented sink used by unit tests, fuzz targets, and simple transport adapters.
+#[derive(Debug)]
+pub struct SegmentedSink<'segments, 'bytes> {
+    segments: &'segments mut [&'bytes mut [u8]],
+    len: u64,
+}
+
+impl<'segments, 'bytes> SegmentedSink<'segments, 'bytes> {
+    pub fn new(segments: &'segments mut [&'bytes mut [u8]]) -> Result<Self, SegmentedRegionError> {
+        let len = checked_segment_len(segments.iter().map(|segment| segment.len()))?;
+        Ok(Self { segments, len })
+    }
+}
+
+impl ByteSink for SegmentedSink<'_, '_> {
+    fn len(&self) -> u64 {
+        self.len
+    }
+
+    fn write_at(&mut self, offset: u64, source: &[u8]) -> Result<(), BackendError> {
+        checked_range(offset, source.len(), self.len)?;
+        if source.is_empty() {
+            return Ok(());
+        }
+
+        let mut skip = offset;
+        let mut read = 0;
+        for segment in self.segments.iter_mut() {
+            let segment = &mut **segment;
+            let segment_len = segment.len() as u64;
+            if skip >= segment_len {
+                skip -= segment_len;
+                continue;
+            }
+
+            let start = skip as usize;
+            let count = min(segment.len() - start, source.len() - read);
+            segment[start..start + count].copy_from_slice(&source[read..read + count]);
+            read += count;
+            skip = 0;
+            if read == source.len() {
+                return Ok(());
+            }
+        }
+
+        Err(BackendError::OutOfBounds)
+    }
+
+    fn as_contiguous_mut(&mut self) -> Option<&mut [u8]> {
+        if self.segments.len() == 1 {
+            Some(&mut *self.segments[0])
+        } else {
+            None
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct ReadableRegion<'a> {
+    source: &'a dyn ByteSource,
+    offset: u64,
+    len: u64,
+}
+
+impl<'a> ReadableRegion<'a> {
+    pub fn new(source: &'a dyn ByteSource, offset: u64, len: u64) -> Result<Self, BackendError> {
+        checked_range_u64(offset, len, source.len())?;
+        Ok(Self {
+            source,
+            offset,
+            len,
+        })
+    }
+}
+
+impl ByteSource for ReadableRegion<'_> {
+    fn len(&self) -> u64 {
+        self.len
+    }
+
+    fn read_at(&self, offset: u64, target: &mut [u8]) -> Result<(), BackendError> {
+        checked_range(offset, target.len(), self.len)?;
+        let source_offset = self
+            .offset
+            .checked_add(offset)
+            .ok_or(BackendError::OutOfBounds)?;
+        self.source.read_at(source_offset, target)
+    }
+
+    fn as_contiguous(&self) -> Option<&[u8]> {
+        let start = usize::try_from(self.offset).ok()?;
+        let len = usize::try_from(self.len).ok()?;
+        let end = start.checked_add(len)?;
+        self.source.as_contiguous()?.get(start..end)
+    }
+}
+
+#[derive(Debug)]
+pub struct WritableRegion<'a> {
+    sink: &'a mut dyn ByteSink,
+    offset: u64,
+    len: u64,
+}
+
+impl<'a> WritableRegion<'a> {
+    pub fn new(sink: &'a mut dyn ByteSink, offset: u64, len: u64) -> Result<Self, BackendError> {
+        checked_range_u64(offset, len, sink.len())?;
+        Ok(Self { sink, offset, len })
+    }
+}
+
+impl ByteSink for WritableRegion<'_> {
+    fn len(&self) -> u64 {
+        self.len
+    }
+
+    fn write_at(&mut self, offset: u64, source: &[u8]) -> Result<(), BackendError> {
+        checked_range(offset, source.len(), self.len)?;
+        let sink_offset = self
+            .offset
+            .checked_add(offset)
+            .ok_or(BackendError::OutOfBounds)?;
+        self.sink.write_at(sink_offset, source)
+    }
+
+    fn as_contiguous_mut(&mut self) -> Option<&mut [u8]> {
+        let start = usize::try_from(self.offset).ok()?;
+        let len = usize::try_from(self.len).ok()?;
+        let end = start.checked_add(len)?;
+        self.sink.as_contiguous_mut()?.get_mut(start..end)
+    }
+}
+
+fn checked_segment_len(
+    lengths: impl IntoIterator<Item = usize>,
+) -> Result<u64, SegmentedRegionError> {
+    let mut count = 0_usize;
+    let mut total = 0_u64;
+    for len in lengths {
+        count += 1;
+        if len == 0 {
+            return Err(SegmentedRegionError::ZeroLength);
+        }
+        total = total
+            .checked_add(len as u64)
+            .ok_or(SegmentedRegionError::LengthOverflow)?;
+    }
+    if count == 0 {
+        return Err(SegmentedRegionError::Empty);
+    }
+    Ok(total)
+}
+
+fn checked_range(offset: u64, bytes: usize, len: u64) -> Result<(), BackendError> {
+    let bytes = u64::try_from(bytes).map_err(|_| BackendError::OutOfBounds)?;
+    checked_range_u64(offset, bytes, len)
+}
+
+fn checked_range_u64(offset: u64, bytes: u64, len: u64) -> Result<(), BackendError> {
+    let end = offset.checked_add(bytes).ok_or(BackendError::OutOfBounds)?;
+    if end > len {
+        return Err(BackendError::OutOfBounds);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chain_layout_rejects_direction_and_length_errors() {
+        assert_eq!(
+            validate_chain_layout(
+                &[
+                    ChainRegion::readable(16),
+                    ChainRegion::writable(16),
+                    ChainRegion::readable(1),
+                ],
+                8,
+            ),
+            Err(ChainLayoutError::Direction)
+        );
+        assert_eq!(
+            validate_chain_layout(&[ChainRegion::readable(0), ChainRegion::writable(16),], 8,),
+            Err(ChainLayoutError::ZeroLength)
+        );
+        assert_eq!(
+            validate_chain_layout(
+                &[
+                    ChainRegion::readable(u64::MAX),
+                    ChainRegion::readable(1),
+                    ChainRegion::writable(16),
+                ],
+                8,
+            ),
+            Err(ChainLayoutError::LengthOverflow)
+        );
+    }
+
+    #[test]
+    fn segmented_ports_cross_every_boundary() {
+        let bytes = *b"segmented";
+        for split in 1..bytes.as_slice().len() {
+            let source_segments = [&bytes[..split], &bytes[split..]];
+            let source = SegmentedSource::new(&source_segments).unwrap();
+            let mut decoded = [0_u8; 9];
+            source.read_at(0, &mut decoded).unwrap();
+            assert_eq!(decoded, bytes);
+
+            let mut first = [0_u8; 9];
+            let (left, right) = first.split_at_mut(split);
+            let mut sink_segments: [&mut [u8]; 2] = [left, right];
+            let mut sink = SegmentedSink::new(&mut sink_segments).unwrap();
+            sink.write_at(0, &bytes).unwrap();
+            assert_eq!(first, bytes);
+        }
+    }
+
+    #[test]
+    fn subregions_preserve_bounds_and_contiguous_fast_paths() {
+        let bytes = *b"01234567";
+        let region = ReadableRegion::new(&bytes, 2, 4).unwrap();
+        assert_eq!(region.as_contiguous(), Some(&b"2345"[..]));
+
+        let mut output = [0_u8; 8];
+        {
+            let mut region = WritableRegion::new(&mut output, 2, 4).unwrap();
+            assert_eq!(region.as_contiguous_mut().unwrap().len(), 4);
+            region.write_at(0, b"abcd").unwrap();
+        }
+        assert_eq!(&output, b"\0\0abcd\0\0");
+    }
+}

--- a/crates/virtio-accel-device/src/response.rs
+++ b/crates/virtio-accel-device/src/response.rs
@@ -8,7 +8,8 @@ use virtio_accel_core::{ByteSink, ByteSource};
 use virtio_accel_proto::{ResponseHeader, StatusCode};
 use zerocopy::IntoBytes;
 
-const RESPONSE_HEADER_BYTES: u64 = core::mem::size_of::<virtio_accel_proto::ResponseHeader>() as u64;
+const RESPONSE_HEADER_BYTES: u64 =
+    core::mem::size_of::<virtio_accel_proto::ResponseHeader>() as u64;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ResponseWriteError {

--- a/crates/virtio-accel-device/src/response.rs
+++ b/crates/virtio-accel-device/src/response.rs
@@ -5,9 +5,8 @@
 //! fixed 4 KiB stack scratch buffer and never allocates or writes beyond the preflighted frame.
 
 use virtio_accel_core::{ByteSink, ByteSource};
-use virtio_accel_proto::StatusCode;
-
-use crate::WritableRegion;
+use virtio_accel_proto::{ResponseHeader, StatusCode};
+use zerocopy::IntoBytes;
 
 const RESPONSE_HEADER_BYTES: u64 = 16;
 
@@ -47,32 +46,21 @@ impl<'a> ResponseWriter<'a> {
         self.max_response_bytes
     }
 
-    pub fn payload_region(
+    /// Borrow the exact success-payload destination.
+    ///
+    /// The returned guard commits the same payload length that was preflighted here, preventing a
+    /// caller from initializing one range and advertising another in the response header.
+    pub fn payload(
         &mut self,
         payload_bytes: u64,
-    ) -> Result<WritableRegion<'_>, ResponseWriteError> {
-        self.preflight(payload_bytes)?;
-        WritableRegion::new(self.sink, RESPONSE_HEADER_BYTES, payload_bytes)
-            .map_err(|_| ResponseWriteError::InsufficientCapacity)
-    }
-
-    /// Commit the response header after its payload has been initialized.
-    pub fn commit(
-        &mut self,
-        status: StatusCode,
-        request_id: u64,
-        payload_bytes: u32,
-    ) -> Result<u32, ResponseWriteError> {
-        let used = self.preflight(u64::from(payload_bytes))?;
-        let mut header = [0_u8; RESPONSE_HEADER_BYTES as usize];
-        header[0..2].copy_from_slice(&status.0.to_le_bytes());
-        header[2..4].copy_from_slice(&0_u16.to_le_bytes());
-        header[4..8].copy_from_slice(&payload_bytes.to_le_bytes());
-        header[8..16].copy_from_slice(&request_id.to_le_bytes());
-        self.sink
-            .write_at(0, &header)
-            .map_err(|_| ResponseWriteError::SinkAccess)?;
-        Ok(used)
+    ) -> Result<ResponsePayload<'_>, ResponseWriteError> {
+        let used = self.preflight(payload_bytes)?;
+        Ok(ResponsePayload {
+            sink: self.sink,
+            payload_bytes: u32::try_from(payload_bytes)
+                .map_err(|_| ResponseWriteError::FrameTooLarge)?,
+            used,
+        })
     }
 
     /// Write a bounded payload first, then atomically expose it by committing the header.
@@ -83,11 +71,11 @@ impl<'a> ResponseWriter<'a> {
         payload: &dyn ByteSource,
     ) -> Result<u32, ResponseWriteError> {
         let payload_bytes = payload.len();
-        self.preflight(payload_bytes)?;
+        let mut destination = self.payload(payload_bytes)?;
 
         if let Some(contiguous) = payload.as_contiguous() {
-            self.sink
-                .write_at(RESPONSE_HEADER_BYTES, contiguous)
+            destination
+                .write_at(0, contiguous)
                 .map_err(|_| ResponseWriteError::SinkAccess)?;
         } else {
             let mut scratch = [0_u8; 4096];
@@ -99,18 +87,14 @@ impl<'a> ResponseWriter<'a> {
                 payload
                     .read_at(offset, &mut scratch[..count])
                     .map_err(|_| ResponseWriteError::SourceAccess)?;
-                self.sink
-                    .write_at(RESPONSE_HEADER_BYTES + offset, &scratch[..count])
+                destination
+                    .write_at(offset, &scratch[..count])
                     .map_err(|_| ResponseWriteError::SinkAccess)?;
                 offset += count as u64;
             }
         }
 
-        self.commit(
-            status,
-            request_id,
-            u32::try_from(payload_bytes).map_err(|_| ResponseWriteError::FrameTooLarge)?,
-        )
+        destination.commit(status, request_id)
     }
 
     pub fn write_empty(
@@ -118,7 +102,9 @@ impl<'a> ResponseWriter<'a> {
         status: StatusCode,
         request_id: u64,
     ) -> Result<u32, ResponseWriteError> {
-        self.commit(status, request_id, 0)
+        let used = self.preflight(0)?;
+        write_header(self.sink, status, request_id, 0)?;
+        Ok(used)
     }
 
     fn preflight(&self, payload_bytes: u64) -> Result<u32, ResponseWriteError> {
@@ -133,6 +119,72 @@ impl<'a> ResponseWriter<'a> {
         }
         Ok(total as u32)
     }
+}
+
+/// Exact payload destination for one preflighted response.
+pub struct ResponsePayload<'a> {
+    sink: &'a mut dyn ByteSink,
+    payload_bytes: u32,
+    used: u32,
+}
+
+impl core::fmt::Debug for ResponsePayload<'_> {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        formatter
+            .debug_struct("ResponsePayload")
+            .field("payload_bytes", &self.payload_bytes)
+            .field("used", &self.used)
+            .finish()
+    }
+}
+
+impl ResponsePayload<'_> {
+    /// Commit the response header after the complete payload has been initialized.
+    pub fn commit(self, status: StatusCode, request_id: u64) -> Result<u32, ResponseWriteError> {
+        write_header(self.sink, status, request_id, self.payload_bytes)?;
+        Ok(self.used)
+    }
+}
+
+impl ByteSink for ResponsePayload<'_> {
+    fn len(&self) -> u64 {
+        u64::from(self.payload_bytes)
+    }
+
+    fn write_at(
+        &mut self,
+        offset: u64,
+        source: &[u8],
+    ) -> Result<(), virtio_accel_core::BackendError> {
+        let bytes = u64::try_from(source.len())
+            .map_err(|_| virtio_accel_core::BackendError::OutOfBounds)?;
+        let end = offset
+            .checked_add(bytes)
+            .ok_or(virtio_accel_core::BackendError::OutOfBounds)?;
+        if end > self.len() {
+            return Err(virtio_accel_core::BackendError::OutOfBounds);
+        }
+        self.sink.write_at(RESPONSE_HEADER_BYTES + offset, source)
+    }
+
+    fn as_contiguous_mut(&mut self) -> Option<&mut [u8]> {
+        let sink = self.sink.as_contiguous_mut()?;
+        let end = RESPONSE_HEADER_BYTES
+            .checked_add(u64::from(self.payload_bytes))
+            .and_then(|end| usize::try_from(end).ok())?;
+        sink.get_mut(RESPONSE_HEADER_BYTES as usize..end)
+    }
+}
+
+fn write_header(
+    sink: &mut dyn ByteSink,
+    status: StatusCode,
+    request_id: u64,
+    payload_bytes: u32,
+) -> Result<(), ResponseWriteError> {
+    let header = ResponseHeader::new(status, payload_bytes, request_id);
+    sink.write_at(0, header.as_bytes())
+        .map_err(|_| ResponseWriteError::SinkAccess)
 }
 
 #[cfg(test)]
@@ -170,11 +222,9 @@ mod tests {
     fn direct_payload_region_does_not_touch_excess_capacity() {
         let mut output = [0xaa_u8; 32];
         let mut writer = ResponseWriter::new(&mut output, 32);
-        {
-            let mut payload = writer.payload_region(4).unwrap();
-            payload.write_at(0, b"data").unwrap();
-        }
-        assert_eq!(writer.commit(StatusCode::OK, 7, 4), Ok(20));
+        let mut payload = writer.payload(4).unwrap();
+        payload.write_at(0, b"data").unwrap();
+        assert_eq!(payload.commit(StatusCode::OK, 7), Ok(20));
         assert_eq!(&output[16..20], b"data");
         assert_eq!(&output[20..], &[0xaa; 12]);
     }
@@ -184,9 +234,21 @@ mod tests {
         let mut output = [0xaa_u8; 16];
         let mut writer = ResponseWriter::new(&mut output, u32::MAX);
         assert_eq!(
-            writer.payload_region(u64::MAX).unwrap_err(),
+            writer.payload(u64::MAX).unwrap_err(),
             ResponseWriteError::FrameTooLarge
         );
         assert_eq!(output, [0xaa; 16]);
+    }
+
+    #[test]
+    fn payload_guard_commits_the_preflighted_length() {
+        let mut output = [0xaa_u8; 24];
+        let mut writer = ResponseWriter::new(&mut output, 24);
+        let mut payload = writer.payload(8).unwrap();
+        assert_eq!(payload.len(), 8);
+        assert!(payload.write_at(7, &[1, 2]).is_err());
+        payload.write_at(0, &[0; 8]).unwrap();
+        assert_eq!(payload.commit(StatusCode::OK, 9), Ok(24));
+        assert_eq!(&output[4..8], &8_u32.to_le_bytes());
     }
 }

--- a/crates/virtio-accel-device/src/response.rs
+++ b/crates/virtio-accel-device/src/response.rs
@@ -190,11 +190,13 @@ fn write_header(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::SegmentedSink;
+    use crate::{SegmentedSink, SegmentedSource};
 
     #[test]
     fn response_header_and_payload_cross_every_writable_split() {
         let payload = *b"response";
+        let payload_segments = [&payload[..3], &payload[3..]];
+        let payload_source = SegmentedSource::new(&payload_segments).unwrap();
         let expected_len = 16 + payload.as_slice().len();
         for split in 1..expected_len {
             let mut output = [0_u8; 24];
@@ -204,7 +206,7 @@ mod tests {
             let mut writer = ResponseWriter::new(&mut sink, 1024);
             assert_eq!(
                 writer
-                    .write_response(StatusCode::OK, 0x0102_0304_0506_0708, &payload)
+                    .write_response(StatusCode::OK, 0x0102_0304_0506_0708, &payload_source)
                     .unwrap(),
                 expected_len as u32
             );

--- a/crates/virtio-accel-device/src/response.rs
+++ b/crates/virtio-accel-device/src/response.rs
@@ -1,0 +1,192 @@
+//! Bounded response framing over a potentially segmented destination.
+//!
+//! Callers can expose an exact payload subregion directly to a backend, then commit the 16-byte
+//! response header only after the payload is initialized. The convenience streaming path uses one
+//! fixed 4 KiB stack scratch buffer and never allocates or writes beyond the preflighted frame.
+
+use virtio_accel_core::{ByteSink, ByteSource};
+use virtio_accel_proto::StatusCode;
+
+use crate::WritableRegion;
+
+const RESPONSE_HEADER_BYTES: u64 = 16;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ResponseWriteError {
+    FrameTooLarge,
+    InsufficientCapacity,
+    SourceAccess,
+    SinkAccess,
+}
+
+/// Preflighted writer for one response frame.
+pub struct ResponseWriter<'a> {
+    sink: &'a mut dyn ByteSink,
+    max_response_bytes: u32,
+}
+
+impl core::fmt::Debug for ResponseWriter<'_> {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        formatter
+            .debug_struct("ResponseWriter")
+            .field("capacity", &self.sink.len())
+            .field("max_response_bytes", &self.max_response_bytes)
+            .finish()
+    }
+}
+
+impl<'a> ResponseWriter<'a> {
+    pub fn new(sink: &'a mut dyn ByteSink, max_response_bytes: u32) -> Self {
+        Self {
+            sink,
+            max_response_bytes,
+        }
+    }
+
+    pub const fn max_response_bytes(&self) -> u32 {
+        self.max_response_bytes
+    }
+
+    pub fn payload_region(
+        &mut self,
+        payload_bytes: u64,
+    ) -> Result<WritableRegion<'_>, ResponseWriteError> {
+        self.preflight(payload_bytes)?;
+        WritableRegion::new(self.sink, RESPONSE_HEADER_BYTES, payload_bytes)
+            .map_err(|_| ResponseWriteError::InsufficientCapacity)
+    }
+
+    /// Commit the response header after its payload has been initialized.
+    pub fn commit(
+        &mut self,
+        status: StatusCode,
+        request_id: u64,
+        payload_bytes: u32,
+    ) -> Result<u32, ResponseWriteError> {
+        let used = self.preflight(u64::from(payload_bytes))?;
+        let mut header = [0_u8; RESPONSE_HEADER_BYTES as usize];
+        header[0..2].copy_from_slice(&status.0.to_le_bytes());
+        header[2..4].copy_from_slice(&0_u16.to_le_bytes());
+        header[4..8].copy_from_slice(&payload_bytes.to_le_bytes());
+        header[8..16].copy_from_slice(&request_id.to_le_bytes());
+        self.sink
+            .write_at(0, &header)
+            .map_err(|_| ResponseWriteError::SinkAccess)?;
+        Ok(used)
+    }
+
+    /// Write a bounded payload first, then atomically expose it by committing the header.
+    pub fn write_response(
+        &mut self,
+        status: StatusCode,
+        request_id: u64,
+        payload: &dyn ByteSource,
+    ) -> Result<u32, ResponseWriteError> {
+        let payload_bytes = payload.len();
+        self.preflight(payload_bytes)?;
+
+        if let Some(contiguous) = payload.as_contiguous() {
+            self.sink
+                .write_at(RESPONSE_HEADER_BYTES, contiguous)
+                .map_err(|_| ResponseWriteError::SinkAccess)?;
+        } else {
+            let mut scratch = [0_u8; 4096];
+            let mut offset = 0_u64;
+            while offset < payload_bytes {
+                let remaining = payload_bytes - offset;
+                let count = usize::try_from(remaining.min(scratch.as_slice().len() as u64))
+                    .map_err(|_| ResponseWriteError::FrameTooLarge)?;
+                payload
+                    .read_at(offset, &mut scratch[..count])
+                    .map_err(|_| ResponseWriteError::SourceAccess)?;
+                self.sink
+                    .write_at(RESPONSE_HEADER_BYTES + offset, &scratch[..count])
+                    .map_err(|_| ResponseWriteError::SinkAccess)?;
+                offset += count as u64;
+            }
+        }
+
+        self.commit(
+            status,
+            request_id,
+            u32::try_from(payload_bytes).map_err(|_| ResponseWriteError::FrameTooLarge)?,
+        )
+    }
+
+    pub fn write_empty(
+        &mut self,
+        status: StatusCode,
+        request_id: u64,
+    ) -> Result<u32, ResponseWriteError> {
+        self.commit(status, request_id, 0)
+    }
+
+    fn preflight(&self, payload_bytes: u64) -> Result<u32, ResponseWriteError> {
+        let total = RESPONSE_HEADER_BYTES
+            .checked_add(payload_bytes)
+            .ok_or(ResponseWriteError::FrameTooLarge)?;
+        if total > u64::from(self.max_response_bytes) || total > u64::from(u32::MAX) {
+            return Err(ResponseWriteError::FrameTooLarge);
+        }
+        if total > self.sink.len() {
+            return Err(ResponseWriteError::InsufficientCapacity);
+        }
+        Ok(total as u32)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::SegmentedSink;
+
+    #[test]
+    fn response_header_and_payload_cross_every_writable_split() {
+        let payload = *b"response";
+        let expected_len = 16 + payload.as_slice().len();
+        for split in 1..expected_len {
+            let mut output = [0_u8; 24];
+            let (left, right) = output.split_at_mut(split);
+            let mut segments: [&mut [u8]; 2] = [left, right];
+            let mut sink = SegmentedSink::new(&mut segments).unwrap();
+            let mut writer = ResponseWriter::new(&mut sink, 1024);
+            assert_eq!(
+                writer
+                    .write_response(StatusCode::OK, 0x0102_0304_0506_0708, &payload)
+                    .unwrap(),
+                expected_len as u32
+            );
+
+            assert_eq!(&output[0..2], &StatusCode::OK.0.to_le_bytes());
+            assert_eq!(
+                &output[4..8],
+                &(payload.as_slice().len() as u32).to_le_bytes()
+            );
+            assert_eq!(&output[16..], &payload);
+        }
+    }
+
+    #[test]
+    fn direct_payload_region_does_not_touch_excess_capacity() {
+        let mut output = [0xaa_u8; 32];
+        let mut writer = ResponseWriter::new(&mut output, 32);
+        {
+            let mut payload = writer.payload_region(4).unwrap();
+            payload.write_at(0, b"data").unwrap();
+        }
+        assert_eq!(writer.commit(StatusCode::OK, 7, 4), Ok(20));
+        assert_eq!(&output[16..20], b"data");
+        assert_eq!(&output[20..], &[0xaa; 12]);
+    }
+
+    #[test]
+    fn response_length_overflow_is_rejected_before_writing() {
+        let mut output = [0xaa_u8; 16];
+        let mut writer = ResponseWriter::new(&mut output, u32::MAX);
+        assert_eq!(
+            writer.payload_region(u64::MAX).unwrap_err(),
+            ResponseWriteError::FrameTooLarge
+        );
+        assert_eq!(output, [0xaa; 16]);
+    }
+}

--- a/crates/virtio-accel-device/src/response.rs
+++ b/crates/virtio-accel-device/src/response.rs
@@ -8,7 +8,7 @@ use virtio_accel_core::{ByteSink, ByteSource};
 use virtio_accel_proto::{ResponseHeader, StatusCode};
 use zerocopy::IntoBytes;
 
-const RESPONSE_HEADER_BYTES: u64 = 16;
+const RESPONSE_HEADER_BYTES: u64 = core::mem::size_of::<virtio_accel_proto::ResponseHeader>() as u64;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ResponseWriteError {


### PR DESCRIPTION
## Summary

- add transport-neutral chain topology validation and segmented readable/writable byte ports
- decode every protocol 1.0 request incrementally, including reserved fields, exact lengths, limits, ranges, and binding arrays
- keep write-buffer and artifact tails borrowed from the original segmented request instead of coalescing complete payloads
- add atomic command-frame preflight so only fully validated requests become dispatchable
- write recoverable protocol failures as exact 16-byte responses while unusable chains remain untouched with used length zero
- add length-bound response payload guards for direct segmented `READ_BUFFER` output

## Safety and performance

- remains `no_std + alloc` and contains no guest-address, operating-system, or virtqueue types
- uses fixed stack scratch space for headers and fixed prefixes
- limits fallible allocation to the validated `SUBMIT` binding count
- performs linear binding validation with radix-based duplicate-slot detection
- preserves direct segmented access for request tails and response payloads

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --offline -- -D warnings`
- `cargo test --workspace --all-targets --all-features --offline`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps --offline`
- portable `no_std` checks for `aarch64-unknown-none` and `riscv64gc-unknown-none-elf`
- adversarial unit coverage for every canonical request split at every byte boundary

Closes #12
