### PR TITLE
Implement submission and event lifecycle

### DIFF
--- a/conformance/v1.0/requirements.json
+++ b/conformance/v1.0/requirements.json
@@ -580,9 +580,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-50EC74C4B4A6",
+      "id": "REQ-SPEC-33E85C6AD59D",
       "source": "docs/specification.md",
-      "line": 215,
+      "line": 219,
       "section": "4. Terminology and object model",
       "keyword": "MUST NOT",
       "statement": "The command engine **MUST NOT** convert an indeterminate submission into an ordinary error.",
@@ -602,9 +602,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-B45FEED8ABA7",
+      "id": "REQ-SPEC-E77511D6085E",
       "source": "docs/specification.md",
-      "line": 222,
+      "line": 226,
       "section": "4. Terminology and object model",
       "keyword": "MUST",
       "statement": "An event **MUST** retain its execution queue, program, buffers, and per-invocation backend state until",
@@ -624,9 +624,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-E8F4BC935D93",
+      "id": "REQ-SPEC-C7B728AD67B3",
       "source": "docs/specification.md",
-      "line": 223,
+      "line": 227,
       "section": "4. Terminology and object model",
       "keyword": "MUST NOT",
       "statement": "it is terminal and successfully destroyed. A pending event **MUST NOT** be destroyed.",
@@ -646,9 +646,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-68CFBB9C2D41",
+      "id": "REQ-SPEC-AEC4DC4C1559",
       "source": "docs/specification.md",
-      "line": 244,
+      "line": 252,
       "section": "5. Baseline capabilities and feature policy",
       "keyword": "MUST",
       "statement": "The portable v1 baseline **MUST** provide:",
@@ -666,9 +666,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-6A5CA92B1CFE",
+      "id": "REQ-SPEC-AFBF838B4F2D",
       "source": "docs/specification.md",
-      "line": 259,
+      "line": 267,
       "section": "5. Baseline capabilities and feature policy",
       "keyword": "MUST",
       "statement": "advertise semantic event-cancellation capability, the device **MUST** return `UNSUPPORTED` without",
@@ -686,9 +686,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-FD0B52B87A47",
+      "id": "REQ-SPEC-86C7CC9E6BDB",
       "source": "docs/specification.md",
-      "line": 268,
+      "line": 276,
       "section": "5. Baseline capabilities and feature policy",
       "keyword": "MUST NOT",
       "statement": "`TIMELINE_FENCES`, and `SECURE_CONTEXTS` reserve numeric positions only. A baseline device **MUST NOT**",
@@ -706,9 +706,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-A7094E01E82E",
+      "id": "REQ-SPEC-0206502CFC72",
       "source": "docs/specification.md",
-      "line": 269,
+      "line": 277,
       "section": "5. Baseline capabilities and feature policy",
       "keyword": "MUST NOT",
       "statement": "advertise them and a baseline driver **MUST NOT** accept them. Protocol 1.0 assigns no semantics to",
@@ -726,9 +726,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-26AB1F1F0970",
+      "id": "REQ-SPEC-7643E8E58065",
       "source": "docs/specification.md",
-      "line": 272,
+      "line": 280,
       "section": "5. Baseline capabilities and feature policy",
       "keyword": "MUST NOT",
       "statement": "Unknown device-specific feature bits **MUST NOT** be accepted by a driver. A device **MUST NOT**",
@@ -746,9 +746,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-899753DD52D4",
+      "id": "REQ-SPEC-EE0B8056BD02",
       "source": "docs/specification.md",
-      "line": 272,
+      "line": 280,
       "section": "5. Baseline capabilities and feature policy",
       "keyword": "MUST NOT",
       "statement": "Unknown device-specific feature bits **MUST NOT** be accepted by a driver. A device **MUST NOT**",
@@ -766,9 +766,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-AE542DCB3D68",
+      "id": "REQ-SPEC-F0DC58280363",
       "source": "docs/specification.md",
-      "line": 290,
+      "line": 298,
       "section": "5. Baseline capabilities and feature policy",
       "keyword": "MUST NOT",
       "statement": "ownership, synchronization, and isolation rules are specified. A protocol 1.0 device **MUST NOT**",
@@ -786,9 +786,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-7807653A3F9F",
+      "id": "REQ-SPEC-A8A5BBCC23A0",
       "source": "docs/specification.md",
-      "line": 293,
+      "line": 301,
       "section": "5. Baseline capabilities and feature policy",
       "keyword": "MUST",
       "statement": "The device **MUST** reject an allocation for an unsupported memory domain before invoking the",
@@ -806,9 +806,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-86369B5E9589",
+      "id": "REQ-SPEC-C2EEBEA200DF",
       "source": "docs/specification.md",
-      "line": 299,
+      "line": 307,
       "section": "5. Baseline capabilities and feature policy",
       "keyword": "MUST",
       "statement": "new synchronization, or changed lifetime rules, the device **MUST** also negotiate an appropriate",
@@ -826,9 +826,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-EADCE4F0A8A9",
+      "id": "REQ-SPEC-013430EC73B8",
       "source": "docs/specification.md",
-      "line": 304,
+      "line": 312,
       "section": "5. Baseline capabilities and feature policy",
       "keyword": "MUST NOT",
       "statement": "implementation **MUST NOT** translate an underspecified capability into additional wire behavior.",
@@ -846,9 +846,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-C4C81B1D7BB6",
+      "id": "REQ-SPEC-AEC435BFF0AF",
       "source": "docs/specification.md",
-      "line": 309,
+      "line": 317,
       "section": "5. Baseline capabilities and feature policy",
       "keyword": "MUST",
       "statement": "reserved and **MUST** be zero.",
@@ -866,9 +866,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-C679BCADAAEA",
+      "id": "REQ-SPEC-6008D0C2488F",
       "source": "docs/specification.md",
-      "line": 312,
+      "line": 320,
       "section": "5. Baseline capabilities and feature policy",
       "keyword": "MUST",
       "statement": "**MUST** be rejected before backend invocation. Reserved fields **MUST** be zero.",
@@ -886,9 +886,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-D861A636A153",
+      "id": "REQ-SPEC-AD1B44BE1427",
       "source": "docs/specification.md",
-      "line": 312,
+      "line": 320,
       "section": "5. Baseline capabilities and feature policy",
       "keyword": "MUST",
       "statement": "**MUST** be rejected before backend invocation. Reserved fields **MUST** be zero.",
@@ -906,9 +906,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-BB680E1A0B79",
+      "id": "REQ-SPEC-75AB5333C8C4",
       "source": "docs/specification.md",
-      "line": 319,
+      "line": 327,
       "section": "6. Versioning and compatibility",
       "keyword": "MUST",
       "statement": "Candidate implementations **MUST** expose major `1` and minor `0` in device-specific configuration",
@@ -927,9 +927,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-8597E84F67FD",
+      "id": "REQ-SPEC-20BBDCCEEC92",
       "source": "docs/specification.md",
-      "line": 320,
+      "line": 328,
       "section": "6. Versioning and compatibility",
       "keyword": "MUST NOT",
       "statement": "and **MUST NOT** claim candidate protocol 1.0 conformance unless they satisfy the normative wire,",
@@ -948,9 +948,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-CE119CF28472",
+      "id": "REQ-SPEC-5348BBC0D8FD",
       "source": "docs/specification.md",
-      "line": 324,
+      "line": 332,
       "section": "6. Versioning and compatibility",
       "keyword": "MUST",
       "statement": "#33. Before that audit, an intentional candidate revision **MUST** follow the coordinated procedure",
@@ -969,9 +969,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-6875C63115F8",
+      "id": "REQ-SPEC-6121F6E1EB77",
       "source": "docs/specification.md",
-      "line": 325,
+      "line": 333,
       "section": "6. Versioning and compatibility",
       "keyword": "MUST NOT",
       "statement": "in [wire-abi.md](wire-abi.md) and **MUST NOT** be described as a frozen or stable release.",
@@ -990,9 +990,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-00BB7B9A2B4C",
+      "id": "REQ-SPEC-72DE383CDBC0",
       "source": "docs/specification.md",
-      "line": 331,
+      "line": 339,
       "section": "6. Versioning and compatibility",
       "keyword": "MUST",
       "statement": "- a driver **MUST** reject a device with an unsupported major version;",
@@ -1011,9 +1011,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-8FCB39B7C119",
+      "id": "REQ-SPEC-3803DA96468A",
       "source": "docs/specification.md",
-      "line": 333,
+      "line": 341,
       "section": "6. Versioning and compatibility",
       "keyword": "MUST NOT",
       "statement": "- a driver **MUST NOT** use behavior newer than the device minor version it observed; and",
@@ -1032,9 +1032,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-FE18F408035C",
+      "id": "REQ-SPEC-6E4D852251B8",
       "source": "docs/specification.md",
-      "line": 342,
+      "line": 350,
       "section": "6. Versioning and compatibility",
       "keyword": "MUST NOT",
       "statement": "Therefore a minor version alone **MUST NOT** append fields to an existing response that an older",
@@ -1053,9 +1053,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-6C45506F15E8",
+      "id": "REQ-SPEC-756F68A7AAFD",
       "source": "docs/specification.md",
-      "line": 346,
+      "line": 354,
       "section": "6. Versioning and compatibility",
       "keyword": "SHOULD",
       "statement": "negotiated feature explicitly selects a different layout. Extensions **SHOULD** use a new opcode or",
@@ -1074,9 +1074,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-754533E01919",
+      "id": "REQ-SPEC-D0F8BB882F40",
       "source": "docs/specification.md",
-      "line": 349,
+      "line": 357,
       "section": "6. Versioning and compatibility",
       "keyword": "MUST",
       "statement": "Without such a feature, a receiver **MUST** require the exact payload length for the opcode and",
@@ -1095,9 +1095,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-D1E971E43B4A",
+      "id": "REQ-SPEC-B8E6FB0D7274",
       "source": "docs/specification.md",
-      "line": 350,
+      "line": 358,
       "section": "6. Versioning and compatibility",
       "keyword": "MUST",
       "statement": "**MUST** reject trailing bytes. It **MUST NOT** silently reinterpret or ignore an unknown tail.",
@@ -1116,9 +1116,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-E5BE5302740B",
+      "id": "REQ-SPEC-9EC4D79F120D",
       "source": "docs/specification.md",
-      "line": 350,
+      "line": 358,
       "section": "6. Versioning and compatibility",
       "keyword": "MUST NOT",
       "statement": "**MUST** reject trailing bytes. It **MUST NOT** silently reinterpret or ignore an unknown tail.",
@@ -1137,9 +1137,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-89F3C7144057",
+      "id": "REQ-SPEC-E44726AD481F",
       "source": "docs/specification.md",
-      "line": 357,
+      "line": 365,
       "section": "6. Versioning and compatibility",
       "keyword": "MUST NOT",
       "statement": "- An unknown response status is an opaque failure. A driver **MUST NOT** treat it as success or",
@@ -1158,9 +1158,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-75D40B718E67",
+      "id": "REQ-SPEC-FC0B92A06782",
       "source": "docs/specification.md",
-      "line": 364,
+      "line": 372,
       "section": "7. Ownership and destruction",
       "keyword": "MUST",
       "statement": "The device owns the mapping from opaque object IDs to backend handles. The mapping **MUST** reject:",
@@ -1179,9 +1179,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-3FCD0B88A0D2",
+      "id": "REQ-SPEC-56593F42BA6E",
       "source": "docs/specification.md",
-      "line": 372,
+      "line": 380,
       "section": "7. Ownership and destruction",
       "keyword": "MUST NOT",
       "statement": "Object-ID encoding is implementation-private. Drivers **MUST NOT** infer slot, kind, generation, or",
@@ -1200,9 +1200,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-2AA25E912F8B",
+      "id": "REQ-SPEC-231C9BFD9771",
       "source": "docs/specification.md",
-      "line": 377,
+      "line": 385,
       "section": "7. Ownership and destruction",
       "keyword": "MUST",
       "statement": "- a rejected release returns the still-live handle and the device **MUST** restore it for retry;",
@@ -1221,9 +1221,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-98C389360C1A",
+      "id": "REQ-SPEC-D59392AFA174",
       "source": "docs/specification.md",
-      "line": 379,
+      "line": 387,
       "section": "7. Ownership and destruction",
       "keyword": "MUST NOT",
       "statement": "- an indeterminate release invalidates the guest ID and requires recovery. The device **MUST NOT**",
@@ -1242,9 +1242,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-58CA48105327",
+      "id": "REQ-SPEC-0198899B57F8",
       "source": "docs/specification.md",
-      "line": 382,
+      "line": 390,
       "section": "7. Ownership and destruction",
       "keyword": "MUST NOT",
       "statement": "`Drop` may provide defensive cleanup inside an implementation but **MUST NOT** be used as",
@@ -1263,9 +1263,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-516FEBC9DC0B",
+      "id": "REQ-SPEC-B35C802C4CE1",
       "source": "docs/specification.md",
-      "line": 388,
+      "line": 396,
       "section": "8. Time and progress",
       "keyword": "MUST NOT",
       "statement": "infinite. Absolute guest timestamps **MUST NOT** be compared with a host clock because their",
@@ -1282,9 +1282,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-B3DE8C0C13C8",
+      "id": "REQ-SPEC-A3E630EEB53C",
       "source": "docs/specification.md",
-      "line": 391,
+      "line": 399,
       "section": "8. Time and progress",
       "keyword": "MUST",
       "statement": "Polling an event **MUST** be nonblocking and bounded. The portable contract creates no background",
@@ -1301,9 +1301,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-C0E2DDFC4E95",
+      "id": "REQ-SPEC-9A070026FAAE",
       "source": "docs/specification.md",
-      "line": 395,
+      "line": 403,
       "section": "8. Time and progress",
       "keyword": "MUST",
       "statement": "cannot prove rejection is indeterminate and **MUST** retain an event.",
@@ -1320,9 +1320,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-CB3886392A30",
+      "id": "REQ-SPEC-B87D11017952",
       "source": "docs/specification.md",
-      "line": 404,
+      "line": 412,
       "section": "9. Errors",
       "keyword": "MUST",
       "statement": "A device **MUST** map errors deterministically and **MUST NOT** expose uninitialized response bytes.",
@@ -1340,9 +1340,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-D2EC5C810722",
+      "id": "REQ-SPEC-9DA3CA594109",
       "source": "docs/specification.md",
-      "line": 404,
+      "line": 412,
       "section": "9. Errors",
       "keyword": "MUST NOT",
       "statement": "A device **MUST** map errors deterministically and **MUST NOT** expose uninitialized response bytes.",
@@ -1360,9 +1360,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-063210EF2C88",
+      "id": "REQ-SPEC-549D7EA018D8",
       "source": "docs/specification.md",
-      "line": 408,
+      "line": 416,
       "section": "9. Errors",
       "keyword": "MUST NOT",
       "statement": "An error response **MUST NOT** imply that a backend operation was rejected when acceptance was",
@@ -1380,9 +1380,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-48AE033662E2",
+      "id": "REQ-SPEC-C38079758E77",
       "source": "docs/specification.md",
-      "line": 413,
+      "line": 421,
       "section": "10. Portability requirements",
       "keyword": "MUST NOT",
       "statement": "Portable crates **MUST NOT** select an operating system, VMM, kernel, vendor API, or global runtime.",
@@ -1398,9 +1398,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-38AC895175F0",
+      "id": "REQ-SPEC-15A354D61BD7",
       "source": "docs/specification.md",
-      "line": 420,
+      "line": 428,
       "section": "10. Portability requirements",
       "keyword": "MUST NOT",
       "statement": "Platform adapters depend inward on the portable layers. A portable layer **MUST NOT** conditionally",
@@ -1416,9 +1416,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-E90D593ED0AD",
+      "id": "REQ-SPEC-0E2CA4544542",
       "source": "docs/specification.md",
-      "line": 436,
+      "line": 444,
       "section": "11. Tracked completion work",
       "keyword": "MAY",
       "statement": "No implementation **MAY** advertise a reserved optional feature merely because a Rust constant",
@@ -1765,9 +1765,9 @@
       }
     },
     {
-      "id": "REQ-WIRE-521DFC5AAE65",
+      "id": "REQ-WIRE-313FCB978A7A",
       "source": "docs/wire-abi.md",
-      "line": 145,
+      "line": 149,
       "section": "4. Common value namespaces",
       "keyword": "MUST",
       "statement": "Unknown event states make the response invalid to a 1.0 driver. A driver **MUST** retain the event",
@@ -1782,9 +1782,9 @@
       }
     },
     {
-      "id": "REQ-WIRE-64102815576B",
+      "id": "REQ-WIRE-80A0DAA86EAD",
       "source": "docs/wire-abi.md",
-      "line": 195,
+      "line": 199,
       "section": "5. Opcodes and payloads",
       "keyword": "MUST NOT",
       "statement": "Capability bits are semantic reports, not Virtio feature bits. A capability **MUST NOT** alter wire",
@@ -1802,9 +1802,9 @@
       }
     },
     {
-      "id": "REQ-WIRE-4B8751C702D4",
+      "id": "REQ-WIRE-8A055801233E",
       "source": "docs/wire-abi.md",
-      "line": 208,
+      "line": 212,
       "section": "5. Opcodes and payloads",
       "keyword": "MUST NOT",
       "statement": "Bits 3 (`EXTERNAL_MEMORY`) and 4 (`SECURE_CONTEXTS`) are reserved and **MUST NOT** be advertised by a",
@@ -1822,9 +1822,9 @@
       }
     },
     {
-      "id": "REQ-WIRE-580C3DD285D4",
+      "id": "REQ-WIRE-67C188990B79",
       "source": "docs/wire-abi.md",
-      "line": 213,
+      "line": 217,
       "section": "5. Opcodes and payloads",
       "keyword": "MUST",
       "statement": "`CreateContextRequest` is eight bytes: `flags: u32` followed by `reserved: u32`. Both fields **MUST**",
@@ -1842,9 +1842,9 @@
       }
     },
     {
-      "id": "REQ-WIRE-4EAD37AC39A4",
+      "id": "REQ-WIRE-42EB92A9EC01",
       "source": "docs/wire-abi.md",
-      "line": 232,
+      "line": 236,
       "section": "5. Opcodes and payloads",
       "keyword": "MUST",
       "statement": "The device **MUST** reject a memory domain whose corresponding semantic capability is absent before",
@@ -1862,9 +1862,9 @@
       }
     },
     {
-      "id": "REQ-WIRE-87BB31FD5813",
+      "id": "REQ-WIRE-223FBC8A60C0",
       "source": "docs/wire-abi.md",
-      "line": 238,
+      "line": 242,
       "section": "5. Opcodes and payloads",
       "keyword": "MUST",
       "statement": "`TransferBufferRequest` is 24 bytes containing `buffer_id`, `offset`, and `bytes`. `bytes` **MUST**",
@@ -1882,9 +1882,9 @@
       }
     },
     {
-      "id": "REQ-WIRE-E017FD0EEA20",
+      "id": "REQ-WIRE-5C3F347D6615",
       "source": "docs/wire-abi.md",
-      "line": 239,
+      "line": 243,
       "section": "5. Opcodes and payloads",
       "keyword": "MUST NOT",
       "statement": "be nonzero. `offset + bytes` **MUST NOT** overflow and **MUST** fit in the buffer.",
@@ -1902,9 +1902,9 @@
       }
     },
     {
-      "id": "REQ-WIRE-271DD2086E42",
+      "id": "REQ-WIRE-B27D105076D0",
       "source": "docs/wire-abi.md",
-      "line": 239,
+      "line": 243,
       "section": "5. Opcodes and payloads",
       "keyword": "MUST",
       "statement": "be nonzero. `offset + bytes` **MUST NOT** overflow and **MUST** fit in the buffer.",
@@ -1922,9 +1922,9 @@
       }
     },
     {
-      "id": "REQ-WIRE-8008071E0526",
+      "id": "REQ-WIRE-241B1A675E6E",
       "source": "docs/wire-abi.md",
-      "line": 241,
+      "line": 245,
       "section": "5. Opcodes and payloads",
       "keyword": "MUST",
       "statement": "For `WRITE_BUFFER`, the request payload length **MUST** be `24 + bytes`, and bytes following the",
@@ -1942,9 +1942,9 @@
       }
     },
     {
-      "id": "REQ-WIRE-4EF44E350137",
+      "id": "REQ-WIRE-EF36BE53AF84",
       "source": "docs/wire-abi.md",
-      "line": 263,
+      "line": 267,
       "section": "5. Opcodes and payloads",
       "keyword": "MUST",
       "statement": "`80 + payload_bytes` **MUST** fit the request payload and configured frame limit.",
@@ -1962,9 +1962,9 @@
       }
     },
     {
-      "id": "REQ-WIRE-9444BF78467A",
+      "id": "REQ-WIRE-ED65F48C9645",
       "source": "docs/wire-abi.md",
-      "line": 268,
+      "line": 272,
       "section": "5. Opcodes and payloads",
       "keyword": "MUST",
       "statement": "reserved words **MUST** be zero in protocol 1.0.",
@@ -1982,9 +1982,9 @@
       }
     },
     {
-      "id": "REQ-WIRE-F9B8603BE34B",
+      "id": "REQ-WIRE-C5375BF48766",
       "source": "docs/wire-abi.md",
-      "line": 275,
+      "line": 279,
       "section": "5. Opcodes and payloads",
       "keyword": "MUST",
       "statement": "- `binding_count` **MUST** be 1 through both advertised `max_bindings_per_submission` and 4096.",
@@ -2002,9 +2002,9 @@
       }
     },
     {
-      "id": "REQ-WIRE-47AC091DB502",
+      "id": "REQ-WIRE-20A4C3C896DE",
       "source": "docs/wire-abi.md",
-      "line": 276,
+      "line": 280,
       "section": "5. Opcodes and payloads",
       "keyword": "MUST",
       "statement": "- `flags` **MUST** be zero.",
@@ -2022,9 +2022,9 @@
       }
     },
     {
-      "id": "REQ-WIRE-219F0562BE70",
+      "id": "REQ-WIRE-FAF253929B2A",
       "source": "docs/wire-abi.md",
-      "line": 278,
+      "line": 282,
       "section": "5. Opcodes and payloads",
       "keyword": "MUST",
       "statement": "- The payload length **MUST** be `32 + binding_count * 32`.",
@@ -2042,9 +2042,9 @@
       }
     },
     {
-      "id": "REQ-WIRE-6E7783E86053",
+      "id": "REQ-WIRE-9994C43527C9",
       "source": "docs/wire-abi.md",
-      "line": 323,
+      "line": 328,
       "section": "7. Response atomicity",
       "keyword": "MUST",
       "statement": "Before backend invocation, the device **MUST** validate the complete readable frame and enough",
@@ -2061,9 +2061,9 @@
       }
     },
     {
-      "id": "REQ-WIRE-464698253A6B",
+      "id": "REQ-WIRE-9C21B8D4BFC1",
       "source": "docs/wire-abi.md",
-      "line": 324,
+      "line": 329,
       "section": "7. Response atomicity",
       "keyword": "MUST",
       "statement": "writable capacity for every possible response shape of that command. It **MUST** initialize every",
@@ -2080,9 +2080,9 @@
       }
     },
     {
-      "id": "REQ-WIRE-38CDAB01C914",
+      "id": "REQ-WIRE-E64A25494C17",
       "source": "docs/wire-abi.md",
-      "line": 328,
+      "line": 333,
       "section": "7. Response atomicity",
       "keyword": "MUST",
       "statement": "occurs after semantic mutation, or a release becomes indeterminate, the device **MUST** enter",
@@ -2099,9 +2099,9 @@
       }
     },
     {
-      "id": "REQ-WIRE-50389481EBC0",
+      "id": "REQ-WIRE-A92557C08CB5",
       "source": "docs/wire-abi.md",
-      "line": 329,
+      "line": 334,
       "section": "7. Response atomicity",
       "keyword": "MUST NOT",
       "statement": "recovery and expose the Virtio `DEVICE_NEEDS_RESET` condition. It **MUST NOT** report an ordinary",
@@ -2118,9 +2118,9 @@
       }
     },
     {
-      "id": "REQ-WIRE-C6BCD8DA20D3",
+      "id": "REQ-WIRE-06A28D538D92",
       "source": "docs/wire-abi.md",
-      "line": 343,
+      "line": 348,
       "section": "9. Candidate and post-freeze change procedure",
       "keyword": "MUST",
       "statement": "A proposed wire change **MUST** be classified before code is merged:",
@@ -2137,9 +2137,9 @@
       }
     },
     {
-      "id": "REQ-WIRE-0AD257A3D59E",
+      "id": "REQ-WIRE-EA6631A95021",
       "source": "docs/wire-abi.md",
-      "line": 356,
+      "line": 361,
       "section": "9. Candidate and post-freeze change procedure",
       "keyword": "MUST",
       "statement": "The same reviewed change **MUST** update the normative documents, Rust constants/layout assertions,",

--- a/crates/virtio-accel-core/src/lib.rs
+++ b/crates/virtio-accel-core/src/lib.rs
@@ -211,6 +211,19 @@ impl BufferDesc {
         self.alignment.get()
     }
 
+    /// Whether this declaration permits one program binding access mode.
+    pub const fn allows_access(self, access: AccessMode) -> bool {
+        match access {
+            AccessMode::Read => self
+                .usage
+                .intersects(BufferUsage::PROGRAM_INPUT.union(BufferUsage::MUTABLE_STATE)),
+            AccessMode::Write => self
+                .usage
+                .intersects(BufferUsage::PROGRAM_OUTPUT.union(BufferUsage::MUTABLE_STATE)),
+            AccessMode::ReadWrite => self.usage.contains(BufferUsage::MUTABLE_STATE),
+        }
+    }
+
     /// Whether this allocation can appear in a program binding.
     pub const fn is_program_visible(self) -> bool {
         self.usage.intersects(
@@ -607,7 +620,7 @@ impl Timeout {
 ///
 /// Program-visible buffers carry [`BufferProperties::DIRECT_BINDING`]. A backend must reject an
 /// incompatible buffer/program combination instead of copying the range into a hidden bounce
-/// allocation.
+/// allocation. Binding order is not semantic; command engines may present the slice in slot order.
 #[derive(Debug)]
 pub struct BindingRef<'a, B> {
     pub slot: u32,
@@ -744,7 +757,15 @@ pub trait Accelerator {
         bindings: &[BindingRef<'_, Self::Buffer>],
         timeout: Timeout,
     ) -> Result<Self::Event, SubmitFailure<Self::Event>>;
+    /// Observe event state without blocking or driving an executor.
+    ///
+    /// Once a terminal state is observed, every later successful poll returns the same state.
     fn poll_event(&self, event: &Self::Event) -> Result<EventState, BackendError>;
+    /// Attempt to make a pending event terminal as [`EventState::Cancelled`].
+    ///
+    /// If completion wins the race, the backend returns [`BackendError::Busy`] and polling reveals
+    /// the selected terminal result. Returning `Ok(())` means cancellation won and every later
+    /// successful poll returns `Cancelled`.
     fn cancel_event(&self, _event: &Self::Event) -> Result<(), BackendError> {
         Err(BackendError::Unsupported)
     }
@@ -766,6 +787,27 @@ mod tests {
                 .alignment(),
             16
         );
+    }
+
+    #[test]
+    fn buffer_usage_defines_submission_access_compatibility() {
+        let input =
+            BufferDesc::new(64, 16, MemoryDomain::Host, BufferUsage::PROGRAM_INPUT).unwrap();
+        assert!(input.allows_access(AccessMode::Read));
+        assert!(!input.allows_access(AccessMode::Write));
+        assert!(!input.allows_access(AccessMode::ReadWrite));
+
+        let output =
+            BufferDesc::new(64, 16, MemoryDomain::Host, BufferUsage::PROGRAM_OUTPUT).unwrap();
+        assert!(!output.allows_access(AccessMode::Read));
+        assert!(output.allows_access(AccessMode::Write));
+        assert!(!output.allows_access(AccessMode::ReadWrite));
+
+        let mutable =
+            BufferDesc::new(64, 16, MemoryDomain::Host, BufferUsage::MUTABLE_STATE).unwrap();
+        assert!(mutable.allows_access(AccessMode::Read));
+        assert!(mutable.allows_access(AccessMode::Write));
+        assert!(mutable.allows_access(AccessMode::ReadWrite));
     }
 
     #[test]

--- a/crates/virtio-accel-device/src/decoder.rs
+++ b/crates/virtio-accel-device/src/decoder.rs
@@ -2,11 +2,9 @@
 //!
 //! Fixed wire values use an 80-byte stack scratch area. Transfer and artifact tails remain
 //! borrowed views over the original [`ByteSource`]. `SUBMIT` is the only allocating decode path:
-//! it retains one [`DecodedBinding`] per advertised binding and temporarily uses two `u32` arrays
-//! per binding for four-pass radix duplicate detection. All three allocations are bounded by the
-//! configured binding limit and use fallible reservation. The decoder performs a constant number
-//! of fixed-prefix reads plus one 32-byte read and four fixed radix passes per binding, so its own
-//! work is linear in the validated payload size.
+//! it retains one [`DecodedBinding`] per advertised binding, then sorts that allocation in place by
+//! slot to reject duplicates. The allocation is bounded by the configured binding limit and uses
+//! fallible reservation. No payload bytes are coalesced.
 
 use alloc::vec::Vec;
 use core::mem::size_of;
@@ -540,10 +538,6 @@ impl FrameDecoder {
         bindings
             .try_reserve_exact(count)
             .map_err(|_| BodyDecodeError::Protocol(StatusCode::OUT_OF_MEMORY))?;
-        let mut slots = Vec::new();
-        slots
-            .try_reserve_exact(count)
-            .map_err(|_| BodyDecodeError::Protocol(StatusCode::OUT_OF_MEMORY))?;
 
         let binding_base = REQUEST_HEADER_BYTES + size_of::<SubmitRequest>() as u64;
         for index in 0..count {
@@ -563,7 +557,6 @@ impl FrameDecoder {
             }
             let range = BufferRange::new(binding.offset.get(), bytes).map_err(|_| invalid())?;
             let access = AccessMode::try_from(binding.access).map_err(|_| invalid())?;
-            slots.push(binding.slot.get());
             bindings.push(DecodedBinding {
                 buffer_id: object_id(binding.buffer_id.get())?,
                 range,
@@ -572,7 +565,11 @@ impl FrameDecoder {
             });
         }
 
-        if has_duplicate_slots(&mut slots)? {
+        bindings.sort_unstable_by_key(|binding| binding.slot);
+        if bindings
+            .windows(2)
+            .any(|window| window[0].slot == window[1].slot)
+        {
             return Err(invalid());
         }
 
@@ -677,44 +674,6 @@ fn decode_transfer(
         object_id(value.buffer_id.get())?,
         BufferRange::new(value.offset.get(), bytes).map_err(|_| invalid())?,
     ))
-}
-
-fn has_duplicate_slots(slots: &mut [u32]) -> Result<bool, BodyDecodeError> {
-    if slots.len() < 2 {
-        return Ok(false);
-    }
-
-    let mut scratch = Vec::new();
-    scratch
-        .try_reserve_exact(slots.len())
-        .map_err(|_| BodyDecodeError::Protocol(StatusCode::OUT_OF_MEMORY))?;
-    scratch.resize(slots.len(), 0);
-
-    radix_pass(slots, &mut scratch, 0);
-    radix_pass(&scratch, slots, 8);
-    radix_pass(slots, &mut scratch, 16);
-    radix_pass(&scratch, slots, 24);
-    Ok(slots.windows(2).any(|window| window[0] == window[1]))
-}
-
-fn radix_pass(input: &[u32], output: &mut [u32], shift: u32) {
-    let mut counts = [0_usize; 256];
-    for value in input {
-        counts[((value >> shift) & 0xff) as usize] += 1;
-    }
-
-    let mut next = 0;
-    for count in &mut counts {
-        let start = next;
-        next += *count;
-        *count = start;
-    }
-
-    for value in input {
-        let bucket = ((value >> shift) & 0xff) as usize;
-        output[counts[bucket]] = *value;
-        counts[bucket] += 1;
-    }
 }
 
 #[cfg(test)]

--- a/crates/virtio-accel-device/src/engine.rs
+++ b/crates/virtio-accel-device/src/engine.rs
@@ -5,19 +5,24 @@
 //! executor. Transport integrations may schedule distinct processors or backend work concurrently,
 //! but state admission and response commitment remain explicit serialization boundaries.
 
+use alloc::vec::Vec;
+
 use virtio_accel_core::{
-    Accelerator, ArtifactRef, BackendError, BufferRange, BufferUsage, ByteSink, ByteSource,
-    DeviceInfo, ReleaseFailure,
+    Accelerator, ArtifactRef, BackendError, BindingRef, BufferRange, BufferUsage, ByteSink,
+    ByteSource, Capabilities, DeviceInfo, EventState, ReleaseFailure, SubmitFailure, Timeout,
 };
-use virtio_accel_proto::{Le16, Le32, Le64, ObjectPayload, StatusCode, WireConfig, WireDeviceInfo};
+use virtio_accel_proto::{
+    KnownEventState, Le16, Le32, Le64, ObjectPayload, StatusCode, SubmitResponse, WireConfig,
+    WireDeviceInfo, WireEventState,
+};
 use zerocopy::IntoBytes;
 
 use crate::{
-    BufferRecord, ChainRegion, CreateError, DecodedRequest, DecodedRequestBody, DecoderLimits,
-    DecoderLimitsError, DeviceState, DeviceStateConfigError, DeviceStateError, FrameDecoder,
-    FramePreflight, FramePreflightError, ObjectId, ObjectNamespace, ResponseWriteError,
-    ResponseWriter, UnusableFrame, preflight_command_frame, status_from_backend_error,
-    status_from_device_state_error,
+    BufferRecord, ChainRegion, CreateError, DecodedBinding, DecodedRequest, DecodedRequestBody,
+    DecoderLimits, DecoderLimitsError, DeviceState, DeviceStateConfigError, DeviceStateError,
+    FrameDecoder, FramePreflight, FramePreflightError, ObjectId, ObjectNamespace,
+    ResponseWriteError, ResponseWriter, UnusableFrame, preflight_command_frame,
+    status_from_backend_error, status_from_device_state_error,
 };
 
 pub type AcceleratorState<A> = DeviceState<
@@ -55,6 +60,14 @@ pub enum CommandOutcome {
         used: u32,
     },
     Unusable(UnusableFrame),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SubmitCreateError {
+    State(DeviceStateError),
+    OutOfMemory,
+    Rejected(BackendError),
+    Validation(StatusCode),
 }
 
 /// One synchronization-free command engine for a backend instance.
@@ -263,11 +276,201 @@ impl<A: Accelerator> CommandProcessor<A> {
             DecodedRequestBody::DestroyQueue { queue_id } => {
                 self.destroy_queue(response, request_id, queue_id)
             }
-            DecodedRequestBody::Submit { .. }
-            | DecodedRequestBody::PollEvent { .. }
-            | DecodedRequestBody::CancelEvent { .. }
-            | DecodedRequestBody::DestroyEvent { .. } => {
-                self.respond_empty(response, StatusCode::UNSUPPORTED, request_id, false)
+            DecodedRequestBody::Submit {
+                queue_id,
+                program_id,
+                bindings,
+                timeout,
+            } => self.submit(
+                response, request_id, queue_id, program_id, bindings, timeout,
+            ),
+            DecodedRequestBody::PollEvent { event_id } => {
+                self.poll_event(response, request_id, event_id)
+            }
+            DecodedRequestBody::CancelEvent { event_id } => {
+                self.cancel_event(response, request_id, event_id)
+            }
+            DecodedRequestBody::DestroyEvent { event_id } => {
+                self.destroy_event(response, request_id, event_id)
+            }
+        }
+    }
+
+    fn submit(
+        &mut self,
+        response: &mut dyn ByteSink,
+        request_id: u64,
+        queue_id: ObjectId,
+        program_id: ObjectId,
+        bindings: Vec<DecodedBinding>,
+        timeout: Timeout,
+    ) -> Result<CommandOutcome, CommandProcessError> {
+        let mut buffer_ids = Vec::new();
+        if buffer_ids.try_reserve_exact(bindings.len()).is_err() {
+            return self.respond_empty(response, StatusCode::OUT_OF_MEMORY, request_id, false);
+        }
+        buffer_ids.extend(bindings.iter().map(|binding| binding.buffer_id));
+
+        let accelerator = &self.accelerator;
+        let mut admission_status = StatusCode::OK;
+        let result = self
+            .state
+            .create_event_with(queue_id, program_id, buffer_ids, |resources| {
+                let mut native_bindings = Vec::new();
+                native_bindings
+                    .try_reserve_exact(bindings.len())
+                    .map_err(|_| SubmitCreateError::OutOfMemory)?;
+                for binding in &bindings {
+                    let (buffer, info) = resources
+                        .buffer_with_info_by_id(binding.buffer_id)
+                        .map_err(SubmitCreateError::State)?;
+                    let desc = info.desc();
+                    if binding.range.end() > desc.bytes() {
+                        return Err(SubmitCreateError::Validation(StatusCode::OUT_OF_BOUNDS));
+                    }
+                    if !desc.allows_access(binding.access) {
+                        return Err(SubmitCreateError::Validation(StatusCode::PERMISSION_DENIED));
+                    }
+                    native_bindings.push(BindingRef {
+                        slot: binding.slot,
+                        buffer,
+                        range: binding.range,
+                        access: binding.access,
+                    });
+                }
+                match accelerator.submit(
+                    resources.queue(),
+                    resources.program(),
+                    &native_bindings,
+                    timeout,
+                ) {
+                    Ok(event) => Ok(event),
+                    Err(SubmitFailure::Rejected(error)) => Err(SubmitCreateError::Rejected(error)),
+                    Err(SubmitFailure::Indeterminate { error, event }) => {
+                        admission_status = status_from_backend_error(error);
+                        Ok(event)
+                    }
+                }
+            });
+
+        match result {
+            Ok(event_id) => {
+                self.respond_event_id(response, admission_status, request_id, event_id, true)
+            }
+            Err(CreateError::State(error)) => self.respond_state_error(response, request_id, error),
+            Err(CreateError::Provider(SubmitCreateError::Rejected(error))) => {
+                self.respond_backend_error(response, request_id, error, false)
+            }
+            Err(CreateError::Provider(SubmitCreateError::OutOfMemory)) => {
+                self.respond_empty(response, StatusCode::OUT_OF_MEMORY, request_id, false)
+            }
+            Err(CreateError::Provider(SubmitCreateError::Validation(status))) => {
+                self.respond_empty(response, status, request_id, false)
+            }
+            Err(CreateError::Provider(SubmitCreateError::State(_))) => {
+                self.recovery_response(response, request_id)
+            }
+        }
+    }
+
+    fn poll_event(
+        &mut self,
+        response: &mut dyn ByteSink,
+        request_id: u64,
+        event_id: ObjectId,
+    ) -> Result<CommandOutcome, CommandProcessError> {
+        let event = match self.state.event_record(event_id) {
+            Ok(record) => match record.resource() {
+                Ok(event) => event,
+                Err(error) => return self.respond_state_error(response, request_id, error),
+            },
+            Err(error) => return self.respond_state_error(response, request_id, error),
+        };
+        match self.accelerator.poll_event(event) {
+            Ok(state) => {
+                let payload = wire_event_state(state);
+                self.respond_bytes(
+                    response,
+                    StatusCode::OK,
+                    request_id,
+                    payload.as_bytes(),
+                    false,
+                )
+            }
+            Err(error) => self.respond_backend_error(response, request_id, error, false),
+        }
+    }
+
+    fn cancel_event(
+        &mut self,
+        response: &mut dyn ByteSink,
+        request_id: u64,
+        event_id: ObjectId,
+    ) -> Result<CommandOutcome, CommandProcessError> {
+        if !self
+            .info
+            .capabilities
+            .contains(Capabilities::EVENT_CANCELLATION)
+        {
+            return self.respond_empty(response, StatusCode::UNSUPPORTED, request_id, false);
+        }
+        let event = match self.state.event_record(event_id) {
+            Ok(record) => match record.resource() {
+                Ok(event) => event,
+                Err(error) => return self.respond_state_error(response, request_id, error),
+            },
+            Err(error) => return self.respond_state_error(response, request_id, error),
+        };
+        match self.accelerator.cancel_event(event) {
+            Ok(()) => self.respond_empty(response, StatusCode::OK, request_id, true),
+            Err(error) => self.respond_backend_error(response, request_id, error, false),
+        }
+    }
+
+    fn destroy_event(
+        &mut self,
+        response: &mut dyn ByteSink,
+        request_id: u64,
+        event_id: ObjectId,
+    ) -> Result<CommandOutcome, CommandProcessError> {
+        let state = {
+            let event = match self.state.event_record(event_id) {
+                Ok(record) => match record.resource() {
+                    Ok(event) => event,
+                    Err(error) => return self.respond_state_error(response, request_id, error),
+                },
+                Err(error) => return self.respond_state_error(response, request_id, error),
+            };
+            self.accelerator.poll_event(event)
+        };
+        match state {
+            Ok(EventState::Pending) => {
+                return self.respond_empty(response, StatusCode::BUSY, request_id, false);
+            }
+            Ok(EventState::Complete | EventState::Failed(_) | EventState::Cancelled) => {}
+            Err(error) => {
+                return self.respond_backend_error(response, request_id, error, false);
+            }
+        }
+
+        let event = match self.state.begin_event_release(event_id) {
+            Ok(event) => event,
+            Err(error) => return self.respond_state_error(response, request_id, error),
+        };
+        match self.accelerator.destroy_event(event) {
+            Ok(()) => match self.state.commit_event_release(event_id) {
+                Ok(()) => self.respond_empty(response, StatusCode::OK, request_id, true),
+                Err(_) => self.recovery_response(response, request_id),
+            },
+            Err(ReleaseFailure::Rejected { error, resource }) => {
+                match self.state.restore_event_release(event_id, resource) {
+                    Ok(()) => self.respond_backend_error(response, request_id, error, false),
+                    Err(_) => self.recovery_response(response, request_id),
+                }
+            }
+            Err(ReleaseFailure::Indeterminate { .. }) => {
+                let _ = self.state.commit_event_release(event_id);
+                self.recovery_response(response, request_id)
             }
         }
     }
@@ -536,6 +739,20 @@ impl<A: Accelerator> CommandProcessor<A> {
         )
     }
 
+    fn respond_event_id(
+        &mut self,
+        response: &mut dyn ByteSink,
+        status: StatusCode,
+        request_id: u64,
+        id: ObjectId,
+        mutated: bool,
+    ) -> Result<CommandOutcome, CommandProcessError> {
+        let payload = SubmitResponse {
+            event_id: Le64::new(id.get()),
+        };
+        self.respond_bytes(response, status, request_id, payload.as_bytes(), mutated)
+    }
+
     fn respond_bytes(
         &mut self,
         response: &mut dyn ByteSink,
@@ -627,5 +844,19 @@ fn wire_device_info(info: DeviceInfo) -> WireDeviceInfo {
         max_bindings_per_submission: Le32::new(info.limits.max_bindings_per_submission),
         max_buffer_bytes: Le64::new(info.limits.max_buffer_bytes),
         max_artifact_bytes: Le64::new(info.limits.max_artifact_bytes),
+    }
+}
+
+fn wire_event_state(state: EventState) -> WireEventState {
+    let (state, error) = match state {
+        EventState::Pending => (KnownEventState::Pending, StatusCode::OK),
+        EventState::Complete => (KnownEventState::Complete, StatusCode::OK),
+        EventState::Failed(error) => (KnownEventState::Failed, status_from_backend_error(error)),
+        EventState::Cancelled => (KnownEventState::Cancelled, StatusCode::OK),
+    };
+    WireEventState {
+        state: Le16::new(state as u16),
+        error: Le16::new(error.0),
+        reserved: Le32::new(0),
     }
 }

--- a/crates/virtio-accel-device/src/state.rs
+++ b/crates/virtio-accel-device/src/state.rs
@@ -297,16 +297,24 @@ impl<'a, B, P, Q> SubmissionResources<'a, B, P, Q> {
         self.program
     }
 
+    /// Retained buffer IDs sorted by raw object ID, including duplicate bindings.
     pub fn buffer_ids(&self) -> &[ObjectId] {
         self.buffer_ids
     }
 
-    pub fn buffer(&self, index: usize) -> Result<&'a B, DeviceStateError> {
-        let id = *self
-            .buffer_ids
-            .get(index)
-            .ok_or(DeviceStateError::InvalidArgument)?;
-        self.buffers.get(id).map_err(map_table_error)?.resource()
+    pub fn buffer_by_id(&self, id: ObjectId) -> Result<&'a B, DeviceStateError> {
+        self.buffer_with_info_by_id(id).map(|(buffer, _)| buffer)
+    }
+
+    pub(crate) fn buffer_with_info_by_id(
+        &self,
+        id: ObjectId,
+    ) -> Result<(&'a B, BufferInfo), DeviceStateError> {
+        self.buffer_ids
+            .binary_search_by_key(&id.get(), |candidate| candidate.get())
+            .map_err(|_| DeviceStateError::InvalidArgument)?;
+        let record = self.buffers.get(id).map_err(map_table_error)?;
+        Ok((record.resource()?, record.info()))
     }
 }
 
@@ -535,7 +543,7 @@ impl<C, B, P, Q, E> DeviceState<C, B, P, Q, E> {
         &mut self,
         queue_id: ObjectId,
         program_id: ObjectId,
-        buffer_ids: &[ObjectId],
+        mut buffer_ids: Vec<ObjectId>,
         create: impl FnOnce(SubmissionResources<'_, B, P, Q>) -> Result<E, ProviderError>,
     ) -> Result<ObjectId, CreateError<ProviderError>> {
         if buffer_ids.is_empty() {
@@ -546,7 +554,7 @@ impl<C, B, P, Q, E> DeviceState<C, B, P, Q, E> {
         }
 
         let context_id = self
-            .validate_submission(queue_id, program_id, buffer_ids)
+            .validate_submission(queue_id, program_id, &buffer_ids)
             .map_err(CreateError::State)?;
         let context = self
             .contexts
@@ -559,15 +567,10 @@ impl<C, B, P, Q, E> DeviceState<C, B, P, Q, E> {
             .try_reserve_insert()
             .map_err(|error| CreateError::State(map_table_error(error)))?;
 
-        let mut retained_buffers = Vec::new();
-        retained_buffers
-            .try_reserve_exact(buffer_ids.len())
-            .map_err(|_| CreateError::State(DeviceStateError::OutOfMemory))?;
-        retained_buffers.extend_from_slice(buffer_ids);
-        retained_buffers.sort_unstable_by_key(|id| id.get());
-        self.check_reference_increments(queue_id, program_id, &retained_buffers)
+        buffer_ids.sort_unstable_by_key(|id| id.get());
+        self.check_reference_increments(queue_id, program_id, &buffer_ids)
             .map_err(CreateError::State)?;
-        self.increment_event_references(context_id, queue_id, program_id, buffer_ids)
+        self.increment_event_references(context_id, queue_id, program_id, &buffer_ids)
             .map_err(CreateError::State)?;
 
         let event_result = {
@@ -586,13 +589,13 @@ impl<C, B, P, Q, E> DeviceState<C, B, P, Q, E> {
                 queue,
                 program,
                 buffers: &self.buffers,
-                buffer_ids,
+                buffer_ids: &buffer_ids,
             })
         };
         let event = match event_result {
             Ok(event) => event,
             Err(error) => {
-                self.decrement_event_references(context_id, queue_id, program_id, buffer_ids)
+                self.decrement_event_references(context_id, queue_id, program_id, &buffer_ids)
                     .map_err(CreateError::State)?;
                 return Err(CreateError::Provider(error));
             }
@@ -603,7 +606,7 @@ impl<C, B, P, Q, E> DeviceState<C, B, P, Q, E> {
             context_id,
             queue_id,
             program_id,
-            buffer_ids: retained_buffers,
+            buffer_ids,
         });
         Ok(id)
     }
@@ -1093,12 +1096,11 @@ mod tests {
             })
             .unwrap();
         let event = state
-            .create_event_with(queue, program, &[buffer, buffer], |resources| {
+            .create_event_with(queue, program, alloc::vec![buffer, buffer], |resources| {
                 assert_eq!(resources.context_id(), context);
                 assert_eq!(*resources.queue(), 40);
                 assert_eq!(*resources.program(), 30);
-                assert_eq!(*resources.buffer(0).unwrap(), 21);
-                assert_eq!(*resources.buffer(1).unwrap(), 21);
+                assert_eq!(*resources.buffer_by_id(buffer).unwrap(), 21);
                 Ok::<_, &'static str>(50)
             })
             .unwrap();
@@ -1253,13 +1255,13 @@ mod tests {
         ));
 
         state
-            .create_event_with(queue, program, &[buffer], |_| {
+            .create_event_with(queue, program, alloc::vec![buffer], |_| {
                 calls.set(calls.get() + 1);
                 Ok::<_, &'static str>(50)
             })
             .unwrap();
         assert!(matches!(
-            state.create_event_with(queue, program, &[buffer], |_| {
+            state.create_event_with(queue, program, alloc::vec![buffer], |_| {
                 calls.set(calls.get() + 1);
                 Ok::<_, &'static str>(51)
             }),
@@ -1314,7 +1316,9 @@ mod tests {
             .create_queue_with(context, |_| Ok::<_, &'static str>(40))
             .unwrap();
         assert!(matches!(
-            state.create_event_with(queue, program, &[buffer], |_| { Err::<u32, _>("event") }),
+            state.create_event_with(queue, program, alloc::vec![buffer], |_| {
+                Err::<u32, _>("event")
+            }),
             Err(CreateError::Provider("event"))
         ));
         assert_eq!(state.event_count(), 0);
@@ -1342,7 +1346,7 @@ mod tests {
             .unwrap();
         let called = Cell::new(false);
         assert!(matches!(
-            first.create_event_with(queue, program, &[buffer], |_| {
+            first.create_event_with(queue, program, alloc::vec![buffer], |_| {
                 called.set(true);
                 Ok::<_, &'static str>(50)
             }),

--- a/crates/virtio-accel-device/tests/command_processor.rs
+++ b/crates/virtio-accel-device/tests/command_processor.rs
@@ -3,9 +3,9 @@ use std::rc::Rc;
 use std::vec::Vec;
 
 use virtio_accel_core::{
-    Accelerator, AllocatedBuffer, ArtifactRef, BackendError, BindingRef, BufferDesc, BufferUsage,
-    ByteSink, ByteSource, ContextDesc, DeviceInfo, EventState, MemoryDomain, QueueDesc,
-    ReleaseFailure, SubmitFailure, Timeout,
+    Accelerator, AccessMode, AllocatedBuffer, ArtifactRef, BackendError, BindingRef, BufferDesc,
+    BufferUsage, ByteSink, ByteSource, Capabilities, ContextDesc, DeviceInfo, EventState,
+    MemoryDomain, QueueDesc, ReleaseFailure, SubmitFailure, Timeout,
 };
 use virtio_accel_device::{
     ChainRegion, CommandOutcome, CommandProcessError, CommandProcessor, CommandProcessorInitError,
@@ -17,9 +17,10 @@ use virtio_accel_mock::{
 };
 use virtio_accel_proto::{
     AllocateBufferRequest, BASELINE_COMMAND_QUEUES, CreateContextRequest, CreateQueueRequest,
-    HARD_MAX_REQUEST_BYTES, HARD_MAX_RESPONSE_BYTES, Le16, Le32, Le64, LoadProgramRequest,
-    ObjectPayload, PROTOCOL_MAJOR, PROTOCOL_MINOR, RequestFlags, RequestHeader, ResponseHeader,
-    StatusCode, TransferBufferRequest, WireConfig, WireDeviceInfo, read_exact,
+    HARD_MAX_REQUEST_BYTES, HARD_MAX_RESPONSE_BYTES, KnownEventState, Le16, Le32, Le64,
+    LoadProgramRequest, ObjectPayload, PROTOCOL_MAJOR, PROTOCOL_MINOR, RequestFlags, RequestHeader,
+    ResponseHeader, StatusCode, SubmitRequest, SubmitResponse, TransferBufferRequest, WireBinding,
+    WireConfig, WireDeviceInfo, WireEventState, read_exact,
 };
 use zerocopy::IntoBytes;
 
@@ -28,6 +29,13 @@ const REQUEST_ID: u64 = 0x0102_0304_0506_0708;
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum ReleaseMode {
     Pass,
+    Reject,
+    Indeterminate,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SubmitMode {
+    Accept,
     Reject,
     Indeterminate,
 }
@@ -45,6 +53,15 @@ struct RecordingBackend {
     segmented_write: Cell<bool>,
     segmented_read: Cell<bool>,
     segmented_artifact: Cell<bool>,
+    submit_mode: Cell<SubmitMode>,
+    submit_calls: Cell<u32>,
+    last_timeout: Cell<Option<Timeout>>,
+    poll_error: Cell<Option<BackendError>>,
+    event_state_override: Cell<Option<EventState>>,
+    poll_calls: Cell<u32>,
+    cancel_calls: Cell<u32>,
+    event_release_mode: Cell<ReleaseMode>,
+    destroy_event_calls: Cell<u32>,
 }
 
 impl Default for RecordingBackend {
@@ -62,6 +79,15 @@ impl Default for RecordingBackend {
             segmented_write: Cell::new(false),
             segmented_read: Cell::new(false),
             segmented_artifact: Cell::new(false),
+            submit_mode: Cell::new(SubmitMode::Accept),
+            submit_calls: Cell::new(0),
+            last_timeout: Cell::new(None),
+            poll_error: Cell::new(None),
+            event_state_override: Cell::new(None),
+            poll_calls: Cell::new(0),
+            cancel_calls: Cell::new(0),
+            event_release_mode: Cell::new(ReleaseMode::Pass),
+            destroy_event_calls: Cell::new(0),
         }
     }
 }
@@ -171,19 +197,57 @@ impl Accelerator for RecordingBackend {
         bindings: &[BindingRef<'_, Self::Buffer>],
         timeout: Timeout,
     ) -> Result<Self::Event, SubmitFailure<Self::Event>> {
-        self.inner.submit(queue, program, bindings, timeout)
+        self.submit_calls.set(self.submit_calls.get() + 1);
+        self.last_timeout.set(Some(timeout));
+        match self.submit_mode.get() {
+            SubmitMode::Accept => self.inner.submit(queue, program, bindings, timeout),
+            SubmitMode::Reject => Err(SubmitFailure::Rejected(BackendError::Busy)),
+            SubmitMode::Indeterminate => {
+                match self.inner.submit(queue, program, bindings, timeout) {
+                    Ok(event) => Err(SubmitFailure::Indeterminate {
+                        error: BackendError::DeadlineExpired,
+                        event,
+                    }),
+                    Err(error) => Err(error),
+                }
+            }
+        }
     }
 
     fn poll_event(&self, event: &Self::Event) -> Result<EventState, BackendError> {
+        self.poll_calls.set(self.poll_calls.get() + 1);
+        if let Some(error) = self.poll_error.take() {
+            return Err(error);
+        }
+        if let Some(state) = self.event_state_override.get() {
+            return Ok(state);
+        }
         self.inner.poll_event(event)
     }
 
     fn cancel_event(&self, event: &Self::Event) -> Result<(), BackendError> {
+        self.cancel_calls.set(self.cancel_calls.get() + 1);
         self.inner.cancel_event(event)
     }
 
     fn destroy_event(&self, event: Self::Event) -> Result<(), ReleaseFailure<Self::Event>> {
-        self.inner.destroy_event(event)
+        self.destroy_event_calls
+            .set(self.destroy_event_calls.get() + 1);
+        match self.event_release_mode.get() {
+            ReleaseMode::Pass => match self.event_state_override.get() {
+                Some(EventState::Complete | EventState::Failed(_) | EventState::Cancelled) => {
+                    Ok(())
+                }
+                Some(EventState::Pending) | None => self.inner.destroy_event(event),
+            },
+            ReleaseMode::Reject => Err(ReleaseFailure::Rejected {
+                error: BackendError::Busy,
+                resource: event,
+            }),
+            ReleaseMode::Indeterminate => Err(ReleaseFailure::Indeterminate {
+                error: BackendError::DeviceLost,
+            }),
+        }
     }
 }
 
@@ -327,6 +391,108 @@ fn allocate_buffer_with_usage(
     let (outcome, response) = run(processor, &frame, 24);
     assert_eq!(status(outcome), StatusCode::OK);
     object_id(&response)
+}
+
+fn load_program(
+    processor: &mut CommandProcessor<RecordingBackend>,
+    context_id: ObjectId,
+) -> ObjectId {
+    let artifact = b"program";
+    let load = LoadProgramRequest {
+        context_id: Le64::new(context_id.get()),
+        format: Le32::new(1),
+        flags: Le32::new(0),
+        target: [Le32::new(0); 12],
+        payload_bytes: Le64::new(artifact.as_slice().len() as u64),
+        resident_bytes: Le64::new(artifact.as_slice().len() as u64),
+    };
+    let mut payload = Vec::from(load.as_bytes());
+    payload.extend_from_slice(artifact);
+    let (outcome, response) = run(
+        processor,
+        &request(virtio_accel_proto::KnownOpcode::LoadProgram, &payload),
+        24,
+    );
+    assert_eq!(status(outcome), StatusCode::OK);
+    object_id(&response)
+}
+
+fn create_queue(
+    processor: &mut CommandProcessor<RecordingBackend>,
+    context_id: ObjectId,
+) -> ObjectId {
+    let frame = request(
+        virtio_accel_proto::KnownOpcode::CreateQueue,
+        CreateQueueRequest {
+            context_id: Le64::new(context_id.get()),
+            flags: Le32::new(0),
+            reserved: Le32::new(0),
+        }
+        .as_bytes(),
+    );
+    let (outcome, response) = run(processor, &frame, 24);
+    assert_eq!(status(outcome), StatusCode::OK);
+    object_id(&response)
+}
+
+fn submission_objects(
+    processor: &mut CommandProcessor<RecordingBackend>,
+    usage: BufferUsage,
+) -> (ObjectId, ObjectId, ObjectId, ObjectId) {
+    let context = create_context(processor);
+    let buffer = allocate_buffer_with_usage(processor, context, usage);
+    let program = load_program(processor, context);
+    let queue = create_queue(processor, context);
+    (context, buffer, program, queue)
+}
+
+fn submit_request(
+    queue_id: ObjectId,
+    program_id: ObjectId,
+    buffer_id: ObjectId,
+    offset: u64,
+    bytes: u64,
+    access: AccessMode,
+) -> Vec<u8> {
+    submit_request_with_timeout(queue_id, program_id, buffer_id, offset, bytes, access, 0)
+}
+
+fn submit_request_with_timeout(
+    queue_id: ObjectId,
+    program_id: ObjectId,
+    buffer_id: ObjectId,
+    offset: u64,
+    bytes: u64,
+    access: AccessMode,
+    timeout_ns: u64,
+) -> Vec<u8> {
+    let submit = SubmitRequest {
+        queue_id: Le64::new(queue_id.get()),
+        program_id: Le64::new(program_id.get()),
+        binding_count: Le32::new(1),
+        flags: Le32::new(0),
+        timeout_ns: Le64::new(timeout_ns),
+    };
+    let binding = WireBinding {
+        buffer_id: Le64::new(buffer_id.get()),
+        offset: Le64::new(offset),
+        bytes: Le64::new(bytes),
+        slot: Le32::new(0),
+        access: access as u8,
+        reserved: [0; 3],
+    };
+    let mut payload = Vec::from(submit.as_bytes());
+    payload.extend_from_slice(binding.as_bytes());
+    request(virtio_accel_proto::KnownOpcode::Submit, &payload)
+}
+
+fn event_id(response: &[u8]) -> ObjectId {
+    let payload = read_exact::<SubmitResponse>(&response[16..24]).unwrap();
+    ObjectId::from_raw(payload.event_id.get()).unwrap()
+}
+
+fn event_state(response: &[u8]) -> WireEventState {
+    read_exact::<WireEventState>(&response[16..24]).unwrap()
 }
 
 #[test]
@@ -650,4 +816,476 @@ fn response_failure_after_creation_requires_reset() {
     );
     assert_eq!(processor.state().context_count(), 1);
     assert_eq!(processor.health(), DeviceHealth::NeedsReset);
+}
+
+#[test]
+fn accepted_events_retain_resources_and_resolve_cancel_completion_races() {
+    let mut processor = processor();
+    let (_context, buffer, program, queue) =
+        submission_objects(&mut processor, BufferUsage::PROGRAM_INPUT);
+    let submit =
+        submit_request_with_timeout(queue, program, buffer, 0, 8, AccessMode::Read, 1_000_000);
+
+    let (outcome, response) = run(&mut processor, &submit, 24);
+    assert_eq!(status(outcome), StatusCode::OK);
+    assert_eq!(
+        processor.accelerator().last_timeout.get(),
+        Some(Timeout::from_wire_ns(1_000_000))
+    );
+    let cancelled_event = event_id(&response);
+    assert_eq!(processor.state().event_count(), 1);
+    assert_eq!(
+        processor.state().buffer_record(buffer).unwrap().in_flight(),
+        1
+    );
+    assert_eq!(
+        processor
+            .state()
+            .program_record(program)
+            .unwrap()
+            .in_flight(),
+        1
+    );
+    assert_eq!(
+        processor.state().queue_record(queue).unwrap().in_flight(),
+        1
+    );
+
+    let free = object_request(virtio_accel_proto::KnownOpcode::FreeBuffer, buffer);
+    assert_eq!(status(run(&mut processor, &free, 16).0), StatusCode::BUSY);
+
+    let poll = object_request(virtio_accel_proto::KnownOpcode::PollEvent, cancelled_event);
+    let (outcome, response) = run(&mut processor, &poll, 24);
+    assert_eq!(status(outcome), StatusCode::OK);
+    assert_eq!(
+        event_state(&response).known_state().unwrap(),
+        KnownEventState::Pending
+    );
+
+    let destroy = object_request(
+        virtio_accel_proto::KnownOpcode::DestroyEvent,
+        cancelled_event,
+    );
+    assert_eq!(
+        status(run(&mut processor, &destroy, 16).0),
+        StatusCode::BUSY
+    );
+    assert_eq!(processor.accelerator().destroy_event_calls.get(), 0);
+
+    let cancel = object_request(
+        virtio_accel_proto::KnownOpcode::CancelEvent,
+        cancelled_event,
+    );
+    assert_eq!(status(run(&mut processor, &cancel, 16).0), StatusCode::OK);
+    let (outcome, response) = run(&mut processor, &poll, 24);
+    assert_eq!(status(outcome), StatusCode::OK);
+    assert_eq!(
+        event_state(&response).known_state().unwrap(),
+        KnownEventState::Cancelled
+    );
+    assert_eq!(status(run(&mut processor, &destroy, 16).0), StatusCode::OK);
+    assert_eq!(processor.state().event_count(), 0);
+    assert_eq!(
+        processor.state().buffer_record(buffer).unwrap().in_flight(),
+        0
+    );
+    assert_eq!(
+        processor
+            .state()
+            .program_record(program)
+            .unwrap()
+            .in_flight(),
+        0
+    );
+    assert_eq!(
+        processor.state().queue_record(queue).unwrap().in_flight(),
+        0
+    );
+
+    let (outcome, response) = run(&mut processor, &submit, 24);
+    assert_eq!(status(outcome), StatusCode::OK);
+    let pending_event = event_id(&response);
+    let (outcome, response) = run(&mut processor, &submit, 24);
+    assert_eq!(status(outcome), StatusCode::OK);
+    let completed_event = event_id(&response);
+    assert_ne!(pending_event, completed_event);
+    assert_eq!(
+        processor.state().buffer_record(buffer).unwrap().in_flight(),
+        2
+    );
+    let event = processor
+        .state()
+        .event_record(completed_event)
+        .unwrap()
+        .resource()
+        .unwrap();
+    processor.accelerator().inner.complete(event).unwrap();
+
+    let poll = object_request(virtio_accel_proto::KnownOpcode::PollEvent, pending_event);
+    let (outcome, response) = run(&mut processor, &poll, 24);
+    assert_eq!(status(outcome), StatusCode::OK);
+    assert_eq!(
+        event_state(&response).known_state().unwrap(),
+        KnownEventState::Pending
+    );
+
+    let cancel = object_request(
+        virtio_accel_proto::KnownOpcode::CancelEvent,
+        completed_event,
+    );
+    assert_eq!(status(run(&mut processor, &cancel, 16).0), StatusCode::BUSY);
+    let poll = object_request(virtio_accel_proto::KnownOpcode::PollEvent, completed_event);
+    let (outcome, response) = run(&mut processor, &poll, 24);
+    assert_eq!(status(outcome), StatusCode::OK);
+    assert_eq!(
+        event_state(&response).known_state().unwrap(),
+        KnownEventState::Complete
+    );
+    let destroy = object_request(
+        virtio_accel_proto::KnownOpcode::DestroyEvent,
+        completed_event,
+    );
+    assert_eq!(status(run(&mut processor, &destroy, 16).0), StatusCode::OK);
+    assert_eq!(
+        processor.state().buffer_record(buffer).unwrap().in_flight(),
+        1
+    );
+
+    let cancel = object_request(virtio_accel_proto::KnownOpcode::CancelEvent, pending_event);
+    assert_eq!(status(run(&mut processor, &cancel, 16).0), StatusCode::OK);
+    let destroy = object_request(virtio_accel_proto::KnownOpcode::DestroyEvent, pending_event);
+    assert_eq!(status(run(&mut processor, &destroy, 16).0), StatusCode::OK);
+    assert_eq!(
+        processor.state().buffer_record(buffer).unwrap().in_flight(),
+        0
+    );
+}
+
+#[test]
+fn rejected_and_indeterminate_submissions_preserve_the_admission_boundary() {
+    let mut processor = processor();
+    let (_context, buffer, program, queue) =
+        submission_objects(&mut processor, BufferUsage::PROGRAM_INPUT);
+    let submit = submit_request(queue, program, buffer, 0, 8, AccessMode::Read);
+
+    processor.accelerator().submit_mode.set(SubmitMode::Reject);
+    let (outcome, response) = run(&mut processor, &submit, 24);
+    assert_eq!(status(outcome), StatusCode::BUSY);
+    assert_eq!(
+        read_exact::<ResponseHeader>(&response[..16])
+            .unwrap()
+            .payload_bytes
+            .get(),
+        0
+    );
+    assert_eq!(processor.state().event_count(), 0);
+    assert_eq!(
+        processor.state().buffer_record(buffer).unwrap().in_flight(),
+        0
+    );
+    assert_eq!(
+        processor
+            .state()
+            .program_record(program)
+            .unwrap()
+            .in_flight(),
+        0
+    );
+    assert_eq!(
+        processor.state().queue_record(queue).unwrap().in_flight(),
+        0
+    );
+
+    processor
+        .accelerator()
+        .submit_mode
+        .set(SubmitMode::Indeterminate);
+    let (outcome, response) = run(&mut processor, &submit, 24);
+    assert_eq!(status(outcome), StatusCode::DEADLINE_EXPIRED);
+    let event_id = event_id(&response);
+    assert_eq!(processor.health(), DeviceHealth::Running);
+    assert_eq!(processor.state().event_count(), 1);
+    assert_eq!(
+        processor.state().buffer_record(buffer).unwrap().in_flight(),
+        1
+    );
+    assert_eq!(
+        processor
+            .state()
+            .program_record(program)
+            .unwrap()
+            .in_flight(),
+        1
+    );
+    assert_eq!(
+        processor.state().queue_record(queue).unwrap().in_flight(),
+        1
+    );
+
+    let event = processor
+        .state()
+        .event_record(event_id)
+        .unwrap()
+        .resource()
+        .unwrap();
+    processor.accelerator().inner.complete(event).unwrap();
+    let destroy = object_request(virtio_accel_proto::KnownOpcode::DestroyEvent, event_id);
+    assert_eq!(status(run(&mut processor, &destroy, 16).0), StatusCode::OK);
+    assert_eq!(
+        processor.state().buffer_record(buffer).unwrap().in_flight(),
+        0
+    );
+    assert_eq!(
+        processor
+            .state()
+            .program_record(program)
+            .unwrap()
+            .in_flight(),
+        0
+    );
+    assert_eq!(
+        processor.state().queue_record(queue).unwrap().in_flight(),
+        0
+    );
+}
+
+#[test]
+fn submission_validation_rejects_before_backend_admission() {
+    let mut processor = processor();
+    let (_context, buffer, program, queue) =
+        submission_objects(&mut processor, BufferUsage::PROGRAM_OUTPUT);
+
+    let wrong_access = submit_request(queue, program, buffer, 0, 8, AccessMode::Read);
+    assert_eq!(
+        status(run(&mut processor, &wrong_access, 24).0),
+        StatusCode::PERMISSION_DENIED
+    );
+
+    let out_of_bounds = submit_request(queue, program, buffer, 1, 8, AccessMode::Write);
+    assert_eq!(
+        status(run(&mut processor, &out_of_bounds, 24).0),
+        StatusCode::OUT_OF_BOUNDS
+    );
+
+    let other_context = create_context(&mut processor);
+    let other_buffer =
+        allocate_buffer_with_usage(&mut processor, other_context, BufferUsage::PROGRAM_INPUT);
+    let wrong_context = submit_request(queue, program, other_buffer, 0, 8, AccessMode::Read);
+    assert_eq!(
+        status(run(&mut processor, &wrong_context, 24).0),
+        StatusCode::STALE_OBJECT
+    );
+    assert_eq!(processor.accelerator().submit_calls.get(), 0);
+    assert_eq!(processor.state().event_count(), 0);
+    assert_eq!(
+        processor.state().buffer_record(buffer).unwrap().in_flight(),
+        0
+    );
+    assert_eq!(
+        processor
+            .state()
+            .program_record(program)
+            .unwrap()
+            .in_flight(),
+        0
+    );
+    assert_eq!(
+        processor.state().queue_record(queue).unwrap().in_flight(),
+        0
+    );
+    assert_eq!(
+        processor
+            .state()
+            .buffer_record(other_buffer)
+            .unwrap()
+            .in_flight(),
+        0
+    );
+}
+
+#[test]
+fn event_release_rejection_retries_and_indeterminate_release_requires_reset() {
+    let mut processor = processor();
+    let (_context, buffer, program, queue) =
+        submission_objects(&mut processor, BufferUsage::PROGRAM_INPUT);
+    let submit = submit_request(queue, program, buffer, 0, 8, AccessMode::Read);
+
+    let (_, response) = run(&mut processor, &submit, 24);
+    let first_event = event_id(&response);
+    let event = processor
+        .state()
+        .event_record(first_event)
+        .unwrap()
+        .resource()
+        .unwrap();
+    processor.accelerator().inner.complete(event).unwrap();
+    let destroy = object_request(virtio_accel_proto::KnownOpcode::DestroyEvent, first_event);
+
+    processor
+        .accelerator()
+        .event_release_mode
+        .set(ReleaseMode::Reject);
+    assert_eq!(
+        status(run(&mut processor, &destroy, 16).0),
+        StatusCode::BUSY
+    );
+    assert!(processor.state().event_record(first_event).is_ok());
+    assert_eq!(
+        processor.state().buffer_record(buffer).unwrap().in_flight(),
+        1
+    );
+
+    processor
+        .accelerator()
+        .event_release_mode
+        .set(ReleaseMode::Pass);
+    assert_eq!(status(run(&mut processor, &destroy, 16).0), StatusCode::OK);
+    assert_eq!(
+        processor.state().buffer_record(buffer).unwrap().in_flight(),
+        0
+    );
+
+    let (_, response) = run(&mut processor, &submit, 24);
+    let second_event = event_id(&response);
+    let event = processor
+        .state()
+        .event_record(second_event)
+        .unwrap()
+        .resource()
+        .unwrap();
+    processor.accelerator().inner.complete(event).unwrap();
+    processor
+        .accelerator()
+        .event_release_mode
+        .set(ReleaseMode::Indeterminate);
+    let destroy = object_request(virtio_accel_proto::KnownOpcode::DestroyEvent, second_event);
+    assert_eq!(
+        status(run(&mut processor, &destroy, 16).0),
+        StatusCode::DEVICE_LOST
+    );
+    assert_eq!(processor.health(), DeviceHealth::NeedsReset);
+    assert_eq!(
+        processor.state().event_record(second_event).unwrap_err(),
+        DeviceStateError::StaleObject
+    );
+    assert_eq!(
+        processor.state().buffer_record(buffer).unwrap().in_flight(),
+        0
+    );
+}
+
+#[test]
+fn event_faults_and_unreportable_admission_require_recovery() {
+    let mut poll_processor = processor();
+    let (_context, buffer, program, queue) =
+        submission_objects(&mut poll_processor, BufferUsage::PROGRAM_INPUT);
+    let submit = submit_request(queue, program, buffer, 0, 8, AccessMode::Read);
+    let (_, response) = run(&mut poll_processor, &submit, 24);
+    let event = event_id(&response);
+    poll_processor
+        .accelerator()
+        .poll_error
+        .set(Some(BackendError::DeviceLost));
+    let poll = object_request(virtio_accel_proto::KnownOpcode::PollEvent, event);
+    assert_eq!(
+        status(run(&mut poll_processor, &poll, 24).0),
+        StatusCode::DEVICE_LOST
+    );
+    assert_eq!(poll_processor.health(), DeviceHealth::NeedsReset);
+    assert_eq!(poll_processor.state().event_count(), 1);
+
+    let mut completion_processor = processor();
+    let (_context, buffer, program, queue) =
+        submission_objects(&mut completion_processor, BufferUsage::PROGRAM_INPUT);
+    let submit = submit_request(queue, program, buffer, 0, 8, AccessMode::Read);
+    let (_, response) = run(&mut completion_processor, &submit, 24);
+    let event = event_id(&response);
+    completion_processor
+        .accelerator()
+        .event_state_override
+        .set(Some(EventState::Failed(BackendError::DeadlineExpired)));
+    let poll = object_request(virtio_accel_proto::KnownOpcode::PollEvent, event);
+    for _ in 0..2 {
+        let (outcome, response) = run(&mut completion_processor, &poll, 24);
+        assert_eq!(status(outcome), StatusCode::OK);
+        let state = event_state(&response);
+        assert_eq!(state.known_state().unwrap(), KnownEventState::Failed);
+        assert_eq!(state.error.get(), StatusCode::DEADLINE_EXPIRED.0);
+    }
+    let destroy = object_request(virtio_accel_proto::KnownOpcode::DestroyEvent, event);
+    assert_eq!(
+        status(run(&mut completion_processor, &destroy, 16).0),
+        StatusCode::OK
+    );
+    assert_eq!(
+        completion_processor
+            .state()
+            .buffer_record(buffer)
+            .unwrap()
+            .in_flight(),
+        0
+    );
+
+    let mut response_processor = processor();
+    let (_context, buffer, program, queue) =
+        submission_objects(&mut response_processor, BufferUsage::PROGRAM_INPUT);
+    response_processor
+        .accelerator()
+        .submit_mode
+        .set(SubmitMode::Indeterminate);
+    let submit = submit_request(queue, program, buffer, 0, 8, AccessMode::Read);
+    let request_segments = [submit.as_slice()];
+    let source = SegmentedSource::new(&request_segments).unwrap();
+    let regions = [
+        ChainRegion::readable(submit.len() as u64),
+        ChainRegion::writable(24),
+    ];
+    let mut sink = FailingSink { len: 24 };
+
+    assert_eq!(
+        response_processor.process(&regions, &source, &mut sink),
+        Err(CommandProcessError::ResponseWrite(
+            ResponseWriteError::SinkAccess
+        ))
+    );
+    assert_eq!(response_processor.state().event_count(), 1);
+    assert_eq!(
+        response_processor
+            .state()
+            .buffer_record(buffer)
+            .unwrap()
+            .in_flight(),
+        1
+    );
+    assert_eq!(response_processor.health(), DeviceHealth::NeedsReset);
+}
+
+#[test]
+fn cancellation_is_not_forwarded_without_the_capability() {
+    let backend = RecordingBackend::default();
+    let mut info = backend.device_info().unwrap();
+    backend.device_info_calls.set(0);
+    info.capabilities.remove(Capabilities::EVENT_CANCELLATION);
+    backend.info_override.set(Some(info));
+    let mut processor =
+        CommandProcessor::new(backend, &config(), ObjectNamespace::new(1).unwrap()).unwrap();
+    let (_context, buffer, program, queue) =
+        submission_objects(&mut processor, BufferUsage::PROGRAM_INPUT);
+    let submit = submit_request(queue, program, buffer, 0, 8, AccessMode::Read);
+    let (_, response) = run(&mut processor, &submit, 24);
+    let event = event_id(&response);
+    let cancel = object_request(virtio_accel_proto::KnownOpcode::CancelEvent, event);
+
+    assert_eq!(
+        status(run(&mut processor, &cancel, 16).0),
+        StatusCode::UNSUPPORTED
+    );
+    assert_eq!(processor.accelerator().cancel_calls.get(), 0);
+    let poll = object_request(virtio_accel_proto::KnownOpcode::PollEvent, event);
+    let (outcome, response) = run(&mut processor, &poll, 24);
+    assert_eq!(status(outcome), StatusCode::OK);
+    assert_eq!(
+        event_state(&response).known_state().unwrap(),
+        KnownEventState::Pending
+    );
 }

--- a/crates/virtio-accel-mock/src/lib.rs
+++ b/crates/virtio-accel-mock/src/lib.rs
@@ -307,6 +307,9 @@ impl Accelerator for MockAccelerator {
             if binding.range.end() > binding.buffer.desc.bytes() {
                 return Err(SubmitFailure::Rejected(BackendError::OutOfBounds));
             }
+            if !binding.buffer.desc.allows_access(binding.access) {
+                return Err(SubmitFailure::Rejected(BackendError::PermissionDenied));
+            }
         }
         Ok(MockEvent {
             state: Arc::new(AtomicU8::new(EVENT_PENDING)),

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -154,6 +154,12 @@ validation of program-specific compatibility, native handle/address binding, and
 does not allocate per binding, assemble a second binding array with owned payloads, or copy tensor
 contents. Small command and metadata writes are not buffer staging and remain provider-specific.
 
+The command engine uses three bounded metadata allocations for `SUBMIT`: decoded bindings, retained
+buffer IDs, and borrowed native binding references. Duplicate-slot detection sorts the decoded
+allocation in place; event state takes ownership of the retained-ID allocation. No allocation owns
+buffer contents, boxes individual bindings, or survives event reclamation except the retained ID
+list required for exactly-once reference release.
+
 Issue #29 owns quantitative evidence: explicit-transfer bytes, staged bytes and allocations,
 submission allocations, retained memory, and host preparation versus device execution time. A
 backend should be diagnosable when it misses the intended path rather than requiring a profiler to

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -199,6 +199,10 @@ Binding slot numbers **MUST** be unique within a submission. A binding does not 
 of its buffer, but the device **MUST** retain the buffer until the resulting event is safely
 reclaimed.
 
+Read access requires a buffer declared for program input or mutable state. Write access requires a
+buffer declared for program output or mutable state. Read-write access requires mutable state.
+Binding-array order has no semantic meaning; the slot number identifies the program argument.
+
 ### 4.8 Submission
 
 A **submission** is an attempt to admit one program, execution queue, binding list, and relative
@@ -221,6 +225,10 @@ state is pending, complete, failed, or cancelled.
 
 An event **MUST** retain its execution queue, program, buffers, and per-invocation backend state until
 it is terminal and successfully destroyed. A pending event **MUST NOT** be destroyed.
+
+Terminal event states are stable. Cancellation and completion select exactly one terminal result:
+if cancellation wins, the cancellation command succeeds and polling reports cancelled; if
+completion wins, cancellation returns `BUSY` and polling reports the completed or failed result.
 
 ### 4.10 Request and response
 

--- a/docs/wire-abi.md
+++ b/docs/wire-abi.md
@@ -133,6 +133,10 @@ At least one usage bit **MUST** be set. Unknown bits produce `UNSUPPORTED`.
 
 All other values produce `INVALID_ARGUMENT`.
 
+`Read` requires `PROGRAM_INPUT` or `MUTABLE_STATE`, `Write` requires `PROGRAM_OUTPUT` or
+`MUTABLE_STATE`, and `Read and write` requires `MUTABLE_STATE`. A mismatch produces
+`PERMISSION_DENIED` before backend admission.
+
 ### 4.5 Event states
 
 | Value | State | `error` field |
@@ -286,7 +290,8 @@ with the mapped non-`OK` status when admission is indeterminate. A rejected subm
 error payload.
 
 `WireEventState` is eight bytes: `state: u16`, `error: u16`, and `reserved: u32`. Reserved bytes are
-zero and the state/error combinations are exactly those in section 4.5.
+zero and the state/error combinations are exactly those in section 4.5. Polling is nonblocking.
+Once a terminal state is observed, later successful polls return the same terminal state.
 
 ## 6. Status namespace
 


### PR DESCRIPTION
## Summary

- implement `SUBMIT`, `POLL_EVENT`, `CANCEL_EVENT`, and `DESTROY_EVENT`
- retain queue, program, and buffer leases across accepted and indeterminate submissions
- preserve rejected versus indeterminate admission and return stable event IDs
- make pending event destruction retryable and release terminal resources exactly once
- define buffer access compatibility and stable cancellation/completion race semantics
- reduce submission decoding to one in-place-sorted allocation with no payload copies

## Design

`DeviceState` remains single-owner and synchronization-free. Provider event handles decide
completion versus cancellation with their native atomic token; the command engine only serializes
guest-visible admission, ID publication, and reclamation.

The steady-state submission path uses three bounded metadata allocations: decoded bindings,
retained buffer IDs, and borrowed native binding references. Buffer contents are never copied or
boxed, and the retained-ID allocation moves directly into event state.

## Validation

- `cargo +stable fmt --all -- --check`
- `cargo +stable clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo +stable doc --workspace --all-features --no-deps`
- `cargo +stable test --workspace --all-targets --all-features`
- `cargo +stable test --workspace --doc --all-features`
- `cargo +stable check --workspace --release --all-features`
- `cargo +1.85.0 check --workspace --all-targets --all-features`
- `cargo +1.85.0 test --workspace --all-features`
- portable `no_std` check on `x86_64-unknown-none`
- `python3 ci/check-normative-requirements.py --check`
- `bash ci/check-portable-dependencies.sh`

Closes #15

Stacked on #41; review this PR against `codex/issue-14-command-engine`.
