### PR TITLE
Implement baseline command processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,6 +128,7 @@ version = "0.1.0"
 dependencies = [
  "serde_json",
  "virtio-accel-core",
+ "virtio-accel-mock",
  "virtio-accel-proto",
  "zerocopy",
 ]

--- a/crates/virtio-accel-core/src/lib.rs
+++ b/crates/virtio-accel-core/src/lib.rs
@@ -713,6 +713,8 @@ pub trait Accelerator {
     ///
     /// The command engine calls this only for buffers with [`BufferUsage::TRANSFER_SOURCE`]. The
     /// provider must not retain `data` and should write directly across segmented destinations.
+    /// Returning `Ok(())` guarantees that every byte in `data` was initialized; the command engine
+    /// may publish the complete destination without first clearing it.
     fn read_buffer(
         &self,
         buffer: &Self::Buffer,

--- a/crates/virtio-accel-device/Cargo.toml
+++ b/crates/virtio-accel-device/Cargo.toml
@@ -14,3 +14,4 @@ zerocopy.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true
+virtio-accel-mock.workspace = true

--- a/crates/virtio-accel-device/src/engine.rs
+++ b/crates/virtio-accel-device/src/engine.rs
@@ -1,0 +1,631 @@
+//! Transport-neutral baseline command processing.
+//!
+//! `CommandProcessor` owns one backend and one device-state graph. Processing requires exclusive
+//! access, so the portable layer contains no locks, atomics, reference-counted handles, or hidden
+//! executor. Transport integrations may schedule distinct processors or backend work concurrently,
+//! but state admission and response commitment remain explicit serialization boundaries.
+
+use virtio_accel_core::{
+    Accelerator, ArtifactRef, BackendError, BufferRange, BufferUsage, ByteSink, ByteSource,
+    DeviceInfo, ReleaseFailure,
+};
+use virtio_accel_proto::{Le16, Le32, Le64, ObjectPayload, StatusCode, WireConfig, WireDeviceInfo};
+use zerocopy::IntoBytes;
+
+use crate::{
+    BufferRecord, ChainRegion, CreateError, DecodedRequest, DecodedRequestBody, DecoderLimits,
+    DecoderLimitsError, DeviceState, DeviceStateConfigError, DeviceStateError, FrameDecoder,
+    FramePreflight, FramePreflightError, ObjectId, ObjectNamespace, ResponseWriteError,
+    ResponseWriter, UnusableFrame, preflight_command_frame, status_from_backend_error,
+    status_from_device_state_error,
+};
+
+pub type AcceleratorState<A> = DeviceState<
+    <A as Accelerator>::Context,
+    <A as Accelerator>::Buffer,
+    <A as Accelerator>::Program,
+    <A as Accelerator>::Queue,
+    <A as Accelerator>::Event,
+>;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DeviceHealth {
+    Running,
+    NeedsReset,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CommandProcessorInitError {
+    Backend(BackendError),
+    Decoder(DecoderLimitsError),
+    State(DeviceStateConfigError),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CommandProcessError {
+    Preflight(FramePreflightError),
+    ResponseWrite(ResponseWriteError),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CommandOutcome {
+    Response {
+        request_id: u64,
+        status: StatusCode,
+        used: u32,
+    },
+    Unusable(UnusableFrame),
+}
+
+/// One synchronization-free command engine for a backend instance.
+///
+/// The backend's immutable device information is fetched once during construction and then used
+/// for decoding, validation, and discovery responses. This prevents limits from changing beneath
+/// live object state and removes a backend call from the discovery path.
+pub struct CommandProcessor<A: Accelerator> {
+    accelerator: A,
+    info: DeviceInfo,
+    decoder: FrameDecoder,
+    state: AcceleratorState<A>,
+    health: DeviceHealth,
+}
+
+impl<A: Accelerator> core::fmt::Debug for CommandProcessor<A> {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        formatter
+            .debug_struct("CommandProcessor")
+            .field("info", &self.info)
+            .field("decoder", &self.decoder)
+            .field("health", &self.health)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<A: Accelerator> CommandProcessor<A> {
+    pub fn new(
+        accelerator: A,
+        config: &WireConfig,
+        namespace: ObjectNamespace,
+    ) -> Result<Self, CommandProcessorInitError> {
+        config.validate().map_err(|error| {
+            CommandProcessorInitError::Decoder(DecoderLimitsError::Config(error))
+        })?;
+        let info = accelerator
+            .device_info()
+            .map_err(CommandProcessorInitError::Backend)?;
+        let limits =
+            DecoderLimits::new(config, info).map_err(CommandProcessorInitError::Decoder)?;
+        let state =
+            DeviceState::new(namespace, info.limits).map_err(CommandProcessorInitError::State)?;
+        Ok(Self {
+            accelerator,
+            info,
+            decoder: FrameDecoder::new(limits),
+            state,
+            health: DeviceHealth::Running,
+        })
+    }
+
+    pub const fn device_info(&self) -> DeviceInfo {
+        self.info
+    }
+
+    pub const fn health(&self) -> DeviceHealth {
+        self.health
+    }
+
+    pub const fn decoder(&self) -> &FrameDecoder {
+        &self.decoder
+    }
+
+    pub const fn accelerator(&self) -> &A {
+        &self.accelerator
+    }
+
+    pub const fn state(&self) -> &AcceleratorState<A> {
+        &self.state
+    }
+
+    /// Process one complete flattened command chain.
+    ///
+    /// A successful preflight guarantees response capacity for the command's largest success
+    /// payload before semantic state or the backend is touched. Once recovery is required, later
+    /// valid frames receive `DEVICE_LOST` without reaching semantic dispatch.
+    pub fn process(
+        &mut self,
+        regions: &[ChainRegion],
+        request: &dyn ByteSource,
+        response: &mut dyn ByteSink,
+    ) -> Result<CommandOutcome, CommandProcessError> {
+        match preflight_command_frame(&self.decoder, regions, request, response)
+            .map_err(CommandProcessError::Preflight)?
+        {
+            FramePreflight::Rejected {
+                request_id,
+                status,
+                used,
+            } => Ok(CommandOutcome::Response {
+                request_id,
+                status,
+                used,
+            }),
+            FramePreflight::Unusable(error) => Ok(CommandOutcome::Unusable(error)),
+            FramePreflight::Ready(request) => {
+                if self.health == DeviceHealth::NeedsReset {
+                    return self.respond_empty(
+                        response,
+                        StatusCode::DEVICE_LOST,
+                        request.request_id(),
+                        false,
+                    );
+                }
+                self.dispatch(request, response)
+            }
+        }
+    }
+
+    fn dispatch(
+        &mut self,
+        request: DecodedRequest<'_>,
+        response: &mut dyn ByteSink,
+    ) -> Result<CommandOutcome, CommandProcessError> {
+        let request_id = request.request_id();
+        match request.into_body() {
+            DecodedRequestBody::GetDeviceInfo => {
+                let payload = wire_device_info(self.info);
+                self.respond_bytes(
+                    response,
+                    StatusCode::OK,
+                    request_id,
+                    payload.as_bytes(),
+                    false,
+                )
+            }
+            DecodedRequestBody::CreateContext(desc) => {
+                let accelerator = &self.accelerator;
+                match self
+                    .state
+                    .create_context_with(|| accelerator.create_context(desc))
+                {
+                    Ok(id) => self.respond_object(response, request_id, id, true),
+                    Err(error) => self.respond_create_error(response, request_id, error),
+                }
+            }
+            DecodedRequestBody::DestroyContext { context_id } => {
+                self.destroy_context(response, request_id, context_id)
+            }
+            DecodedRequestBody::AllocateBuffer { context_id, desc } => {
+                let accelerator = &self.accelerator;
+                let info = self.info;
+                match self
+                    .state
+                    .create_buffer_with(context_id, desc, |context, requested| {
+                        let allocated = accelerator.allocate_buffer(context, requested)?;
+                        info.validate_buffer_info(requested, allocated.info())?;
+                        Ok(allocated.into_parts())
+                    }) {
+                    Ok(id) => self.respond_object(response, request_id, id, true),
+                    Err(error) => self.respond_create_error(response, request_id, error),
+                }
+            }
+            DecodedRequestBody::FreeBuffer { buffer_id } => {
+                self.free_buffer(response, request_id, buffer_id)
+            }
+            DecodedRequestBody::WriteBuffer {
+                buffer_id,
+                range,
+                data,
+            } => self.write_buffer(response, request_id, buffer_id, range, &data),
+            DecodedRequestBody::ReadBuffer { buffer_id, range } => {
+                self.read_buffer(response, request_id, buffer_id, range)
+            }
+            DecodedRequestBody::LoadProgram {
+                context_id,
+                format,
+                target,
+                payload,
+                resident_bytes,
+            } => {
+                let accelerator = &self.accelerator;
+                let artifact_bytes = payload.len();
+                match self.state.create_program_with(
+                    context_id,
+                    artifact_bytes,
+                    resident_bytes,
+                    |context| {
+                        accelerator.load_program(
+                            context,
+                            ArtifactRef {
+                                format,
+                                target,
+                                payload: &payload,
+                                resident_bytes,
+                            },
+                        )
+                    },
+                ) {
+                    Ok(id) => self.respond_object(response, request_id, id, true),
+                    Err(error) => self.respond_create_error(response, request_id, error),
+                }
+            }
+            DecodedRequestBody::UnloadProgram { program_id } => {
+                self.unload_program(response, request_id, program_id)
+            }
+            DecodedRequestBody::CreateQueue { context_id, desc } => {
+                let accelerator = &self.accelerator;
+                match self.state.create_queue_with(context_id, |context| {
+                    accelerator.create_queue(context, desc)
+                }) {
+                    Ok(id) => self.respond_object(response, request_id, id, true),
+                    Err(error) => self.respond_create_error(response, request_id, error),
+                }
+            }
+            DecodedRequestBody::DestroyQueue { queue_id } => {
+                self.destroy_queue(response, request_id, queue_id)
+            }
+            DecodedRequestBody::Submit { .. }
+            | DecodedRequestBody::PollEvent { .. }
+            | DecodedRequestBody::CancelEvent { .. }
+            | DecodedRequestBody::DestroyEvent { .. } => {
+                self.respond_empty(response, StatusCode::UNSUPPORTED, request_id, false)
+            }
+        }
+    }
+
+    fn write_buffer(
+        &mut self,
+        response: &mut dyn ByteSink,
+        request_id: u64,
+        buffer_id: ObjectId,
+        range: BufferRange,
+        data: &dyn ByteSource,
+    ) -> Result<CommandOutcome, CommandProcessError> {
+        let result = {
+            let record = match self.state.buffer_record_mut(buffer_id) {
+                Ok(record) => record,
+                Err(error) => {
+                    return self.respond_state_error(response, request_id, error);
+                }
+            };
+            if let Err(status) = validate_transfer(record, range, BufferUsage::TRANSFER_DESTINATION)
+            {
+                return self.respond_empty(response, status, request_id, false);
+            }
+            let buffer = match record.resource_mut() {
+                Ok(buffer) => buffer,
+                Err(error) => {
+                    return self.respond_state_error(response, request_id, error);
+                }
+            };
+            self.accelerator.write_buffer(buffer, range.offset, data)
+        };
+
+        match result {
+            Ok(()) => self.respond_empty(response, StatusCode::OK, request_id, true),
+            Err(error) => self.respond_backend_error(response, request_id, error, true),
+        }
+    }
+
+    fn read_buffer(
+        &mut self,
+        response: &mut dyn ByteSink,
+        request_id: u64,
+        buffer_id: ObjectId,
+        range: BufferRange,
+    ) -> Result<CommandOutcome, CommandProcessError> {
+        let record = match self.state.buffer_record(buffer_id) {
+            Ok(record) => record,
+            Err(error) => {
+                return self.respond_state_error(response, request_id, error);
+            }
+        };
+        if let Err(status) = validate_transfer(record, range, BufferUsage::TRANSFER_SOURCE) {
+            return self.respond_empty(response, status, request_id, false);
+        }
+        let buffer = match record.resource() {
+            Ok(buffer) => buffer,
+            Err(error) => {
+                return self.respond_state_error(response, request_id, error);
+            }
+        };
+
+        let mut writer = ResponseWriter::new(response, self.decoder.limits().max_response_bytes());
+        let error = {
+            let mut payload = writer
+                .payload(range.bytes())
+                .map_err(CommandProcessError::ResponseWrite)?;
+            match self
+                .accelerator
+                .read_buffer(buffer, range.offset, &mut payload)
+            {
+                Ok(()) => {
+                    let result = payload.commit(StatusCode::OK, request_id);
+                    return self.complete_response(result, StatusCode::OK, request_id, false);
+                }
+                Err(error) => error,
+            }
+        };
+        let status = self.backend_status(error);
+        let result = writer.write_empty(status, request_id);
+        self.complete_response(result, status, request_id, false)
+    }
+
+    fn destroy_context(
+        &mut self,
+        response: &mut dyn ByteSink,
+        request_id: u64,
+        id: ObjectId,
+    ) -> Result<CommandOutcome, CommandProcessError> {
+        let resource = match self.state.begin_context_release(id) {
+            Ok(resource) => resource,
+            Err(error) => return self.respond_state_error(response, request_id, error),
+        };
+        match self.accelerator.destroy_context(resource) {
+            Ok(()) => match self.state.commit_context_release(id) {
+                Ok(()) => self.respond_empty(response, StatusCode::OK, request_id, true),
+                Err(_) => self.recovery_response(response, request_id),
+            },
+            Err(ReleaseFailure::Rejected { error, resource }) => {
+                match self.state.restore_context_release(id, resource) {
+                    Ok(()) => self.respond_backend_error(response, request_id, error, false),
+                    Err(_) => self.recovery_response(response, request_id),
+                }
+            }
+            Err(ReleaseFailure::Indeterminate { .. }) => {
+                let _ = self.state.commit_context_release(id);
+                self.recovery_response(response, request_id)
+            }
+        }
+    }
+
+    fn free_buffer(
+        &mut self,
+        response: &mut dyn ByteSink,
+        request_id: u64,
+        id: ObjectId,
+    ) -> Result<CommandOutcome, CommandProcessError> {
+        let resource = match self.state.begin_buffer_release(id) {
+            Ok(resource) => resource,
+            Err(error) => return self.respond_state_error(response, request_id, error),
+        };
+        match self.accelerator.free_buffer(resource) {
+            Ok(()) => match self.state.commit_buffer_release(id) {
+                Ok(()) => self.respond_empty(response, StatusCode::OK, request_id, true),
+                Err(_) => self.recovery_response(response, request_id),
+            },
+            Err(ReleaseFailure::Rejected { error, resource }) => {
+                match self.state.restore_buffer_release(id, resource) {
+                    Ok(()) => self.respond_backend_error(response, request_id, error, false),
+                    Err(_) => self.recovery_response(response, request_id),
+                }
+            }
+            Err(ReleaseFailure::Indeterminate { .. }) => {
+                let _ = self.state.commit_buffer_release(id);
+                self.recovery_response(response, request_id)
+            }
+        }
+    }
+
+    fn unload_program(
+        &mut self,
+        response: &mut dyn ByteSink,
+        request_id: u64,
+        id: ObjectId,
+    ) -> Result<CommandOutcome, CommandProcessError> {
+        let resource = match self.state.begin_program_release(id) {
+            Ok(resource) => resource,
+            Err(error) => return self.respond_state_error(response, request_id, error),
+        };
+        match self.accelerator.unload_program(resource) {
+            Ok(()) => match self.state.commit_program_release(id) {
+                Ok(()) => self.respond_empty(response, StatusCode::OK, request_id, true),
+                Err(_) => self.recovery_response(response, request_id),
+            },
+            Err(ReleaseFailure::Rejected { error, resource }) => {
+                match self.state.restore_program_release(id, resource) {
+                    Ok(()) => self.respond_backend_error(response, request_id, error, false),
+                    Err(_) => self.recovery_response(response, request_id),
+                }
+            }
+            Err(ReleaseFailure::Indeterminate { .. }) => {
+                let _ = self.state.commit_program_release(id);
+                self.recovery_response(response, request_id)
+            }
+        }
+    }
+
+    fn destroy_queue(
+        &mut self,
+        response: &mut dyn ByteSink,
+        request_id: u64,
+        id: ObjectId,
+    ) -> Result<CommandOutcome, CommandProcessError> {
+        let resource = match self.state.begin_queue_release(id) {
+            Ok(resource) => resource,
+            Err(error) => return self.respond_state_error(response, request_id, error),
+        };
+        match self.accelerator.destroy_queue(resource) {
+            Ok(()) => match self.state.commit_queue_release(id) {
+                Ok(()) => self.respond_empty(response, StatusCode::OK, request_id, true),
+                Err(_) => self.recovery_response(response, request_id),
+            },
+            Err(ReleaseFailure::Rejected { error, resource }) => {
+                match self.state.restore_queue_release(id, resource) {
+                    Ok(()) => self.respond_backend_error(response, request_id, error, false),
+                    Err(_) => self.recovery_response(response, request_id),
+                }
+            }
+            Err(ReleaseFailure::Indeterminate { .. }) => {
+                let _ = self.state.commit_queue_release(id);
+                self.recovery_response(response, request_id)
+            }
+        }
+    }
+
+    fn respond_create_error(
+        &mut self,
+        response: &mut dyn ByteSink,
+        request_id: u64,
+        error: CreateError<BackendError>,
+    ) -> Result<CommandOutcome, CommandProcessError> {
+        match error {
+            CreateError::State(error) => self.respond_state_error(response, request_id, error),
+            CreateError::Provider(error) => {
+                self.respond_backend_error(response, request_id, error, false)
+            }
+        }
+    }
+
+    fn respond_state_error(
+        &mut self,
+        response: &mut dyn ByteSink,
+        request_id: u64,
+        error: DeviceStateError,
+    ) -> Result<CommandOutcome, CommandProcessError> {
+        self.respond_empty(
+            response,
+            status_from_device_state_error(error),
+            request_id,
+            false,
+        )
+    }
+
+    fn respond_backend_error(
+        &mut self,
+        response: &mut dyn ByteSink,
+        request_id: u64,
+        error: BackendError,
+        mutated: bool,
+    ) -> Result<CommandOutcome, CommandProcessError> {
+        let status = self.backend_status(error);
+        self.respond_empty(response, status, request_id, mutated)
+    }
+
+    fn backend_status(&mut self, error: BackendError) -> StatusCode {
+        if error == BackendError::DeviceLost {
+            self.health = DeviceHealth::NeedsReset;
+        }
+        status_from_backend_error(error)
+    }
+
+    fn recovery_response(
+        &mut self,
+        response: &mut dyn ByteSink,
+        request_id: u64,
+    ) -> Result<CommandOutcome, CommandProcessError> {
+        self.health = DeviceHealth::NeedsReset;
+        self.respond_empty(response, StatusCode::DEVICE_LOST, request_id, true)
+    }
+
+    fn respond_object(
+        &mut self,
+        response: &mut dyn ByteSink,
+        request_id: u64,
+        id: ObjectId,
+        mutated: bool,
+    ) -> Result<CommandOutcome, CommandProcessError> {
+        let payload = ObjectPayload {
+            object_id: Le64::new(id.get()),
+        };
+        self.respond_bytes(
+            response,
+            StatusCode::OK,
+            request_id,
+            payload.as_bytes(),
+            mutated,
+        )
+    }
+
+    fn respond_bytes(
+        &mut self,
+        response: &mut dyn ByteSink,
+        status: StatusCode,
+        request_id: u64,
+        payload: &[u8],
+        mutated: bool,
+    ) -> Result<CommandOutcome, CommandProcessError> {
+        let result = (|| {
+            let mut writer =
+                ResponseWriter::new(response, self.decoder.limits().max_response_bytes());
+            let payload_bytes =
+                u64::try_from(payload.len()).map_err(|_| ResponseWriteError::FrameTooLarge)?;
+            let mut destination = writer.payload(payload_bytes)?;
+            destination
+                .write_at(0, payload)
+                .map_err(|_| ResponseWriteError::SinkAccess)?;
+            destination.commit(status, request_id)
+        })();
+        self.complete_response(result, status, request_id, mutated)
+    }
+
+    fn respond_empty(
+        &mut self,
+        response: &mut dyn ByteSink,
+        status: StatusCode,
+        request_id: u64,
+        mutated: bool,
+    ) -> Result<CommandOutcome, CommandProcessError> {
+        let result = ResponseWriter::new(response, self.decoder.limits().max_response_bytes())
+            .write_empty(status, request_id);
+        self.complete_response(result, status, request_id, mutated)
+    }
+
+    fn complete_response(
+        &mut self,
+        result: Result<u32, ResponseWriteError>,
+        status: StatusCode,
+        request_id: u64,
+        mutated: bool,
+    ) -> Result<CommandOutcome, CommandProcessError> {
+        match result {
+            Ok(used) => Ok(CommandOutcome::Response {
+                request_id,
+                status,
+                used,
+            }),
+            Err(error) => {
+                if mutated {
+                    self.health = DeviceHealth::NeedsReset;
+                }
+                Err(CommandProcessError::ResponseWrite(error))
+            }
+        }
+    }
+}
+
+fn validate_transfer<B>(
+    record: &BufferRecord<B>,
+    range: BufferRange,
+    required_usage: BufferUsage,
+) -> Result<(), StatusCode> {
+    if record.in_flight() != 0 {
+        return Err(StatusCode::BUSY);
+    }
+    let desc = record.info().desc();
+    if range.end() > desc.bytes() {
+        return Err(StatusCode::OUT_OF_BOUNDS);
+    }
+    if !desc.usage.contains(required_usage) {
+        return Err(StatusCode::PERMISSION_DENIED);
+    }
+    Ok(())
+}
+
+fn wire_device_info(info: DeviceInfo) -> WireDeviceInfo {
+    WireDeviceInfo {
+        uuid: info.identity.uuid,
+        class: Le16::new(info.identity.class.get()),
+        reserved: Le16::new(0),
+        vendor_id: Le32::new(info.identity.vendor_id),
+        device_id: Le32::new(info.identity.device_id),
+        capabilities: Le64::new(info.capabilities.bits()),
+        max_contexts: Le32::new(info.limits.max_contexts),
+        max_buffers_per_context: Le32::new(info.limits.max_buffers_per_context),
+        max_programs_per_context: Le32::new(info.limits.max_programs_per_context),
+        max_queues_per_context: Le32::new(info.limits.max_queues_per_context),
+        max_events_per_context: Le32::new(info.limits.max_events_per_context),
+        max_bindings_per_submission: Le32::new(info.limits.max_bindings_per_submission),
+        max_buffer_bytes: Le64::new(info.limits.max_buffer_bytes),
+        max_artifact_bytes: Le64::new(info.limits.max_artifact_bytes),
+    }
+}

--- a/crates/virtio-accel-device/src/lib.rs
+++ b/crates/virtio-accel-device/src/lib.rs
@@ -9,6 +9,7 @@
 extern crate alloc;
 
 mod decoder;
+mod engine;
 mod frame;
 mod object_table;
 mod regions;
@@ -18,6 +19,10 @@ mod state;
 pub use decoder::{
     DecodedBinding, DecodedRequest, DecodedRequestBody, DecoderLimits, DecoderLimitsError,
     FrameDecodeError, FrameDecoder, UnrecoverableDecodeError,
+};
+pub use engine::{
+    AcceleratorState, CommandOutcome, CommandProcessError, CommandProcessor,
+    CommandProcessorInitError, DeviceHealth,
 };
 pub use frame::{FramePreflight, FramePreflightError, UnusableFrame, preflight_command_frame};
 pub use object_table::{ObjectId, ObjectKind, ObjectNamespace, ObjectTable, ObjectTableError};

--- a/crates/virtio-accel-device/tests/command_processor.rs
+++ b/crates/virtio-accel-device/tests/command_processor.rs
@@ -1,0 +1,653 @@
+use std::cell::Cell;
+use std::rc::Rc;
+use std::vec::Vec;
+
+use virtio_accel_core::{
+    Accelerator, AllocatedBuffer, ArtifactRef, BackendError, BindingRef, BufferDesc, BufferUsage,
+    ByteSink, ByteSource, ContextDesc, DeviceInfo, EventState, MemoryDomain, QueueDesc,
+    ReleaseFailure, SubmitFailure, Timeout,
+};
+use virtio_accel_device::{
+    ChainRegion, CommandOutcome, CommandProcessError, CommandProcessor, CommandProcessorInitError,
+    DecoderLimitsError, DeviceHealth, DeviceStateError, ObjectId, ObjectNamespace,
+    ResponseWriteError, SegmentedSink, SegmentedSource, UnusableFrame,
+};
+use virtio_accel_mock::{
+    MockAccelerator, MockBuffer, MockContext, MockEvent, MockProgram, MockQueue,
+};
+use virtio_accel_proto::{
+    AllocateBufferRequest, BASELINE_COMMAND_QUEUES, CreateContextRequest, CreateQueueRequest,
+    HARD_MAX_REQUEST_BYTES, HARD_MAX_RESPONSE_BYTES, Le16, Le32, Le64, LoadProgramRequest,
+    ObjectPayload, PROTOCOL_MAJOR, PROTOCOL_MINOR, RequestFlags, RequestHeader, ResponseHeader,
+    StatusCode, TransferBufferRequest, WireConfig, WireDeviceInfo, read_exact,
+};
+use zerocopy::IntoBytes;
+
+const REQUEST_ID: u64 = 0x0102_0304_0506_0708;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ReleaseMode {
+    Pass,
+    Reject,
+    Indeterminate,
+}
+
+struct RecordingBackend {
+    inner: MockAccelerator,
+    info_override: Cell<Option<DeviceInfo>>,
+    device_info_calls: Rc<Cell<u32>>,
+    create_context_error: Cell<Option<BackendError>>,
+    create_context_calls: Cell<u32>,
+    free_mode: Cell<ReleaseMode>,
+    free_calls: Cell<u32>,
+    write_calls: Cell<u32>,
+    read_calls: Cell<u32>,
+    segmented_write: Cell<bool>,
+    segmented_read: Cell<bool>,
+    segmented_artifact: Cell<bool>,
+}
+
+impl Default for RecordingBackend {
+    fn default() -> Self {
+        Self {
+            inner: MockAccelerator::default(),
+            info_override: Cell::new(None),
+            device_info_calls: Rc::new(Cell::new(0)),
+            create_context_error: Cell::new(None),
+            create_context_calls: Cell::new(0),
+            free_mode: Cell::new(ReleaseMode::Pass),
+            free_calls: Cell::new(0),
+            write_calls: Cell::new(0),
+            read_calls: Cell::new(0),
+            segmented_write: Cell::new(false),
+            segmented_read: Cell::new(false),
+            segmented_artifact: Cell::new(false),
+        }
+    }
+}
+
+impl Accelerator for RecordingBackend {
+    type Context = MockContext;
+    type Buffer = MockBuffer;
+    type Program = MockProgram;
+    type Queue = MockQueue;
+    type Event = MockEvent;
+
+    fn device_info(&self) -> Result<DeviceInfo, BackendError> {
+        self.device_info_calls.set(self.device_info_calls.get() + 1);
+        match self.info_override.get() {
+            Some(info) => Ok(info),
+            None => self.inner.device_info(),
+        }
+    }
+
+    fn create_context(&self, desc: ContextDesc) -> Result<Self::Context, BackendError> {
+        self.create_context_calls
+            .set(self.create_context_calls.get() + 1);
+        if let Some(error) = self.create_context_error.take() {
+            return Err(error);
+        }
+        self.inner.create_context(desc)
+    }
+
+    fn destroy_context(&self, context: Self::Context) -> Result<(), ReleaseFailure<Self::Context>> {
+        self.inner.destroy_context(context)
+    }
+
+    fn allocate_buffer(
+        &self,
+        context: &Self::Context,
+        desc: BufferDesc,
+    ) -> Result<AllocatedBuffer<Self::Buffer>, BackendError> {
+        self.inner.allocate_buffer(context, desc)
+    }
+
+    fn write_buffer(
+        &self,
+        buffer: &mut Self::Buffer,
+        offset: u64,
+        data: &dyn ByteSource,
+    ) -> Result<(), BackendError> {
+        self.write_calls.set(self.write_calls.get() + 1);
+        self.segmented_write.set(data.as_contiguous().is_none());
+        self.inner.write_buffer(buffer, offset, data)
+    }
+
+    fn read_buffer(
+        &self,
+        buffer: &Self::Buffer,
+        offset: u64,
+        data: &mut dyn ByteSink,
+    ) -> Result<(), BackendError> {
+        self.read_calls.set(self.read_calls.get() + 1);
+        self.segmented_read.set(data.as_contiguous_mut().is_none());
+        self.inner.read_buffer(buffer, offset, data)
+    }
+
+    fn free_buffer(&self, buffer: Self::Buffer) -> Result<(), ReleaseFailure<Self::Buffer>> {
+        self.free_calls.set(self.free_calls.get() + 1);
+        match self.free_mode.get() {
+            ReleaseMode::Pass => self.inner.free_buffer(buffer),
+            ReleaseMode::Reject => Err(ReleaseFailure::Rejected {
+                error: BackendError::Busy,
+                resource: buffer,
+            }),
+            ReleaseMode::Indeterminate => Err(ReleaseFailure::Indeterminate {
+                error: BackendError::DeviceLost,
+            }),
+        }
+    }
+
+    fn load_program(
+        &self,
+        context: &Self::Context,
+        artifact: ArtifactRef<'_>,
+    ) -> Result<Self::Program, BackendError> {
+        self.segmented_artifact
+            .set(artifact.payload.as_contiguous().is_none());
+        self.inner.load_program(context, artifact)
+    }
+
+    fn unload_program(&self, program: Self::Program) -> Result<(), ReleaseFailure<Self::Program>> {
+        self.inner.unload_program(program)
+    }
+
+    fn create_queue(
+        &self,
+        context: &Self::Context,
+        desc: QueueDesc,
+    ) -> Result<Self::Queue, BackendError> {
+        self.inner.create_queue(context, desc)
+    }
+
+    fn destroy_queue(&self, queue: Self::Queue) -> Result<(), ReleaseFailure<Self::Queue>> {
+        self.inner.destroy_queue(queue)
+    }
+
+    fn submit(
+        &self,
+        queue: &Self::Queue,
+        program: &Self::Program,
+        bindings: &[BindingRef<'_, Self::Buffer>],
+        timeout: Timeout,
+    ) -> Result<Self::Event, SubmitFailure<Self::Event>> {
+        self.inner.submit(queue, program, bindings, timeout)
+    }
+
+    fn poll_event(&self, event: &Self::Event) -> Result<EventState, BackendError> {
+        self.inner.poll_event(event)
+    }
+
+    fn cancel_event(&self, event: &Self::Event) -> Result<(), BackendError> {
+        self.inner.cancel_event(event)
+    }
+
+    fn destroy_event(&self, event: Self::Event) -> Result<(), ReleaseFailure<Self::Event>> {
+        self.inner.destroy_event(event)
+    }
+}
+
+#[derive(Debug)]
+struct FailingSink {
+    len: u64,
+}
+
+impl ByteSink for FailingSink {
+    fn len(&self) -> u64 {
+        self.len
+    }
+
+    fn write_at(&mut self, _offset: u64, _source: &[u8]) -> Result<(), BackendError> {
+        Err(BackendError::DeviceLost)
+    }
+}
+
+fn config() -> WireConfig {
+    WireConfig {
+        protocol_major: Le16::new(PROTOCOL_MAJOR),
+        protocol_minor: Le16::new(PROTOCOL_MINOR),
+        command_queue_count: Le16::new(BASELINE_COMMAND_QUEUES),
+        max_chain_descriptors: Le16::new(16),
+        max_request_bytes: Le32::new(HARD_MAX_REQUEST_BYTES),
+        max_response_bytes: Le32::new(HARD_MAX_RESPONSE_BYTES),
+    }
+}
+
+fn processor() -> CommandProcessor<RecordingBackend> {
+    CommandProcessor::new(
+        RecordingBackend::default(),
+        &config(),
+        ObjectNamespace::new(1).unwrap(),
+    )
+    .unwrap()
+}
+
+fn request(opcode: virtio_accel_proto::KnownOpcode, payload: &[u8]) -> Vec<u8> {
+    let header = RequestHeader::new(
+        opcode,
+        RequestFlags::empty(),
+        payload.len() as u32,
+        REQUEST_ID,
+    );
+    let mut bytes = Vec::from(header.as_bytes());
+    bytes.extend_from_slice(payload);
+    bytes
+}
+
+fn object_request(opcode: virtio_accel_proto::KnownOpcode, id: ObjectId) -> Vec<u8> {
+    request(
+        opcode,
+        ObjectPayload {
+            object_id: Le64::new(id.get()),
+        }
+        .as_bytes(),
+    )
+}
+
+fn run(
+    processor: &mut CommandProcessor<RecordingBackend>,
+    request: &[u8],
+    response_capacity: usize,
+) -> (CommandOutcome, Vec<u8>) {
+    let request_split = request.len() / 2;
+    let request_segments = [&request[..request_split], &request[request_split..]];
+    let source = SegmentedSource::new(&request_segments).unwrap();
+
+    let mut response = vec![0xaa_u8; response_capacity];
+    let response_split = response_capacity / 2;
+    let (left, right) = response.split_at_mut(response_split);
+    let mut response_segments: [&mut [u8]; 2] = [left, right];
+    let mut sink = SegmentedSink::new(&mut response_segments).unwrap();
+    let regions = [
+        ChainRegion::readable(request_split as u64),
+        ChainRegion::readable((request.len() - request_split) as u64),
+        ChainRegion::writable(response_split as u64),
+        ChainRegion::writable((response_capacity - response_split) as u64),
+    ];
+
+    let outcome = processor.process(&regions, &source, &mut sink).unwrap();
+    (outcome, response)
+}
+
+fn status(outcome: CommandOutcome) -> StatusCode {
+    let CommandOutcome::Response { status, .. } = outcome else {
+        panic!("command did not produce a response");
+    };
+    status
+}
+
+fn object_id(response: &[u8]) -> ObjectId {
+    let payload = read_exact::<ObjectPayload>(&response[16..24]).unwrap();
+    ObjectId::from_raw(payload.object_id.get()).unwrap()
+}
+
+fn create_context(processor: &mut CommandProcessor<RecordingBackend>) -> ObjectId {
+    let frame = request(
+        virtio_accel_proto::KnownOpcode::CreateContext,
+        CreateContextRequest {
+            flags: Le32::new(0),
+            reserved: Le32::new(0),
+        }
+        .as_bytes(),
+    );
+    let (outcome, response) = run(processor, &frame, 24);
+    assert_eq!(status(outcome), StatusCode::OK);
+    object_id(&response)
+}
+
+fn allocate_buffer(
+    processor: &mut CommandProcessor<RecordingBackend>,
+    context_id: ObjectId,
+) -> ObjectId {
+    allocate_buffer_with_usage(
+        processor,
+        context_id,
+        BufferUsage::TRANSFER_SOURCE | BufferUsage::TRANSFER_DESTINATION,
+    )
+}
+
+fn allocate_buffer_with_usage(
+    processor: &mut CommandProcessor<RecordingBackend>,
+    context_id: ObjectId,
+    usage: BufferUsage,
+) -> ObjectId {
+    let frame = request(
+        virtio_accel_proto::KnownOpcode::AllocateBuffer,
+        AllocateBufferRequest {
+            context_id: Le64::new(context_id.get()),
+            bytes: Le64::new(8),
+            alignment: Le64::new(1),
+            memory_domain: MemoryDomain::Host as u8,
+            reserved0: [0; 7],
+            usage: Le32::new(usage.bits()),
+            reserved1: Le32::new(0),
+        }
+        .as_bytes(),
+    );
+    let (outcome, response) = run(processor, &frame, 24);
+    assert_eq!(status(outcome), StatusCode::OK);
+    object_id(&response)
+}
+
+#[test]
+fn invalid_config_is_rejected_before_backend_discovery() {
+    let backend = RecordingBackend::default();
+    let device_info_calls = Rc::clone(&backend.device_info_calls);
+    let mut invalid = config();
+    invalid.protocol_major = Le16::new(PROTOCOL_MAJOR + 1);
+
+    assert!(matches!(
+        CommandProcessor::new(backend, &invalid, ObjectNamespace::new(1).unwrap(),),
+        Err(CommandProcessorInitError::Decoder(
+            DecoderLimitsError::Config(virtio_accel_proto::ConfigError::Version)
+        ))
+    ));
+    assert_eq!(device_info_calls.get(), 0);
+}
+
+#[test]
+fn baseline_lifecycle_preserves_segmented_zero_copy_ports() {
+    let mut processor = processor();
+
+    let get_info = request(virtio_accel_proto::KnownOpcode::GetDeviceInfo, &[]);
+    let (outcome, response) = run(
+        &mut processor,
+        &get_info,
+        16 + core::mem::size_of::<WireDeviceInfo>(),
+    );
+    assert_eq!(status(outcome), StatusCode::OK);
+    let info = read_exact::<WireDeviceInfo>(&response[16..]).unwrap();
+    assert_eq!(info.max_contexts.get(), 64);
+
+    let context = create_context(&mut processor);
+    let buffer = allocate_buffer(&mut processor, context);
+
+    let transfer = TransferBufferRequest {
+        buffer_id: Le64::new(buffer.get()),
+        offset: Le64::new(0),
+        bytes: Le64::new(8),
+    };
+    let mut write_payload = Vec::from(transfer.as_bytes());
+    write_payload.extend_from_slice(b"abcdefgh");
+    let write = request(virtio_accel_proto::KnownOpcode::WriteBuffer, &write_payload);
+    assert_eq!(status(run(&mut processor, &write, 16).0), StatusCode::OK);
+
+    let read = request(
+        virtio_accel_proto::KnownOpcode::ReadBuffer,
+        transfer.as_bytes(),
+    );
+    let (outcome, response) = run(&mut processor, &read, 24);
+    assert_eq!(status(outcome), StatusCode::OK);
+    assert_eq!(&response[16..24], b"abcdefgh");
+
+    let artifact = b"program";
+    let load = LoadProgramRequest {
+        context_id: Le64::new(context.get()),
+        format: Le32::new(1),
+        flags: Le32::new(0),
+        target: [Le32::new(0); 12],
+        payload_bytes: Le64::new(artifact.as_slice().len() as u64),
+        resident_bytes: Le64::new(artifact.as_slice().len() as u64),
+    };
+    let mut load_payload = Vec::from(load.as_bytes());
+    load_payload.extend_from_slice(artifact);
+    let load = request(virtio_accel_proto::KnownOpcode::LoadProgram, &load_payload);
+    let (outcome, response) = run(&mut processor, &load, 24);
+    assert_eq!(status(outcome), StatusCode::OK);
+    let program = object_id(&response);
+
+    let create_queue = request(
+        virtio_accel_proto::KnownOpcode::CreateQueue,
+        CreateQueueRequest {
+            context_id: Le64::new(context.get()),
+            flags: Le32::new(0),
+            reserved: Le32::new(0),
+        }
+        .as_bytes(),
+    );
+    let (outcome, response) = run(&mut processor, &create_queue, 24);
+    assert_eq!(status(outcome), StatusCode::OK);
+    let queue = object_id(&response);
+
+    assert_eq!(
+        status(
+            run(
+                &mut processor,
+                &object_request(virtio_accel_proto::KnownOpcode::DestroyContext, context),
+                16,
+            )
+            .0,
+        ),
+        StatusCode::BUSY
+    );
+
+    for (opcode, id) in [
+        (virtio_accel_proto::KnownOpcode::DestroyQueue, queue),
+        (virtio_accel_proto::KnownOpcode::UnloadProgram, program),
+        (virtio_accel_proto::KnownOpcode::FreeBuffer, buffer),
+        (virtio_accel_proto::KnownOpcode::DestroyContext, context),
+    ] {
+        assert_eq!(
+            status(run(&mut processor, &object_request(opcode, id), 16).0),
+            StatusCode::OK
+        );
+    }
+
+    assert!(processor.accelerator().segmented_write.get());
+    assert!(processor.accelerator().segmented_read.get());
+    assert!(processor.accelerator().segmented_artifact.get());
+    assert_eq!(processor.state().context_count(), 0);
+}
+
+#[test]
+fn semantic_validation_prevents_backend_calls() {
+    let backend = RecordingBackend::default();
+    let mut info = backend.device_info().unwrap();
+    backend.device_info_calls.set(0);
+    info.limits.max_contexts = 1;
+    backend.info_override.set(Some(info));
+    let mut processor =
+        CommandProcessor::new(backend, &config(), ObjectNamespace::new(1).unwrap()).unwrap();
+
+    let context = create_context(&mut processor);
+    let create = request(
+        virtio_accel_proto::KnownOpcode::CreateContext,
+        CreateContextRequest {
+            flags: Le32::new(0),
+            reserved: Le32::new(0),
+        }
+        .as_bytes(),
+    );
+    assert_eq!(
+        status(run(&mut processor, &create, 24).0),
+        StatusCode::RESOURCE_LIMIT
+    );
+    assert_eq!(processor.accelerator().create_context_calls.get(), 1);
+
+    let buffer = allocate_buffer_with_usage(&mut processor, context, BufferUsage::TRANSFER_SOURCE);
+    let transfer = TransferBufferRequest {
+        buffer_id: Le64::new(buffer.get()),
+        offset: Le64::new(0),
+        bytes: Le64::new(8),
+    };
+    let mut write_payload = Vec::from(transfer.as_bytes());
+    write_payload.extend_from_slice(b"abcdefgh");
+    let write = request(virtio_accel_proto::KnownOpcode::WriteBuffer, &write_payload);
+    assert_eq!(
+        status(run(&mut processor, &write, 16).0),
+        StatusCode::PERMISSION_DENIED
+    );
+    assert_eq!(processor.accelerator().write_calls.get(), 0);
+
+    let out_of_bounds = TransferBufferRequest {
+        buffer_id: Le64::new(buffer.get()),
+        offset: Le64::new(1),
+        bytes: Le64::new(8),
+    };
+    let read = request(
+        virtio_accel_proto::KnownOpcode::ReadBuffer,
+        out_of_bounds.as_bytes(),
+    );
+    assert_eq!(
+        status(run(&mut processor, &read, 24).0),
+        StatusCode::OUT_OF_BOUNDS
+    );
+    assert_eq!(processor.accelerator().read_calls.get(), 0);
+
+    let wrong_kind = object_request(virtio_accel_proto::KnownOpcode::FreeBuffer, context);
+    assert_eq!(
+        status(run(&mut processor, &wrong_kind, 16).0),
+        StatusCode::STALE_OBJECT
+    );
+    assert_eq!(processor.accelerator().free_calls.get(), 0);
+
+    let read = request(
+        virtio_accel_proto::KnownOpcode::ReadBuffer,
+        transfer.as_bytes(),
+    );
+    let (outcome, response) = run(&mut processor, &read, 16);
+    assert!(matches!(
+        outcome,
+        CommandOutcome::Unusable(UnusableFrame::InsufficientResponse { .. })
+    ));
+    assert_eq!(response, [0xaa; 16]);
+    assert_eq!(processor.accelerator().read_calls.get(), 0);
+
+    assert_eq!(
+        status(
+            run(
+                &mut processor,
+                &object_request(virtio_accel_proto::KnownOpcode::FreeBuffer, buffer),
+                16,
+            )
+            .0,
+        ),
+        StatusCode::OK
+    );
+    assert_eq!(processor.accelerator().free_calls.get(), 1);
+    assert_eq!(
+        status(run(&mut processor, &read, 24).0),
+        StatusCode::STALE_OBJECT
+    );
+    assert_eq!(processor.accelerator().read_calls.get(), 0);
+}
+
+#[test]
+fn short_responses_and_backend_rejection_never_publish_state() {
+    let mut processor = processor();
+    let create = request(
+        virtio_accel_proto::KnownOpcode::CreateContext,
+        CreateContextRequest {
+            flags: Le32::new(0),
+            reserved: Le32::new(0),
+        }
+        .as_bytes(),
+    );
+
+    let (outcome, response) = run(&mut processor, &create, 16);
+    assert!(matches!(
+        outcome,
+        CommandOutcome::Unusable(UnusableFrame::InsufficientResponse { .. })
+    ));
+    assert_eq!(response, [0xaa; 16]);
+    assert_eq!(processor.accelerator().create_context_calls.get(), 0);
+    assert_eq!(processor.state().context_count(), 0);
+
+    processor
+        .accelerator()
+        .create_context_error
+        .set(Some(BackendError::OutOfMemory));
+    let (outcome, response) = run(&mut processor, &create, 24);
+    assert_eq!(status(outcome), StatusCode::OUT_OF_MEMORY);
+    assert_eq!(
+        read_exact::<ResponseHeader>(&response[..16])
+            .unwrap()
+            .payload_bytes
+            .get(),
+        0
+    );
+    assert_eq!(processor.state().context_count(), 0);
+}
+
+#[test]
+fn rejected_release_restores_the_id_and_indeterminate_release_requires_reset() {
+    let mut processor = processor();
+    let context = create_context(&mut processor);
+    let buffer = allocate_buffer(&mut processor, context);
+    let free = object_request(virtio_accel_proto::KnownOpcode::FreeBuffer, buffer);
+
+    processor.accelerator().free_mode.set(ReleaseMode::Reject);
+    assert_eq!(status(run(&mut processor, &free, 16).0), StatusCode::BUSY);
+    assert!(processor.state().buffer_record(buffer).is_ok());
+
+    processor.accelerator().free_mode.set(ReleaseMode::Pass);
+    assert_eq!(status(run(&mut processor, &free, 16).0), StatusCode::OK);
+    assert_eq!(
+        processor.state().buffer_record(buffer).unwrap_err(),
+        DeviceStateError::StaleObject
+    );
+
+    let second = allocate_buffer(&mut processor, context);
+    processor
+        .accelerator()
+        .free_mode
+        .set(ReleaseMode::Indeterminate);
+    assert_eq!(
+        status(
+            run(
+                &mut processor,
+                &object_request(virtio_accel_proto::KnownOpcode::FreeBuffer, second),
+                16,
+            )
+            .0,
+        ),
+        StatusCode::DEVICE_LOST
+    );
+    assert_eq!(processor.health(), DeviceHealth::NeedsReset);
+    assert_eq!(
+        processor.state().buffer_record(second).unwrap_err(),
+        DeviceStateError::StaleObject
+    );
+
+    let get_info = request(virtio_accel_proto::KnownOpcode::GetDeviceInfo, &[]);
+    assert_eq!(
+        status(
+            run(
+                &mut processor,
+                &get_info,
+                16 + core::mem::size_of::<WireDeviceInfo>(),
+            )
+            .0,
+        ),
+        StatusCode::DEVICE_LOST
+    );
+}
+
+#[test]
+fn response_failure_after_creation_requires_reset() {
+    let mut processor = processor();
+    let create = request(
+        virtio_accel_proto::KnownOpcode::CreateContext,
+        CreateContextRequest {
+            flags: Le32::new(0),
+            reserved: Le32::new(0),
+        }
+        .as_bytes(),
+    );
+    let request_segments = [create.as_slice()];
+    let source = SegmentedSource::new(&request_segments).unwrap();
+    let regions = [
+        ChainRegion::readable(create.len() as u64),
+        ChainRegion::writable(24),
+    ];
+    let mut sink = FailingSink { len: 24 };
+
+    assert_eq!(
+        processor.process(&regions, &source, &mut sink),
+        Err(CommandProcessError::ResponseWrite(
+            ResponseWriteError::SinkAccess
+        ))
+    );
+    assert_eq!(processor.state().context_count(), 1);
+    assert_eq!(processor.health(), DeviceHealth::NeedsReset);
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,6 +46,13 @@ resource-lock order. Creation checks quotas and reserves fallible table capacity
 provider. Release moves a handle to an explicit `Releasing` state and either commits removal or
 restores the same live ID after a rejected provider release.
 
+`CommandProcessor` preserves that ownership model rather than placing an atomic or lock in each
+record. One mutable processor owns one backend and one object graph. A transport may move that owner
+between workers or serialize admission at its queue boundary; provider-native asynchronous work
+continues behind borrowed handles and event objects. Atomics belong in provider completion tokens
+or the concrete Virtio status publication path where state is genuinely shared, not in portable
+object lookup or reference counting.
+
 Provider releases have an explicit failure boundary too. A rejected release returns the still-live
 handle for retry. An indeterminate release invalidates the guest ID and requires device recovery;
 the adapter must never guess that the resource is either safe to reuse or safe to free.
@@ -154,15 +161,15 @@ discover an undocumented copy.
 
 ## Next implementation boundary
 
-The next portable milestone is a command engine that depends only on `virtio-accel-proto` and
-`virtio-accel-core`. It will:
+The portable command engine depends only on `virtio-accel-proto` and `virtio-accel-core`. Its
+baseline processor:
 
-1. Decode one bounded request from abstract readable/writable byte regions.
-2. Maintain typed object records and context dependency counts.
-3. Translate wire types into validated semantic values.
-4. Retain buffer, program, and queue ownership through event completion.
-5. Produce a response without knowing about rust-vmm or a host operating system.
+1. Decodes one bounded request from abstract readable/writable byte regions.
+2. Maintains typed object records and context dependency counts.
+3. Translates wire types into validated semantic values.
+4. Passes transfer and artifact regions directly to backend byte ports.
+5. Produces a response without knowing about rust-vmm or a host operating system.
 
-After that engine passes adversarial parser and lifecycle tests, a thin rust-vmm adapter can supply
-`virtio-device`, `virtio-queue`, and `vm-memory` integration. Linux vhost-user and an in-kernel guest
-driver remain later platform layers.
+Submission/event retention and deterministic reset complete this engine before a thin rust-vmm
+adapter supplies `virtio-device`, `virtio-queue`, and `vm-memory` integration. Linux vhost-user and
+an in-kernel guest driver remain later platform layers.


### PR DESCRIPTION
Closes #14

## What changed

- Add a transport-neutral `CommandProcessor<A>` that joins frame preflight, typed device state, backend calls, and bounded response framing.
- Implement discovery plus context, buffer, program, and execution-queue lifecycle commands.
- Stream segmented transfer and artifact regions directly through `ByteSource`/`ByteSink` without frame coalescing.
- Preserve rejected release handles for retry and enter `NeedsReset` after indeterminate release or post-mutation response failure.
- Add end-to-end tests for lifecycle, early validation, quotas, stale IDs, response capacity, segmented ports, and recovery.

## Design

The processor owns one backend and one object graph and requires exclusive mutable access. The portable command path therefore has no locks, atomics, reference-counted handles, or hidden runtime. Atomics remain at genuine shared-state boundaries such as backend event completion and future Virtio status publication.

Successful buffer reads initialize the complete response destination, allowing direct publication without a defensive zero-fill.

## Validation

- `cargo +stable test --workspace --all-targets --offline`
- `cargo +stable clippy --workspace --all-targets --offline -- -D warnings`
- `cargo +1.85.0 check -p virtio-accel-device --lib --offline`
- no-std checks for `aarch64-unknown-none` and `riscv64gc-unknown-none-elf`