### PR TITLE
Implement deterministic reset and recovery semantics

### DIFF
--- a/ci/check-normative-requirements.py
+++ b/ci/check-normative-requirements.py
@@ -274,6 +274,41 @@ COVERAGE: Final[dict[tuple[str, int], Coverage]] = {
     ),
 }
 
+RESET_ENGINE_COVERAGE: Final = coverage(
+    "executable",
+    (
+        "crates/virtio-accel-device/src/engine.rs",
+        "crates/virtio-accel-device/src/object_table.rs",
+        "crates/virtio-accel-device/tests/command_processor.rs",
+    ),
+    rationale="The reset engine and tests enforce bounded child-before-parent teardown, sticky backend discard, explicit quarantine accounting, and fresh object namespaces.",
+)
+RESET_TRANSPORT_COVERAGE: Final = coverage(
+    "mixed",
+    (
+        "crates/virtio-accel-device/src/engine.rs",
+        "crates/virtio-accel-device/tests/command_processor.rs",
+        "docs/virtqueue.md",
+    ),
+    ("#17", "#18"),
+    "The portable reset admission gate is executable; stopping queue fetch and publication requires the transport adapter and split-ring model.",
+)
+RESET_ENGINE_MARKERS: Final = (
+    "Teardown **MUST** be bounded",
+    "The device **MAY** reuse a backend instance",
+    "repeated reset attempts **MUST NOT** invoke that backend again",
+    "Successful reinitialization **MUST** use a fresh nonzero object namespace",
+)
+
+
+def requirement_coverage(source_code: str, number: int, statement: str) -> Coverage | None:
+    if source_code == "SPEC" and number == 4:
+        if statement.startswith("The transport **MUST** stop fetching command chains"):
+            return RESET_TRANSPORT_COVERAGE
+        if any(marker in statement for marker in RESET_ENGINE_MARKERS):
+            return RESET_ENGINE_COVERAGE
+    return COVERAGE.get((source_code, number))
+
 
 def section_number(heading: str) -> int:
     match = SECTION.match(heading)
@@ -311,7 +346,7 @@ def generate() -> dict[str, object]:
             if not matches:
                 continue
             number = section_number(heading)
-            assigned = COVERAGE.get((source_code, number))
+            assigned = requirement_coverage(source_code, number, statement)
             if assigned is None:
                 raise ValueError(
                     f"no coverage mapping for {relative_source}:{line_number} ({heading})"

--- a/conformance/v1.0/requirements.json
+++ b/conformance/v1.0/requirements.json
@@ -1,7 +1,7 @@
 {
   "schema": "virtio-accel-normative-requirements-1",
   "generated_by": "ci/check-normative-requirements.py",
-  "requirement_count": 126,
+  "requirement_count": 131,
   "requirements": [
     {
       "id": "REQ-SPEC-A29885B44214",
@@ -646,9 +646,102 @@
       }
     },
     {
-      "id": "REQ-SPEC-AEC4DC4C1559",
+      "id": "REQ-SPEC-272CA136CE9D",
       "source": "docs/specification.md",
-      "line": 252,
+      "line": 246,
+      "section": "4. Terminology and object model",
+      "keyword": "MUST",
+      "statement": "The transport **MUST** stop fetching command chains and publishing completions before portable",
+      "coverage": {
+        "status": "mixed",
+        "evidence": [
+          "crates/virtio-accel-device/src/engine.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
+          "docs/virtqueue.md"
+        ],
+        "issues": [
+          "#17",
+          "#18"
+        ],
+        "rationale": "The portable reset admission gate is executable; stopping queue fetch and publication requires the transport adapter and split-ring model."
+      }
+    },
+    {
+      "id": "REQ-SPEC-41456A985BB5",
+      "source": "docs/specification.md",
+      "line": 247,
+      "section": "4. Terminology and object model",
+      "keyword": "MUST",
+      "statement": "object teardown begins. Teardown **MUST** be bounded and child-before-parent: events precede their",
+      "coverage": {
+        "status": "executable",
+        "evidence": [
+          "crates/virtio-accel-device/src/engine.rs",
+          "crates/virtio-accel-device/src/object_table.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs"
+        ],
+        "issues": [],
+        "rationale": "The reset engine and tests enforce bounded child-before-parent teardown, sticky backend discard, explicit quarantine accounting, and fresh object namespaces."
+      }
+    },
+    {
+      "id": "REQ-SPEC-A063CFA84B1F",
+      "source": "docs/specification.md",
+      "line": 250,
+      "section": "4. Terminology and object model",
+      "keyword": "MAY",
+      "statement": "The device **MAY** reuse a backend instance only when every known resource is released",
+      "coverage": {
+        "status": "executable",
+        "evidence": [
+          "crates/virtio-accel-device/src/engine.rs",
+          "crates/virtio-accel-device/src/object_table.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs"
+        ],
+        "issues": [],
+        "rationale": "The reset engine and tests enforce bounded child-before-parent teardown, sticky backend discard, explicit quarantine accounting, and fresh object namespaces."
+      }
+    },
+    {
+      "id": "REQ-SPEC-397D57FDA629",
+      "source": "docs/specification.md",
+      "line": 253,
+      "section": "4. Terminology and object model",
+      "keyword": "MUST NOT",
+      "statement": "instance. Once discard is required, repeated reset attempts **MUST NOT** invoke that backend again.",
+      "coverage": {
+        "status": "executable",
+        "evidence": [
+          "crates/virtio-accel-device/src/engine.rs",
+          "crates/virtio-accel-device/src/object_table.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs"
+        ],
+        "issues": [],
+        "rationale": "The reset engine and tests enforce bounded child-before-parent teardown, sticky backend discard, explicit quarantine accounting, and fresh object namespaces."
+      }
+    },
+    {
+      "id": "REQ-SPEC-32D43F9A9F21",
+      "source": "docs/specification.md",
+      "line": 255,
+      "section": "4. Terminology and object model",
+      "keyword": "MUST",
+      "statement": "Successful reinitialization **MUST** use a fresh nonzero object namespace. No object ID created",
+      "coverage": {
+        "status": "executable",
+        "evidence": [
+          "crates/virtio-accel-device/src/engine.rs",
+          "crates/virtio-accel-device/src/object_table.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs"
+        ],
+        "issues": [],
+        "rationale": "The reset engine and tests enforce bounded child-before-parent teardown, sticky backend discard, explicit quarantine accounting, and fresh object namespaces."
+      }
+    },
+    {
+      "id": "REQ-SPEC-6D83CC8BDB22",
+      "source": "docs/specification.md",
+      "line": 262,
       "section": "5. Baseline capabilities and feature policy",
       "keyword": "MUST",
       "statement": "The portable v1 baseline **MUST** provide:",
@@ -666,9 +759,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-AFBF838B4F2D",
+      "id": "REQ-SPEC-E4E71AC72ACA",
       "source": "docs/specification.md",
-      "line": 267,
+      "line": 277,
       "section": "5. Baseline capabilities and feature policy",
       "keyword": "MUST",
       "statement": "advertise semantic event-cancellation capability, the device **MUST** return `UNSUPPORTED` without",
@@ -686,9 +779,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-86C7CC9E6BDB",
+      "id": "REQ-SPEC-D50B70E6702F",
       "source": "docs/specification.md",
-      "line": 276,
+      "line": 286,
       "section": "5. Baseline capabilities and feature policy",
       "keyword": "MUST NOT",
       "statement": "`TIMELINE_FENCES`, and `SECURE_CONTEXTS` reserve numeric positions only. A baseline device **MUST NOT**",
@@ -706,9 +799,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-0206502CFC72",
+      "id": "REQ-SPEC-4EB42592CD49",
       "source": "docs/specification.md",
-      "line": 277,
+      "line": 287,
       "section": "5. Baseline capabilities and feature policy",
       "keyword": "MUST NOT",
       "statement": "advertise them and a baseline driver **MUST NOT** accept them. Protocol 1.0 assigns no semantics to",
@@ -726,9 +819,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-7643E8E58065",
+      "id": "REQ-SPEC-295FDC8F1AFE",
       "source": "docs/specification.md",
-      "line": 280,
+      "line": 290,
       "section": "5. Baseline capabilities and feature policy",
       "keyword": "MUST NOT",
       "statement": "Unknown device-specific feature bits **MUST NOT** be accepted by a driver. A device **MUST NOT**",
@@ -746,9 +839,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-EE0B8056BD02",
+      "id": "REQ-SPEC-D360B56C13CD",
       "source": "docs/specification.md",
-      "line": 280,
+      "line": 290,
       "section": "5. Baseline capabilities and feature policy",
       "keyword": "MUST NOT",
       "statement": "Unknown device-specific feature bits **MUST NOT** be accepted by a driver. A device **MUST NOT**",
@@ -766,9 +859,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-F0DC58280363",
+      "id": "REQ-SPEC-BCB2C7BE23D5",
       "source": "docs/specification.md",
-      "line": 298,
+      "line": 308,
       "section": "5. Baseline capabilities and feature policy",
       "keyword": "MUST NOT",
       "statement": "ownership, synchronization, and isolation rules are specified. A protocol 1.0 device **MUST NOT**",
@@ -786,9 +879,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-A8A5BBCC23A0",
+      "id": "REQ-SPEC-C384FB585A75",
       "source": "docs/specification.md",
-      "line": 301,
+      "line": 311,
       "section": "5. Baseline capabilities and feature policy",
       "keyword": "MUST",
       "statement": "The device **MUST** reject an allocation for an unsupported memory domain before invoking the",
@@ -806,9 +899,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-C2EEBEA200DF",
+      "id": "REQ-SPEC-310DA03F3289",
       "source": "docs/specification.md",
-      "line": 307,
+      "line": 317,
       "section": "5. Baseline capabilities and feature policy",
       "keyword": "MUST",
       "statement": "new synchronization, or changed lifetime rules, the device **MUST** also negotiate an appropriate",
@@ -826,9 +919,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-013430EC73B8",
+      "id": "REQ-SPEC-88D1E0A07A40",
       "source": "docs/specification.md",
-      "line": 312,
+      "line": 322,
       "section": "5. Baseline capabilities and feature policy",
       "keyword": "MUST NOT",
       "statement": "implementation **MUST NOT** translate an underspecified capability into additional wire behavior.",
@@ -846,9 +939,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-AEC435BFF0AF",
+      "id": "REQ-SPEC-2B52FA3DDCAD",
       "source": "docs/specification.md",
-      "line": 317,
+      "line": 327,
       "section": "5. Baseline capabilities and feature policy",
       "keyword": "MUST",
       "statement": "reserved and **MUST** be zero.",
@@ -866,9 +959,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-6008D0C2488F",
+      "id": "REQ-SPEC-53CBDDF2F9E6",
       "source": "docs/specification.md",
-      "line": 320,
+      "line": 330,
       "section": "5. Baseline capabilities and feature policy",
       "keyword": "MUST",
       "statement": "**MUST** be rejected before backend invocation. Reserved fields **MUST** be zero.",
@@ -886,9 +979,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-AD1B44BE1427",
+      "id": "REQ-SPEC-5B0DC6A13B5B",
       "source": "docs/specification.md",
-      "line": 320,
+      "line": 330,
       "section": "5. Baseline capabilities and feature policy",
       "keyword": "MUST",
       "statement": "**MUST** be rejected before backend invocation. Reserved fields **MUST** be zero.",
@@ -906,9 +999,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-75AB5333C8C4",
+      "id": "REQ-SPEC-C15BB0E55C0A",
       "source": "docs/specification.md",
-      "line": 327,
+      "line": 337,
       "section": "6. Versioning and compatibility",
       "keyword": "MUST",
       "statement": "Candidate implementations **MUST** expose major `1` and minor `0` in device-specific configuration",
@@ -927,9 +1020,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-20BBDCCEEC92",
+      "id": "REQ-SPEC-200066C129F2",
       "source": "docs/specification.md",
-      "line": 328,
+      "line": 338,
       "section": "6. Versioning and compatibility",
       "keyword": "MUST NOT",
       "statement": "and **MUST NOT** claim candidate protocol 1.0 conformance unless they satisfy the normative wire,",
@@ -948,9 +1041,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-5348BBC0D8FD",
+      "id": "REQ-SPEC-14CBA0A183EB",
       "source": "docs/specification.md",
-      "line": 332,
+      "line": 342,
       "section": "6. Versioning and compatibility",
       "keyword": "MUST",
       "statement": "#33. Before that audit, an intentional candidate revision **MUST** follow the coordinated procedure",
@@ -969,9 +1062,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-6121F6E1EB77",
+      "id": "REQ-SPEC-5ECE338A6907",
       "source": "docs/specification.md",
-      "line": 333,
+      "line": 343,
       "section": "6. Versioning and compatibility",
       "keyword": "MUST NOT",
       "statement": "in [wire-abi.md](wire-abi.md) and **MUST NOT** be described as a frozen or stable release.",
@@ -990,9 +1083,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-72DE383CDBC0",
+      "id": "REQ-SPEC-95AD226E6215",
       "source": "docs/specification.md",
-      "line": 339,
+      "line": 349,
       "section": "6. Versioning and compatibility",
       "keyword": "MUST",
       "statement": "- a driver **MUST** reject a device with an unsupported major version;",
@@ -1011,9 +1104,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-3803DA96468A",
+      "id": "REQ-SPEC-B767A7B1C839",
       "source": "docs/specification.md",
-      "line": 341,
+      "line": 351,
       "section": "6. Versioning and compatibility",
       "keyword": "MUST NOT",
       "statement": "- a driver **MUST NOT** use behavior newer than the device minor version it observed; and",
@@ -1032,9 +1125,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-6E4D852251B8",
+      "id": "REQ-SPEC-AE218946BDCC",
       "source": "docs/specification.md",
-      "line": 350,
+      "line": 360,
       "section": "6. Versioning and compatibility",
       "keyword": "MUST NOT",
       "statement": "Therefore a minor version alone **MUST NOT** append fields to an existing response that an older",
@@ -1053,9 +1146,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-756F68A7AAFD",
+      "id": "REQ-SPEC-016999BA61E1",
       "source": "docs/specification.md",
-      "line": 354,
+      "line": 364,
       "section": "6. Versioning and compatibility",
       "keyword": "SHOULD",
       "statement": "negotiated feature explicitly selects a different layout. Extensions **SHOULD** use a new opcode or",
@@ -1074,9 +1167,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-D0F8BB882F40",
+      "id": "REQ-SPEC-1C37D20890C7",
       "source": "docs/specification.md",
-      "line": 357,
+      "line": 367,
       "section": "6. Versioning and compatibility",
       "keyword": "MUST",
       "statement": "Without such a feature, a receiver **MUST** require the exact payload length for the opcode and",
@@ -1095,9 +1188,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-B8E6FB0D7274",
+      "id": "REQ-SPEC-7EA21D16DE58",
       "source": "docs/specification.md",
-      "line": 358,
+      "line": 368,
       "section": "6. Versioning and compatibility",
       "keyword": "MUST",
       "statement": "**MUST** reject trailing bytes. It **MUST NOT** silently reinterpret or ignore an unknown tail.",
@@ -1116,9 +1209,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-9EC4D79F120D",
+      "id": "REQ-SPEC-E3E8676ED37E",
       "source": "docs/specification.md",
-      "line": 358,
+      "line": 368,
       "section": "6. Versioning and compatibility",
       "keyword": "MUST NOT",
       "statement": "**MUST** reject trailing bytes. It **MUST NOT** silently reinterpret or ignore an unknown tail.",
@@ -1137,9 +1230,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-E44726AD481F",
+      "id": "REQ-SPEC-A2CB96B8A1C3",
       "source": "docs/specification.md",
-      "line": 365,
+      "line": 375,
       "section": "6. Versioning and compatibility",
       "keyword": "MUST NOT",
       "statement": "- An unknown response status is an opaque failure. A driver **MUST NOT** treat it as success or",
@@ -1158,9 +1251,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-FC0B92A06782",
+      "id": "REQ-SPEC-D3C51FC19E65",
       "source": "docs/specification.md",
-      "line": 372,
+      "line": 382,
       "section": "7. Ownership and destruction",
       "keyword": "MUST",
       "statement": "The device owns the mapping from opaque object IDs to backend handles. The mapping **MUST** reject:",
@@ -1179,9 +1272,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-56593F42BA6E",
+      "id": "REQ-SPEC-1A8E3B4C24C2",
       "source": "docs/specification.md",
-      "line": 380,
+      "line": 390,
       "section": "7. Ownership and destruction",
       "keyword": "MUST NOT",
       "statement": "Object-ID encoding is implementation-private. Drivers **MUST NOT** infer slot, kind, generation, or",
@@ -1200,9 +1293,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-231C9BFD9771",
+      "id": "REQ-SPEC-AB23FAC11CFD",
       "source": "docs/specification.md",
-      "line": 385,
+      "line": 395,
       "section": "7. Ownership and destruction",
       "keyword": "MUST",
       "statement": "- a rejected release returns the still-live handle and the device **MUST** restore it for retry;",
@@ -1221,9 +1314,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-D59392AFA174",
+      "id": "REQ-SPEC-C2F6D1492668",
       "source": "docs/specification.md",
-      "line": 387,
+      "line": 397,
       "section": "7. Ownership and destruction",
       "keyword": "MUST NOT",
       "statement": "- an indeterminate release invalidates the guest ID and requires recovery. The device **MUST NOT**",
@@ -1242,9 +1335,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-0198899B57F8",
+      "id": "REQ-SPEC-00E07DBCC21D",
       "source": "docs/specification.md",
-      "line": 390,
+      "line": 400,
       "section": "7. Ownership and destruction",
       "keyword": "MUST NOT",
       "statement": "`Drop` may provide defensive cleanup inside an implementation but **MUST NOT** be used as",
@@ -1263,9 +1356,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-B35C802C4CE1",
+      "id": "REQ-SPEC-4FCCE03626EA",
       "source": "docs/specification.md",
-      "line": 396,
+      "line": 406,
       "section": "8. Time and progress",
       "keyword": "MUST NOT",
       "statement": "infinite. Absolute guest timestamps **MUST NOT** be compared with a host clock because their",
@@ -1282,9 +1375,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-A3E630EEB53C",
+      "id": "REQ-SPEC-32BEB66EDC72",
       "source": "docs/specification.md",
-      "line": 399,
+      "line": 409,
       "section": "8. Time and progress",
       "keyword": "MUST",
       "statement": "Polling an event **MUST** be nonblocking and bounded. The portable contract creates no background",
@@ -1301,9 +1394,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-9A070026FAAE",
+      "id": "REQ-SPEC-87204B0486BE",
       "source": "docs/specification.md",
-      "line": 403,
+      "line": 413,
       "section": "8. Time and progress",
       "keyword": "MUST",
       "statement": "cannot prove rejection is indeterminate and **MUST** retain an event.",
@@ -1320,9 +1413,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-B87D11017952",
+      "id": "REQ-SPEC-FF88F37F2002",
       "source": "docs/specification.md",
-      "line": 412,
+      "line": 422,
       "section": "9. Errors",
       "keyword": "MUST",
       "statement": "A device **MUST** map errors deterministically and **MUST NOT** expose uninitialized response bytes.",
@@ -1340,9 +1433,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-9DA3CA594109",
+      "id": "REQ-SPEC-9BF9C2113FC0",
       "source": "docs/specification.md",
-      "line": 412,
+      "line": 422,
       "section": "9. Errors",
       "keyword": "MUST NOT",
       "statement": "A device **MUST** map errors deterministically and **MUST NOT** expose uninitialized response bytes.",
@@ -1360,9 +1453,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-549D7EA018D8",
+      "id": "REQ-SPEC-5B13C15F8588",
       "source": "docs/specification.md",
-      "line": 416,
+      "line": 426,
       "section": "9. Errors",
       "keyword": "MUST NOT",
       "statement": "An error response **MUST NOT** imply that a backend operation was rejected when acceptance was",
@@ -1380,9 +1473,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-C38079758E77",
+      "id": "REQ-SPEC-992422D1DC7C",
       "source": "docs/specification.md",
-      "line": 421,
+      "line": 431,
       "section": "10. Portability requirements",
       "keyword": "MUST NOT",
       "statement": "Portable crates **MUST NOT** select an operating system, VMM, kernel, vendor API, or global runtime.",
@@ -1398,9 +1491,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-15A354D61BD7",
+      "id": "REQ-SPEC-A6D1EA8B8FFD",
       "source": "docs/specification.md",
-      "line": 428,
+      "line": 438,
       "section": "10. Portability requirements",
       "keyword": "MUST NOT",
       "statement": "Platform adapters depend inward on the portable layers. A portable layer **MUST NOT** conditionally",
@@ -1416,9 +1509,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-0E2CA4544542",
+      "id": "REQ-SPEC-ABF529AA1C73",
       "source": "docs/specification.md",
-      "line": 444,
+      "line": 454,
       "section": "11. Tracked completion work",
       "keyword": "MAY",
       "statement": "No implementation **MAY** advertise a reserved optional feature merely because a Rust constant",
@@ -2403,9 +2496,9 @@
       }
     },
     {
-      "id": "REQ-VIRTQ-323D67240916",
+      "id": "REQ-VIRTQ-0846530CF878",
       "source": "docs/virtqueue.md",
-      "line": 201,
+      "line": 207,
       "section": "11. Device reset and split-ring disposition",
       "keyword": "MUST NOT",
       "statement": "the base Virtio reset rule. It **MUST NOT** expect response bytes or used entries for those chains.",
@@ -2423,9 +2516,9 @@
       }
     },
     {
-      "id": "REQ-VIRTQ-FF01B37600D9",
+      "id": "REQ-VIRTQ-4738D0B93331",
       "source": "docs/virtqueue.md",
-      "line": 219,
+      "line": 225,
       "section": "12. `DEVICE_NEEDS_RESET`",
       "keyword": "SHOULD",
       "statement": "After observing `DEVICE_NEEDS_RESET`, the driver **SHOULD** stop submitting commands and perform",
@@ -2442,9 +2535,9 @@
       }
     },
     {
-      "id": "REQ-VIRTQ-718233B6C44C",
+      "id": "REQ-VIRTQ-7267CD2CC117",
       "source": "docs/virtqueue.md",
-      "line": 221,
+      "line": 227,
       "section": "12. `DEVICE_NEEDS_RESET`",
       "keyword": "MUST NOT",
       "statement": "but it **MUST NOT** accept new semantic work.",

--- a/crates/virtio-accel-device/src/engine.rs
+++ b/crates/virtio-accel-device/src/engine.rs
@@ -20,7 +20,7 @@ use zerocopy::IntoBytes;
 use crate::{
     BufferRecord, ChainRegion, CreateError, DecodedBinding, DecodedRequest, DecodedRequestBody,
     DecoderLimits, DecoderLimitsError, DeviceState, DeviceStateConfigError, DeviceStateError,
-    FrameDecoder, FramePreflight, FramePreflightError, ObjectId, ObjectNamespace,
+    FrameDecoder, FramePreflight, FramePreflightError, ObjectId, ObjectNamespace, ResourceCounts,
     ResponseWriteError, ResponseWriter, UnusableFrame, preflight_command_frame,
     status_from_backend_error, status_from_device_state_error,
 };
@@ -37,6 +37,26 @@ pub type AcceleratorState<A> = DeviceState<
 pub enum DeviceHealth {
     Running,
     NeedsReset,
+    BackendDiscardRequired,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ResetDisposition {
+    BackendReusable,
+    BackendDiscardRequired,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ResetReport {
+    pub disposition: ResetDisposition,
+    pub released: ResourceCounts,
+    pub quarantined: ResourceCounts,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ResetError {
+    NamespaceReuse,
+    State(DeviceStateConfigError),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -76,11 +96,13 @@ enum SubmitCreateError {
 /// for decoding, validation, and discovery responses. This prevents limits from changing beneath
 /// live object state and removes a backend call from the discovery path.
 pub struct CommandProcessor<A: Accelerator> {
+    state: AcceleratorState<A>,
     accelerator: A,
     info: DeviceInfo,
     decoder: FrameDecoder,
-    state: AcceleratorState<A>,
     health: DeviceHealth,
+    quarantined: ResourceCounts,
+    last_reset: Option<ResetReport>,
 }
 
 impl<A: Accelerator> core::fmt::Debug for CommandProcessor<A> {
@@ -111,11 +133,13 @@ impl<A: Accelerator> CommandProcessor<A> {
         let state =
             DeviceState::new(namespace, info.limits).map_err(CommandProcessorInitError::State)?;
         Ok(Self {
+            state,
             accelerator,
             info,
             decoder: FrameDecoder::new(limits),
-            state,
             health: DeviceHealth::Running,
+            quarantined: ResourceCounts::default(),
+            last_reset: None,
         })
     }
 
@@ -137,6 +161,72 @@ impl<A: Accelerator> CommandProcessor<A> {
 
     pub const fn state(&self) -> &AcceleratorState<A> {
         &self.state
+    }
+
+    /// Perform one bounded, child-before-parent reset pass.
+    ///
+    /// The transport must stop fetching command chains and stop publishing completions before
+    /// calling this method. A reusable result renews every object table with `namespace`; every
+    /// prior ID is then stale. A discard-required result is sticky and makes no backend calls on
+    /// later reset attempts. The caller must discard the complete processor/backend instance.
+    pub fn reset(&mut self, namespace: ObjectNamespace) -> Result<ResetReport, ResetError> {
+        if self.health == DeviceHealth::BackendDiscardRequired {
+            let report = match self.last_reset {
+                Some(report) => report,
+                None => {
+                    let report = self.discard_report(ResourceCounts::default());
+                    self.last_reset = Some(report);
+                    report
+                }
+            };
+            return Ok(report);
+        }
+        if namespace == self.state.namespace() {
+            return Err(ResetError::NamespaceReuse);
+        }
+
+        self.health = DeviceHealth::NeedsReset;
+        self.last_reset = None;
+        let mut released = ResourceCounts::default();
+        let mut progress = ResetProgress::default();
+
+        self.reset_events(&mut released, &mut progress);
+        if progress.backend_callable {
+            self.reset_queues(&mut released, &mut progress);
+        }
+        if progress.backend_callable {
+            self.reset_programs(&mut released, &mut progress);
+        }
+        if progress.backend_callable {
+            self.reset_buffers(&mut released, &mut progress);
+        }
+        if progress.backend_callable {
+            self.reset_contexts(&mut released, &mut progress);
+        }
+
+        let remaining = self.state.resource_counts();
+        let quarantined = self.quarantined.saturating_add(remaining);
+        if progress.backend_reusable && self.state.is_empty() && quarantined.is_empty() {
+            self.state =
+                DeviceState::new(namespace, self.info.limits).map_err(ResetError::State)?;
+            self.health = DeviceHealth::Running;
+            let report = ResetReport {
+                disposition: ResetDisposition::BackendReusable,
+                released,
+                quarantined,
+            };
+            self.last_reset = None;
+            return Ok(report);
+        }
+
+        self.health = DeviceHealth::BackendDiscardRequired;
+        let report = ResetReport {
+            disposition: ResetDisposition::BackendDiscardRequired,
+            released,
+            quarantined,
+        };
+        self.last_reset = Some(report);
+        Ok(report)
     }
 
     /// Process one complete flattened command chain.
@@ -164,7 +254,7 @@ impl<A: Accelerator> CommandProcessor<A> {
             }),
             FramePreflight::Unusable(error) => Ok(CommandOutcome::Unusable(error)),
             FramePreflight::Ready(request) => {
-                if self.health == DeviceHealth::NeedsReset {
+                if self.health != DeviceHealth::Running {
                     return self.respond_empty(
                         response,
                         StatusCode::DEVICE_LOST,
@@ -172,6 +262,7 @@ impl<A: Accelerator> CommandProcessor<A> {
                         false,
                     );
                 }
+                self.last_reset = None;
                 self.dispatch(request, response)
             }
         }
@@ -313,6 +404,7 @@ impl<A: Accelerator> CommandProcessor<A> {
 
         let accelerator = &self.accelerator;
         let mut admission_status = StatusCode::OK;
+        let mut admission_requires_discard = false;
         let result = self
             .state
             .create_event_with(queue_id, program_id, buffer_ids, |resources| {
@@ -348,6 +440,7 @@ impl<A: Accelerator> CommandProcessor<A> {
                     Err(SubmitFailure::Rejected(error)) => Err(SubmitCreateError::Rejected(error)),
                     Err(SubmitFailure::Indeterminate { error, event }) => {
                         admission_status = status_from_backend_error(error);
+                        admission_requires_discard = error == BackendError::DeviceLost;
                         Ok(event)
                     }
                 }
@@ -355,6 +448,9 @@ impl<A: Accelerator> CommandProcessor<A> {
 
         match result {
             Ok(event_id) => {
+                if admission_requires_discard {
+                    self.require_backend_discard();
+                }
                 self.respond_event_id(response, admission_status, request_id, event_id, true)
             }
             Err(CreateError::State(error)) => self.respond_state_error(response, request_id, error),
@@ -368,7 +464,306 @@ impl<A: Accelerator> CommandProcessor<A> {
                 self.respond_empty(response, status, request_id, false)
             }
             Err(CreateError::Provider(SubmitCreateError::State(_))) => {
-                self.recovery_response(response, request_id)
+                self.discard_response(response, request_id)
+            }
+        }
+    }
+
+    fn reset_events(&mut self, released: &mut ResourceCounts, progress: &mut ResetProgress) {
+        let mut cursor = 0;
+        while let Some((next, id)) = self.state.next_event_id(cursor) {
+            cursor = next;
+            if !progress.backend_callable {
+                break;
+            }
+            self.reset_event(id, released, progress);
+        }
+    }
+
+    fn reset_event(
+        &mut self,
+        id: ObjectId,
+        released: &mut ResourceCounts,
+        progress: &mut ResetProgress,
+    ) {
+        let mut event_state = {
+            let event = match self
+                .state
+                .event_record(id)
+                .and_then(|record| record.resource())
+            {
+                Ok(event) => event,
+                Err(_) => {
+                    progress.backend_reusable = false;
+                    return;
+                }
+            };
+            match self.accelerator.poll_event(event) {
+                Ok(state) => state,
+                Err(error) => {
+                    progress.backend_reusable = false;
+                    if error == BackendError::DeviceLost {
+                        progress.backend_callable = false;
+                    }
+                    return;
+                }
+            }
+        };
+
+        if event_state == EventState::Pending {
+            if !self
+                .info
+                .capabilities
+                .contains(Capabilities::EVENT_CANCELLATION)
+            {
+                progress.backend_reusable = false;
+                return;
+            }
+            let cancel_result = {
+                let event = match self
+                    .state
+                    .event_record(id)
+                    .and_then(|record| record.resource())
+                {
+                    Ok(event) => event,
+                    Err(_) => {
+                        progress.backend_reusable = false;
+                        return;
+                    }
+                };
+                self.accelerator.cancel_event(event)
+            };
+            match cancel_result {
+                Ok(()) => event_state = EventState::Cancelled,
+                Err(BackendError::Busy) => {
+                    let event = match self
+                        .state
+                        .event_record(id)
+                        .and_then(|record| record.resource())
+                    {
+                        Ok(event) => event,
+                        Err(_) => {
+                            progress.backend_reusable = false;
+                            return;
+                        }
+                    };
+                    match self.accelerator.poll_event(event) {
+                        Ok(state) => event_state = state,
+                        Err(error) => {
+                            progress.backend_reusable = false;
+                            if error == BackendError::DeviceLost {
+                                progress.backend_callable = false;
+                            }
+                            return;
+                        }
+                    }
+                }
+                Err(error) => {
+                    progress.backend_reusable = false;
+                    if error == BackendError::DeviceLost {
+                        progress.backend_callable = false;
+                    }
+                    return;
+                }
+            }
+        }
+
+        match event_state {
+            EventState::Pending => {
+                progress.backend_reusable = false;
+                return;
+            }
+            EventState::Failed(BackendError::DeviceLost) => {
+                progress.backend_reusable = false;
+                progress.backend_callable = false;
+                return;
+            }
+            EventState::Complete | EventState::Failed(_) | EventState::Cancelled => {}
+        }
+
+        let event = match self.state.begin_event_release(id) {
+            Ok(event) => event,
+            Err(_) => {
+                progress.backend_reusable = false;
+                return;
+            }
+        };
+        match self.accelerator.destroy_event(event) {
+            Ok(()) => match self.state.commit_event_release(id) {
+                Ok(()) => released.events += 1,
+                Err(_) => {
+                    progress.backend_reusable = false;
+                    progress.backend_callable = false;
+                }
+            },
+            Err(ReleaseFailure::Rejected { error, resource }) => {
+                progress.backend_reusable = false;
+                if error == BackendError::DeviceLost {
+                    progress.backend_callable = false;
+                }
+                if self.state.restore_event_release(id, resource).is_err() {
+                    progress.backend_callable = false;
+                }
+            }
+            Err(ReleaseFailure::Indeterminate { .. }) => {
+                progress.backend_reusable = false;
+                progress.backend_callable = false;
+            }
+        }
+    }
+
+    fn reset_queues(&mut self, released: &mut ResourceCounts, progress: &mut ResetProgress) {
+        let mut cursor = 0;
+        while let Some((next, id)) = self.state.next_queue_id(cursor) {
+            cursor = next;
+            let queue = match self.state.begin_queue_release(id) {
+                Ok(queue) => queue,
+                Err(_) => {
+                    progress.backend_reusable = false;
+                    continue;
+                }
+            };
+            match self.accelerator.destroy_queue(queue) {
+                Ok(()) => match self.state.commit_queue_release(id) {
+                    Ok(()) => released.queues += 1,
+                    Err(_) => {
+                        progress.backend_reusable = false;
+                        progress.backend_callable = false;
+                        break;
+                    }
+                },
+                Err(ReleaseFailure::Rejected { error, resource }) => {
+                    progress.backend_reusable = false;
+                    if error == BackendError::DeviceLost {
+                        progress.backend_callable = false;
+                    }
+                    if self.state.restore_queue_release(id, resource).is_err() {
+                        progress.backend_callable = false;
+                        break;
+                    }
+                }
+                Err(ReleaseFailure::Indeterminate { .. }) => {
+                    progress.backend_reusable = false;
+                    progress.backend_callable = false;
+                    break;
+                }
+            }
+        }
+    }
+
+    fn reset_programs(&mut self, released: &mut ResourceCounts, progress: &mut ResetProgress) {
+        let mut cursor = 0;
+        while let Some((next, id)) = self.state.next_program_id(cursor) {
+            cursor = next;
+            let program = match self.state.begin_program_release(id) {
+                Ok(program) => program,
+                Err(_) => {
+                    progress.backend_reusable = false;
+                    continue;
+                }
+            };
+            match self.accelerator.unload_program(program) {
+                Ok(()) => match self.state.commit_program_release(id) {
+                    Ok(()) => released.programs += 1,
+                    Err(_) => {
+                        progress.backend_reusable = false;
+                        progress.backend_callable = false;
+                        break;
+                    }
+                },
+                Err(ReleaseFailure::Rejected { error, resource }) => {
+                    progress.backend_reusable = false;
+                    if error == BackendError::DeviceLost {
+                        progress.backend_callable = false;
+                    }
+                    if self.state.restore_program_release(id, resource).is_err() {
+                        progress.backend_callable = false;
+                        break;
+                    }
+                }
+                Err(ReleaseFailure::Indeterminate { .. }) => {
+                    progress.backend_reusable = false;
+                    progress.backend_callable = false;
+                    break;
+                }
+            }
+        }
+    }
+
+    fn reset_buffers(&mut self, released: &mut ResourceCounts, progress: &mut ResetProgress) {
+        let mut cursor = 0;
+        while let Some((next, id)) = self.state.next_buffer_id(cursor) {
+            cursor = next;
+            let buffer = match self.state.begin_buffer_release(id) {
+                Ok(buffer) => buffer,
+                Err(_) => {
+                    progress.backend_reusable = false;
+                    continue;
+                }
+            };
+            match self.accelerator.free_buffer(buffer) {
+                Ok(()) => match self.state.commit_buffer_release(id) {
+                    Ok(()) => released.buffers += 1,
+                    Err(_) => {
+                        progress.backend_reusable = false;
+                        progress.backend_callable = false;
+                        break;
+                    }
+                },
+                Err(ReleaseFailure::Rejected { error, resource }) => {
+                    progress.backend_reusable = false;
+                    if error == BackendError::DeviceLost {
+                        progress.backend_callable = false;
+                    }
+                    if self.state.restore_buffer_release(id, resource).is_err() {
+                        progress.backend_callable = false;
+                        break;
+                    }
+                }
+                Err(ReleaseFailure::Indeterminate { .. }) => {
+                    progress.backend_reusable = false;
+                    progress.backend_callable = false;
+                    break;
+                }
+            }
+        }
+    }
+
+    fn reset_contexts(&mut self, released: &mut ResourceCounts, progress: &mut ResetProgress) {
+        let mut cursor = 0;
+        while let Some((next, id)) = self.state.next_context_id(cursor) {
+            cursor = next;
+            let context = match self.state.begin_context_release(id) {
+                Ok(context) => context,
+                Err(_) => {
+                    progress.backend_reusable = false;
+                    continue;
+                }
+            };
+            match self.accelerator.destroy_context(context) {
+                Ok(()) => match self.state.commit_context_release(id) {
+                    Ok(()) => released.contexts += 1,
+                    Err(_) => {
+                        progress.backend_reusable = false;
+                        progress.backend_callable = false;
+                        break;
+                    }
+                },
+                Err(ReleaseFailure::Rejected { error, resource }) => {
+                    progress.backend_reusable = false;
+                    if error == BackendError::DeviceLost {
+                        progress.backend_callable = false;
+                    }
+                    if self.state.restore_context_release(id, resource).is_err() {
+                        progress.backend_callable = false;
+                        break;
+                    }
+                }
+                Err(ReleaseFailure::Indeterminate { .. }) => {
+                    progress.backend_reusable = false;
+                    progress.backend_callable = false;
+                    break;
+                }
             }
         }
     }
@@ -388,6 +783,9 @@ impl<A: Accelerator> CommandProcessor<A> {
         };
         match self.accelerator.poll_event(event) {
             Ok(state) => {
+                if state == EventState::Failed(BackendError::DeviceLost) {
+                    self.require_backend_discard();
+                }
                 let payload = wire_event_state(state);
                 self.respond_bytes(
                     response,
@@ -447,6 +845,10 @@ impl<A: Accelerator> CommandProcessor<A> {
             Ok(EventState::Pending) => {
                 return self.respond_empty(response, StatusCode::BUSY, request_id, false);
             }
+            Ok(EventState::Failed(BackendError::DeviceLost)) => {
+                self.require_backend_discard();
+                return self.respond_empty(response, StatusCode::DEVICE_LOST, request_id, false);
+            }
             Ok(EventState::Complete | EventState::Failed(_) | EventState::Cancelled) => {}
             Err(error) => {
                 return self.respond_backend_error(response, request_id, error, false);
@@ -460,17 +862,19 @@ impl<A: Accelerator> CommandProcessor<A> {
         match self.accelerator.destroy_event(event) {
             Ok(()) => match self.state.commit_event_release(event_id) {
                 Ok(()) => self.respond_empty(response, StatusCode::OK, request_id, true),
-                Err(_) => self.recovery_response(response, request_id),
+                Err(_) => self.discard_response(response, request_id),
             },
             Err(ReleaseFailure::Rejected { error, resource }) => {
                 match self.state.restore_event_release(event_id, resource) {
                     Ok(()) => self.respond_backend_error(response, request_id, error, false),
-                    Err(_) => self.recovery_response(response, request_id),
+                    Err(_) => self.discard_response(response, request_id),
                 }
             }
             Err(ReleaseFailure::Indeterminate { .. }) => {
-                let _ = self.state.commit_event_release(event_id);
-                self.recovery_response(response, request_id)
+                if self.state.commit_event_release(event_id).is_ok() {
+                    self.quarantined.events += 1;
+                }
+                self.discard_response(response, request_id)
             }
         }
     }
@@ -566,17 +970,19 @@ impl<A: Accelerator> CommandProcessor<A> {
         match self.accelerator.destroy_context(resource) {
             Ok(()) => match self.state.commit_context_release(id) {
                 Ok(()) => self.respond_empty(response, StatusCode::OK, request_id, true),
-                Err(_) => self.recovery_response(response, request_id),
+                Err(_) => self.discard_response(response, request_id),
             },
             Err(ReleaseFailure::Rejected { error, resource }) => {
                 match self.state.restore_context_release(id, resource) {
                     Ok(()) => self.respond_backend_error(response, request_id, error, false),
-                    Err(_) => self.recovery_response(response, request_id),
+                    Err(_) => self.discard_response(response, request_id),
                 }
             }
             Err(ReleaseFailure::Indeterminate { .. }) => {
-                let _ = self.state.commit_context_release(id);
-                self.recovery_response(response, request_id)
+                if self.state.commit_context_release(id).is_ok() {
+                    self.quarantined.contexts += 1;
+                }
+                self.discard_response(response, request_id)
             }
         }
     }
@@ -594,17 +1000,19 @@ impl<A: Accelerator> CommandProcessor<A> {
         match self.accelerator.free_buffer(resource) {
             Ok(()) => match self.state.commit_buffer_release(id) {
                 Ok(()) => self.respond_empty(response, StatusCode::OK, request_id, true),
-                Err(_) => self.recovery_response(response, request_id),
+                Err(_) => self.discard_response(response, request_id),
             },
             Err(ReleaseFailure::Rejected { error, resource }) => {
                 match self.state.restore_buffer_release(id, resource) {
                     Ok(()) => self.respond_backend_error(response, request_id, error, false),
-                    Err(_) => self.recovery_response(response, request_id),
+                    Err(_) => self.discard_response(response, request_id),
                 }
             }
             Err(ReleaseFailure::Indeterminate { .. }) => {
-                let _ = self.state.commit_buffer_release(id);
-                self.recovery_response(response, request_id)
+                if self.state.commit_buffer_release(id).is_ok() {
+                    self.quarantined.buffers += 1;
+                }
+                self.discard_response(response, request_id)
             }
         }
     }
@@ -622,17 +1030,19 @@ impl<A: Accelerator> CommandProcessor<A> {
         match self.accelerator.unload_program(resource) {
             Ok(()) => match self.state.commit_program_release(id) {
                 Ok(()) => self.respond_empty(response, StatusCode::OK, request_id, true),
-                Err(_) => self.recovery_response(response, request_id),
+                Err(_) => self.discard_response(response, request_id),
             },
             Err(ReleaseFailure::Rejected { error, resource }) => {
                 match self.state.restore_program_release(id, resource) {
                     Ok(()) => self.respond_backend_error(response, request_id, error, false),
-                    Err(_) => self.recovery_response(response, request_id),
+                    Err(_) => self.discard_response(response, request_id),
                 }
             }
             Err(ReleaseFailure::Indeterminate { .. }) => {
-                let _ = self.state.commit_program_release(id);
-                self.recovery_response(response, request_id)
+                if self.state.commit_program_release(id).is_ok() {
+                    self.quarantined.programs += 1;
+                }
+                self.discard_response(response, request_id)
             }
         }
     }
@@ -650,17 +1060,19 @@ impl<A: Accelerator> CommandProcessor<A> {
         match self.accelerator.destroy_queue(resource) {
             Ok(()) => match self.state.commit_queue_release(id) {
                 Ok(()) => self.respond_empty(response, StatusCode::OK, request_id, true),
-                Err(_) => self.recovery_response(response, request_id),
+                Err(_) => self.discard_response(response, request_id),
             },
             Err(ReleaseFailure::Rejected { error, resource }) => {
                 match self.state.restore_queue_release(id, resource) {
                     Ok(()) => self.respond_backend_error(response, request_id, error, false),
-                    Err(_) => self.recovery_response(response, request_id),
+                    Err(_) => self.discard_response(response, request_id),
                 }
             }
             Err(ReleaseFailure::Indeterminate { .. }) => {
-                let _ = self.state.commit_queue_release(id);
-                self.recovery_response(response, request_id)
+                if self.state.commit_queue_release(id).is_ok() {
+                    self.quarantined.queues += 1;
+                }
+                self.discard_response(response, request_id)
             }
         }
     }
@@ -706,18 +1118,33 @@ impl<A: Accelerator> CommandProcessor<A> {
 
     fn backend_status(&mut self, error: BackendError) -> StatusCode {
         if error == BackendError::DeviceLost {
-            self.health = DeviceHealth::NeedsReset;
+            self.require_backend_discard();
         }
         status_from_backend_error(error)
     }
 
-    fn recovery_response(
+    fn require_backend_discard(&mut self) {
+        self.health = DeviceHealth::BackendDiscardRequired;
+        self.last_reset = None;
+    }
+
+    fn discard_response(
         &mut self,
         response: &mut dyn ByteSink,
         request_id: u64,
     ) -> Result<CommandOutcome, CommandProcessError> {
-        self.health = DeviceHealth::NeedsReset;
+        self.require_backend_discard();
         self.respond_empty(response, StatusCode::DEVICE_LOST, request_id, true)
+    }
+
+    fn discard_report(&self, released: ResourceCounts) -> ResetReport {
+        ResetReport {
+            disposition: ResetDisposition::BackendDiscardRequired,
+            released,
+            quarantined: self
+                .quarantined
+                .saturating_add(self.state.resource_counts()),
+        }
     }
 
     fn respond_object(
@@ -801,11 +1228,27 @@ impl<A: Accelerator> CommandProcessor<A> {
                 used,
             }),
             Err(error) => {
-                if mutated {
+                if mutated && self.health == DeviceHealth::Running {
                     self.health = DeviceHealth::NeedsReset;
+                    self.last_reset = None;
                 }
                 Err(CommandProcessError::ResponseWrite(error))
             }
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct ResetProgress {
+    backend_reusable: bool,
+    backend_callable: bool,
+}
+
+impl Default for ResetProgress {
+    fn default() -> Self {
+        Self {
+            backend_reusable: true,
+            backend_callable: true,
         }
     }
 }

--- a/crates/virtio-accel-device/src/lib.rs
+++ b/crates/virtio-accel-device/src/lib.rs
@@ -22,7 +22,7 @@ pub use decoder::{
 };
 pub use engine::{
     AcceleratorState, CommandOutcome, CommandProcessError, CommandProcessor,
-    CommandProcessorInitError, DeviceHealth,
+    CommandProcessorInitError, DeviceHealth, ResetDisposition, ResetError, ResetReport,
 };
 pub use frame::{FramePreflight, FramePreflightError, UnusableFrame, preflight_command_frame};
 pub use object_table::{ObjectId, ObjectKind, ObjectNamespace, ObjectTable, ObjectTableError};
@@ -33,8 +33,8 @@ pub use regions::{
 pub use response::{ResponsePayload, ResponseWriteError, ResponseWriter};
 pub use state::{
     BufferRecord, ChildCounts, ContextRecord, CreateError, DeviceState, DeviceStateConfigError,
-    DeviceStateError, EventRecord, ProgramRecord, QueueRecord, ReleaseState, RestoreError,
-    SubmissionResources,
+    DeviceStateError, EventRecord, ProgramRecord, QueueRecord, ReleaseState, ResourceCounts,
+    RestoreError, SubmissionResources,
 };
 use virtio_accel_core::BackendError;
 use virtio_accel_proto::StatusCode;

--- a/crates/virtio-accel-device/src/object_table.rs
+++ b/crates/virtio-accel-device/src/object_table.rs
@@ -218,6 +218,22 @@ impl<T> ObjectTable<T> {
         Ok(value)
     }
 
+    pub(crate) fn next_id_from(&self, start: usize) -> Option<(usize, ObjectId)> {
+        self.slots
+            .iter()
+            .enumerate()
+            .skip(start)
+            .find_map(|(index, slot)| {
+                if slot.retired || slot.value.is_none() {
+                    return None;
+                }
+                Some((
+                    index + 1,
+                    ObjectId::new(index as u32, self.namespace, slot.generation, self.kind),
+                ))
+            })
+    }
+
     fn locate(&self, id: ObjectId) -> Result<usize, ObjectTableError> {
         let raw = id.get();
         let slot_number = raw as u32;

--- a/crates/virtio-accel-device/src/state.rs
+++ b/crates/virtio-accel-device/src/state.rs
@@ -117,6 +117,43 @@ impl ChildCounts {
     }
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ResourceCounts {
+    pub contexts: u64,
+    pub buffers: u64,
+    pub programs: u64,
+    pub queues: u64,
+    pub events: u64,
+}
+
+impl ResourceCounts {
+    pub const fn is_empty(self) -> bool {
+        self.contexts == 0
+            && self.buffers == 0
+            && self.programs == 0
+            && self.queues == 0
+            && self.events == 0
+    }
+
+    pub const fn total(self) -> u64 {
+        self.contexts
+            .saturating_add(self.buffers)
+            .saturating_add(self.programs)
+            .saturating_add(self.queues)
+            .saturating_add(self.events)
+    }
+
+    pub(crate) const fn saturating_add(self, other: Self) -> Self {
+        Self {
+            contexts: self.contexts.saturating_add(other.contexts),
+            buffers: self.buffers.saturating_add(other.buffers),
+            programs: self.programs.saturating_add(other.programs),
+            queues: self.queues.saturating_add(other.queues),
+            events: self.events.saturating_add(other.events),
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct ContextRecord<C> {
     resource: ResourceSlot<C>,
@@ -320,6 +357,7 @@ impl<'a, B, P, Q> SubmissionResources<'a, B, P, Q> {
 
 /// Complete typed object graph for one device instance.
 pub struct DeviceState<C, B, P, Q, E> {
+    namespace: ObjectNamespace,
     limits: DeviceLimits,
     contexts: ObjectTable<ContextRecord<C>>,
     buffers: ObjectTable<BufferRecord<B>>,
@@ -357,6 +395,7 @@ impl<C, B, P, Q, E> DeviceState<C, B, P, Q, E> {
         let events = aggregate_slots(limits.max_contexts, limits.max_events_per_context)?;
 
         Ok(Self {
+            namespace,
             limits,
             contexts: ObjectTable::with_namespace(
                 ObjectKind::Context,
@@ -372,6 +411,28 @@ impl<C, B, P, Q, E> DeviceState<C, B, P, Q, E> {
 
     pub const fn limits(&self) -> DeviceLimits {
         self.limits
+    }
+
+    pub const fn namespace(&self) -> ObjectNamespace {
+        self.namespace
+    }
+
+    pub const fn resource_counts(&self) -> ResourceCounts {
+        ResourceCounts {
+            contexts: self.context_count() as u64,
+            buffers: self.buffer_count() as u64,
+            programs: self.program_count() as u64,
+            queues: self.queue_count() as u64,
+            events: self.event_count() as u64,
+        }
+    }
+
+    pub const fn is_empty(&self) -> bool {
+        self.contexts.is_empty()
+            && self.buffers.is_empty()
+            && self.programs.is_empty()
+            && self.queues.is_empty()
+            && self.events.is_empty()
     }
 
     pub const fn context_count(&self) -> u32 {
@@ -419,6 +480,26 @@ impl<C, B, P, Q, E> DeviceState<C, B, P, Q, E> {
 
     pub fn event_record(&self, id: ObjectId) -> Result<&EventRecord<E>, DeviceStateError> {
         self.events.get(id).map_err(map_table_error)
+    }
+
+    pub(crate) fn next_context_id(&self, start: usize) -> Option<(usize, ObjectId)> {
+        self.contexts.next_id_from(start)
+    }
+
+    pub(crate) fn next_buffer_id(&self, start: usize) -> Option<(usize, ObjectId)> {
+        self.buffers.next_id_from(start)
+    }
+
+    pub(crate) fn next_program_id(&self, start: usize) -> Option<(usize, ObjectId)> {
+        self.programs.next_id_from(start)
+    }
+
+    pub(crate) fn next_queue_id(&self, start: usize) -> Option<(usize, ObjectId)> {
+        self.queues.next_id_from(start)
+    }
+
+    pub(crate) fn next_event_id(&self, start: usize) -> Option<(usize, ObjectId)> {
+        self.events.next_id_from(start)
     }
 
     pub fn create_context_with<ProviderError>(

--- a/crates/virtio-accel-device/tests/command_processor.rs
+++ b/crates/virtio-accel-device/tests/command_processor.rs
@@ -1,4 +1,5 @@
 use std::cell::Cell;
+use std::cell::RefCell;
 use std::rc::Rc;
 use std::vec::Vec;
 
@@ -10,7 +11,8 @@ use virtio_accel_core::{
 use virtio_accel_device::{
     ChainRegion, CommandOutcome, CommandProcessError, CommandProcessor, CommandProcessorInitError,
     DecoderLimitsError, DeviceHealth, DeviceStateError, ObjectId, ObjectNamespace,
-    ResponseWriteError, SegmentedSink, SegmentedSource, UnusableFrame,
+    ResetDisposition, ResetError, ResourceCounts, ResponseWriteError, SegmentedSink,
+    SegmentedSource, UnusableFrame,
 };
 use virtio_accel_mock::{
     MockAccelerator, MockBuffer, MockContext, MockEvent, MockProgram, MockQueue,
@@ -29,7 +31,7 @@ const REQUEST_ID: u64 = 0x0102_0304_0506_0708;
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum ReleaseMode {
     Pass,
-    Reject,
+    Reject(BackendError),
     Indeterminate,
 }
 
@@ -46,8 +48,12 @@ struct RecordingBackend {
     device_info_calls: Rc<Cell<u32>>,
     create_context_error: Cell<Option<BackendError>>,
     create_context_calls: Cell<u32>,
+    context_release_mode: Cell<ReleaseMode>,
     free_mode: Cell<ReleaseMode>,
     free_calls: Cell<u32>,
+    program_release_mode: Cell<ReleaseMode>,
+    queue_release_mode: Cell<ReleaseMode>,
+    release_log: RefCell<Vec<&'static str>>,
     write_calls: Cell<u32>,
     read_calls: Cell<u32>,
     segmented_write: Cell<bool>,
@@ -72,8 +78,12 @@ impl Default for RecordingBackend {
             device_info_calls: Rc::new(Cell::new(0)),
             create_context_error: Cell::new(None),
             create_context_calls: Cell::new(0),
+            context_release_mode: Cell::new(ReleaseMode::Pass),
             free_mode: Cell::new(ReleaseMode::Pass),
             free_calls: Cell::new(0),
+            program_release_mode: Cell::new(ReleaseMode::Pass),
+            queue_release_mode: Cell::new(ReleaseMode::Pass),
+            release_log: RefCell::new(Vec::new()),
             write_calls: Cell::new(0),
             read_calls: Cell::new(0),
             segmented_write: Cell::new(false),
@@ -117,7 +127,17 @@ impl Accelerator for RecordingBackend {
     }
 
     fn destroy_context(&self, context: Self::Context) -> Result<(), ReleaseFailure<Self::Context>> {
-        self.inner.destroy_context(context)
+        self.release_log.borrow_mut().push("context");
+        match self.context_release_mode.get() {
+            ReleaseMode::Pass => self.inner.destroy_context(context),
+            ReleaseMode::Reject(error) => Err(ReleaseFailure::Rejected {
+                error,
+                resource: context,
+            }),
+            ReleaseMode::Indeterminate => Err(ReleaseFailure::Indeterminate {
+                error: BackendError::DeviceLost,
+            }),
+        }
     }
 
     fn allocate_buffer(
@@ -152,10 +172,11 @@ impl Accelerator for RecordingBackend {
 
     fn free_buffer(&self, buffer: Self::Buffer) -> Result<(), ReleaseFailure<Self::Buffer>> {
         self.free_calls.set(self.free_calls.get() + 1);
+        self.release_log.borrow_mut().push("buffer");
         match self.free_mode.get() {
             ReleaseMode::Pass => self.inner.free_buffer(buffer),
-            ReleaseMode::Reject => Err(ReleaseFailure::Rejected {
-                error: BackendError::Busy,
+            ReleaseMode::Reject(error) => Err(ReleaseFailure::Rejected {
+                error,
                 resource: buffer,
             }),
             ReleaseMode::Indeterminate => Err(ReleaseFailure::Indeterminate {
@@ -175,7 +196,17 @@ impl Accelerator for RecordingBackend {
     }
 
     fn unload_program(&self, program: Self::Program) -> Result<(), ReleaseFailure<Self::Program>> {
-        self.inner.unload_program(program)
+        self.release_log.borrow_mut().push("program");
+        match self.program_release_mode.get() {
+            ReleaseMode::Pass => self.inner.unload_program(program),
+            ReleaseMode::Reject(error) => Err(ReleaseFailure::Rejected {
+                error,
+                resource: program,
+            }),
+            ReleaseMode::Indeterminate => Err(ReleaseFailure::Indeterminate {
+                error: BackendError::DeviceLost,
+            }),
+        }
     }
 
     fn create_queue(
@@ -187,7 +218,17 @@ impl Accelerator for RecordingBackend {
     }
 
     fn destroy_queue(&self, queue: Self::Queue) -> Result<(), ReleaseFailure<Self::Queue>> {
-        self.inner.destroy_queue(queue)
+        self.release_log.borrow_mut().push("queue");
+        match self.queue_release_mode.get() {
+            ReleaseMode::Pass => self.inner.destroy_queue(queue),
+            ReleaseMode::Reject(error) => Err(ReleaseFailure::Rejected {
+                error,
+                resource: queue,
+            }),
+            ReleaseMode::Indeterminate => Err(ReleaseFailure::Indeterminate {
+                error: BackendError::DeviceLost,
+            }),
+        }
     }
 
     fn submit(
@@ -227,12 +268,14 @@ impl Accelerator for RecordingBackend {
 
     fn cancel_event(&self, event: &Self::Event) -> Result<(), BackendError> {
         self.cancel_calls.set(self.cancel_calls.get() + 1);
+        self.release_log.borrow_mut().push("cancel_event");
         self.inner.cancel_event(event)
     }
 
     fn destroy_event(&self, event: Self::Event) -> Result<(), ReleaseFailure<Self::Event>> {
         self.destroy_event_calls
             .set(self.destroy_event_calls.get() + 1);
+        self.release_log.borrow_mut().push("event");
         match self.event_release_mode.get() {
             ReleaseMode::Pass => match self.event_state_override.get() {
                 Some(EventState::Complete | EventState::Failed(_) | EventState::Cancelled) => {
@@ -240,8 +283,8 @@ impl Accelerator for RecordingBackend {
                 }
                 Some(EventState::Pending) | None => self.inner.destroy_event(event),
             },
-            ReleaseMode::Reject => Err(ReleaseFailure::Rejected {
-                error: BackendError::Busy,
+            ReleaseMode::Reject(error) => Err(ReleaseFailure::Rejected {
+                error,
                 resource: event,
             }),
             ReleaseMode::Indeterminate => Err(ReleaseFailure::Indeterminate {
@@ -742,7 +785,10 @@ fn rejected_release_restores_the_id_and_indeterminate_release_requires_reset() {
     let buffer = allocate_buffer(&mut processor, context);
     let free = object_request(virtio_accel_proto::KnownOpcode::FreeBuffer, buffer);
 
-    processor.accelerator().free_mode.set(ReleaseMode::Reject);
+    processor
+        .accelerator()
+        .free_mode
+        .set(ReleaseMode::Reject(BackendError::Busy));
     assert_eq!(status(run(&mut processor, &free, 16).0), StatusCode::BUSY);
     assert!(processor.state().buffer_record(buffer).is_ok());
 
@@ -769,7 +815,7 @@ fn rejected_release_restores_the_id_and_indeterminate_release_requires_reset() {
         ),
         StatusCode::DEVICE_LOST
     );
-    assert_eq!(processor.health(), DeviceHealth::NeedsReset);
+    assert_eq!(processor.health(), DeviceHealth::BackendDiscardRequired);
     assert_eq!(
         processor.state().buffer_record(second).unwrap_err(),
         DeviceStateError::StaleObject
@@ -786,6 +832,16 @@ fn rejected_release_restores_the_id_and_indeterminate_release_requires_reset() {
             .0,
         ),
         StatusCode::DEVICE_LOST
+    );
+    let report = processor.reset(ObjectNamespace::new(2).unwrap()).unwrap();
+    assert_eq!(report.disposition, ResetDisposition::BackendDiscardRequired);
+    assert_eq!(
+        report.quarantined,
+        ResourceCounts {
+            contexts: 1,
+            buffers: 1,
+            ..ResourceCounts::default()
+        }
     );
 }
 
@@ -816,6 +872,30 @@ fn response_failure_after_creation_requires_reset() {
     );
     assert_eq!(processor.state().context_count(), 1);
     assert_eq!(processor.health(), DeviceHealth::NeedsReset);
+
+    let create_calls = processor.accelerator().create_context_calls.get();
+    assert_eq!(
+        status(run(&mut processor, &create, 24).0),
+        StatusCode::DEVICE_LOST
+    );
+    assert_eq!(
+        processor.accelerator().create_context_calls.get(),
+        create_calls
+    );
+    assert_eq!(processor.state().context_count(), 1);
+
+    let report = processor.reset(ObjectNamespace::new(2).unwrap()).unwrap();
+    assert_eq!(report.disposition, ResetDisposition::BackendReusable);
+    assert_eq!(
+        report.released,
+        ResourceCounts {
+            contexts: 1,
+            ..ResourceCounts::default()
+        }
+    );
+    assert!(report.quarantined.is_empty());
+    assert_eq!(processor.health(), DeviceHealth::Running);
+    assert!(processor.state().is_empty());
 }
 
 #[test]
@@ -1124,7 +1204,7 @@ fn event_release_rejection_retries_and_indeterminate_release_requires_reset() {
     processor
         .accelerator()
         .event_release_mode
-        .set(ReleaseMode::Reject);
+        .set(ReleaseMode::Reject(BackendError::Busy));
     assert_eq!(
         status(run(&mut processor, &destroy, 16).0),
         StatusCode::BUSY
@@ -1163,7 +1243,7 @@ fn event_release_rejection_retries_and_indeterminate_release_requires_reset() {
         status(run(&mut processor, &destroy, 16).0),
         StatusCode::DEVICE_LOST
     );
-    assert_eq!(processor.health(), DeviceHealth::NeedsReset);
+    assert_eq!(processor.health(), DeviceHealth::BackendDiscardRequired);
     assert_eq!(
         processor.state().event_record(second_event).unwrap_err(),
         DeviceStateError::StaleObject
@@ -1191,8 +1271,58 @@ fn event_faults_and_unreportable_admission_require_recovery() {
         status(run(&mut poll_processor, &poll, 24).0),
         StatusCode::DEVICE_LOST
     );
-    assert_eq!(poll_processor.health(), DeviceHealth::NeedsReset);
+    assert_eq!(
+        poll_processor.health(),
+        DeviceHealth::BackendDiscardRequired
+    );
     assert_eq!(poll_processor.state().event_count(), 1);
+
+    let mut terminal_processor = processor();
+    let (_context, buffer, program, queue) =
+        submission_objects(&mut terminal_processor, BufferUsage::PROGRAM_INPUT);
+    let submit = submit_request(queue, program, buffer, 0, 8, AccessMode::Read);
+    let (_, response) = run(&mut terminal_processor, &submit, 24);
+    let event = event_id(&response);
+    terminal_processor
+        .accelerator()
+        .event_state_override
+        .set(Some(EventState::Failed(BackendError::DeviceLost)));
+    let poll = object_request(virtio_accel_proto::KnownOpcode::PollEvent, event);
+    let (outcome, response) = run(&mut terminal_processor, &poll, 24);
+    assert_eq!(status(outcome), StatusCode::OK);
+    let state = event_state(&response);
+    assert_eq!(state.known_state().unwrap(), KnownEventState::Failed);
+    assert_eq!(state.error.get(), StatusCode::DEVICE_LOST.0);
+    assert_eq!(
+        terminal_processor.health(),
+        DeviceHealth::BackendDiscardRequired
+    );
+    let poll_calls = terminal_processor.accelerator().poll_calls.get();
+    let report = terminal_processor
+        .reset(ObjectNamespace::new(2).unwrap())
+        .unwrap();
+    assert_eq!(report.disposition, ResetDisposition::BackendDiscardRequired);
+    assert_eq!(
+        report.quarantined,
+        ResourceCounts {
+            contexts: 1,
+            buffers: 1,
+            programs: 1,
+            queues: 1,
+            events: 1,
+        }
+    );
+    assert_eq!(
+        terminal_processor.accelerator().poll_calls.get(),
+        poll_calls
+    );
+    assert!(
+        terminal_processor
+            .accelerator()
+            .release_log
+            .borrow()
+            .is_empty()
+    );
 
     let mut completion_processor = processor();
     let (_context, buffer, program, queue) =
@@ -1288,4 +1418,291 @@ fn cancellation_is_not_forwarded_without_the_capability() {
         event_state(&response).known_state().unwrap(),
         KnownEventState::Pending
     );
+}
+
+#[test]
+fn idle_reset_renews_the_namespace_without_backend_work() {
+    let mut processor = processor();
+
+    let first = processor.reset(ObjectNamespace::new(2).unwrap()).unwrap();
+    assert_eq!(first.disposition, ResetDisposition::BackendReusable);
+    assert!(first.released.is_empty());
+    assert!(first.quarantined.is_empty());
+    assert!(processor.accelerator().release_log.borrow().is_empty());
+
+    assert_eq!(
+        processor.reset(ObjectNamespace::new(2).unwrap()),
+        Err(ResetError::NamespaceReuse)
+    );
+    let second = processor.reset(ObjectNamespace::new(3).unwrap()).unwrap();
+    assert_eq!(second.disposition, ResetDisposition::BackendReusable);
+    assert!(second.released.is_empty());
+    assert!(processor.accelerator().release_log.borrow().is_empty());
+}
+
+#[test]
+fn discard_report_supersedes_a_prior_successful_reset() {
+    let mut processor = processor();
+    let first = processor.reset(ObjectNamespace::new(2).unwrap()).unwrap();
+    assert_eq!(first.disposition, ResetDisposition::BackendReusable);
+
+    let context = create_context(&mut processor);
+    let buffer = allocate_buffer(&mut processor, context);
+    processor
+        .accelerator()
+        .free_mode
+        .set(ReleaseMode::Indeterminate);
+    let free = object_request(virtio_accel_proto::KnownOpcode::FreeBuffer, buffer);
+    assert_eq!(
+        status(run(&mut processor, &free, 16).0),
+        StatusCode::DEVICE_LOST
+    );
+
+    let report = processor.reset(ObjectNamespace::new(3).unwrap()).unwrap();
+    assert_eq!(report.disposition, ResetDisposition::BackendDiscardRequired);
+    assert_eq!(
+        report.quarantined,
+        ResourceCounts {
+            contexts: 1,
+            buffers: 1,
+            ..ResourceCounts::default()
+        }
+    );
+}
+
+#[test]
+fn reset_cancels_pending_events_then_tears_down_child_before_parent() {
+    let mut processor = processor();
+    let (context, buffer, program, queue) =
+        submission_objects(&mut processor, BufferUsage::PROGRAM_INPUT);
+    let submit = submit_request(queue, program, buffer, 0, 8, AccessMode::Read);
+    let (_, response) = run(&mut processor, &submit, 24);
+    let event = event_id(&response);
+
+    let report = processor.reset(ObjectNamespace::new(2).unwrap()).unwrap();
+    assert_eq!(report.disposition, ResetDisposition::BackendReusable);
+    assert_eq!(
+        report.released,
+        ResourceCounts {
+            contexts: 1,
+            buffers: 1,
+            programs: 1,
+            queues: 1,
+            events: 1,
+        }
+    );
+    assert!(report.quarantined.is_empty());
+    assert_eq!(
+        processor.accelerator().release_log.borrow().as_slice(),
+        [
+            "cancel_event",
+            "event",
+            "queue",
+            "program",
+            "buffer",
+            "context"
+        ]
+    );
+    assert_eq!(processor.health(), DeviceHealth::Running);
+    assert!(processor.state().is_empty());
+
+    for (opcode, id) in [
+        (virtio_accel_proto::KnownOpcode::DestroyContext, context),
+        (virtio_accel_proto::KnownOpcode::FreeBuffer, buffer),
+        (virtio_accel_proto::KnownOpcode::UnloadProgram, program),
+        (virtio_accel_proto::KnownOpcode::DestroyQueue, queue),
+        (virtio_accel_proto::KnownOpcode::DestroyEvent, event),
+    ] {
+        assert_eq!(
+            status(run(&mut processor, &object_request(opcode, id), 16).0),
+            StatusCode::STALE_OBJECT
+        );
+    }
+
+    let new_context = create_context(&mut processor);
+    assert_ne!(new_context, context);
+}
+
+#[test]
+fn reset_reclaims_completed_and_cancelled_events_exactly_once() {
+    let mut processor = processor();
+    let (_context, buffer, program, queue) =
+        submission_objects(&mut processor, BufferUsage::PROGRAM_INPUT);
+    let submit = submit_request(queue, program, buffer, 0, 8, AccessMode::Read);
+    let (_, response) = run(&mut processor, &submit, 24);
+    let completed = event_id(&response);
+    let (_, response) = run(&mut processor, &submit, 24);
+    let cancelled = event_id(&response);
+
+    let event = processor
+        .state()
+        .event_record(completed)
+        .unwrap()
+        .resource()
+        .unwrap();
+    processor.accelerator().inner.complete(event).unwrap();
+    let cancel = object_request(virtio_accel_proto::KnownOpcode::CancelEvent, cancelled);
+    assert_eq!(status(run(&mut processor, &cancel, 16).0), StatusCode::OK);
+    processor.accelerator().release_log.borrow_mut().clear();
+
+    let report = processor.reset(ObjectNamespace::new(2).unwrap()).unwrap();
+    assert_eq!(report.disposition, ResetDisposition::BackendReusable);
+    assert_eq!(report.released.events, 2);
+    assert_eq!(report.released.total(), 6);
+    assert!(report.quarantined.is_empty());
+    assert_eq!(
+        processor.accelerator().release_log.borrow().as_slice(),
+        ["event", "event", "queue", "program", "buffer", "context"]
+    );
+}
+
+#[test]
+fn rejected_reset_release_is_quarantined_and_reset_is_idempotent() {
+    let mut processor = processor();
+    submission_objects(&mut processor, BufferUsage::PROGRAM_INPUT);
+    processor
+        .accelerator()
+        .free_mode
+        .set(ReleaseMode::Reject(BackendError::Busy));
+
+    let first = processor.reset(ObjectNamespace::new(2).unwrap()).unwrap();
+    assert_eq!(first.disposition, ResetDisposition::BackendDiscardRequired);
+    assert_eq!(
+        first.released,
+        ResourceCounts {
+            programs: 1,
+            queues: 1,
+            ..ResourceCounts::default()
+        }
+    );
+    assert_eq!(
+        first.quarantined,
+        ResourceCounts {
+            contexts: 1,
+            buffers: 1,
+            ..ResourceCounts::default()
+        }
+    );
+    assert_eq!(
+        processor.accelerator().release_log.borrow().as_slice(),
+        ["queue", "program", "buffer"]
+    );
+    assert_eq!(processor.health(), DeviceHealth::BackendDiscardRequired);
+
+    let calls = processor.accelerator().release_log.borrow().len();
+    let second = processor.reset(ObjectNamespace::new(3).unwrap()).unwrap();
+    assert_eq!(second, first);
+    assert_eq!(processor.accelerator().release_log.borrow().len(), calls);
+}
+
+#[test]
+fn reset_stops_backend_calls_after_device_lost_release_rejection() {
+    let mut processor = processor();
+    submission_objects(&mut processor, BufferUsage::PROGRAM_INPUT);
+    create_context(&mut processor);
+    processor
+        .accelerator()
+        .free_mode
+        .set(ReleaseMode::Reject(BackendError::DeviceLost));
+
+    let report = processor.reset(ObjectNamespace::new(2).unwrap()).unwrap();
+    assert_eq!(report.disposition, ResetDisposition::BackendDiscardRequired);
+    assert_eq!(
+        report.released,
+        ResourceCounts {
+            programs: 1,
+            queues: 1,
+            ..ResourceCounts::default()
+        }
+    );
+    assert_eq!(
+        report.quarantined,
+        ResourceCounts {
+            contexts: 2,
+            buffers: 1,
+            ..ResourceCounts::default()
+        }
+    );
+    assert_eq!(
+        processor.accelerator().release_log.borrow().as_slice(),
+        ["queue", "program", "buffer"]
+    );
+}
+
+#[test]
+fn indeterminate_event_release_quarantines_the_complete_object_graph() {
+    let mut processor = processor();
+    let (_context, buffer, program, queue) =
+        submission_objects(&mut processor, BufferUsage::PROGRAM_INPUT);
+    let submit = submit_request(queue, program, buffer, 0, 8, AccessMode::Read);
+    let (_, response) = run(&mut processor, &submit, 24);
+    let event_id = event_id(&response);
+    let event = processor
+        .state()
+        .event_record(event_id)
+        .unwrap()
+        .resource()
+        .unwrap();
+    processor.accelerator().inner.complete(event).unwrap();
+    processor
+        .accelerator()
+        .event_release_mode
+        .set(ReleaseMode::Indeterminate);
+
+    let first = processor.reset(ObjectNamespace::new(2).unwrap()).unwrap();
+    assert_eq!(first.disposition, ResetDisposition::BackendDiscardRequired);
+    assert!(first.released.is_empty());
+    assert_eq!(
+        first.quarantined,
+        ResourceCounts {
+            contexts: 1,
+            buffers: 1,
+            programs: 1,
+            queues: 1,
+            events: 1,
+        }
+    );
+    assert_eq!(
+        processor.accelerator().release_log.borrow().as_slice(),
+        ["event"]
+    );
+
+    let second = processor.reset(ObjectNamespace::new(3).unwrap()).unwrap();
+    assert_eq!(second, first);
+    assert_eq!(
+        processor.accelerator().release_log.borrow().as_slice(),
+        ["event"]
+    );
+}
+
+#[test]
+fn pending_event_without_cancellation_requires_backend_discard() {
+    let backend = RecordingBackend::default();
+    let mut info = backend.device_info().unwrap();
+    backend.device_info_calls.set(0);
+    info.capabilities.remove(Capabilities::EVENT_CANCELLATION);
+    backend.info_override.set(Some(info));
+    let mut processor =
+        CommandProcessor::new(backend, &config(), ObjectNamespace::new(1).unwrap()).unwrap();
+    let (_context, buffer, program, queue) =
+        submission_objects(&mut processor, BufferUsage::PROGRAM_INPUT);
+    let submit = submit_request(queue, program, buffer, 0, 8, AccessMode::Read);
+    run(&mut processor, &submit, 24);
+
+    let report = processor.reset(ObjectNamespace::new(2).unwrap()).unwrap();
+    assert_eq!(report.disposition, ResetDisposition::BackendDiscardRequired);
+    assert!(report.released.is_empty());
+    assert_eq!(
+        report.quarantined,
+        ResourceCounts {
+            contexts: 1,
+            buffers: 1,
+            programs: 1,
+            queues: 1,
+            events: 1,
+        }
+    );
+    assert_eq!(processor.accelerator().cancel_calls.get(), 0);
+    assert_eq!(processor.accelerator().destroy_event_calls.get(), 0);
+    assert!(processor.accelerator().release_log.borrow().is_empty());
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -57,6 +57,23 @@ Provider releases have an explicit failure boundary too. A rejected release retu
 handle for retry. An indeterminate release invalidates the guest ID and requires device recovery;
 the adapter must never guess that the resource is either safe to reuse or safe to free.
 
+### Reset and quarantine
+
+The transport stops fetching chains and publishing completions before handing exclusive ownership
+to `CommandProcessor::reset`. The processor then makes one bounded pass: events first, followed by
+execution queues, programs, buffers, and contexts. Pending events are cancelled only when the
+backend advertises cancellation; no reset path spins, waits, or creates a background executor.
+
+A completely drained graph receives a fresh `ObjectNamespace` and may continue with the same
+backend. Any unresolved pending event, rejected reset release, indeterminate release, device loss,
+or accounting contradiction produces `BackendDiscardRequired`. That result reports both resources
+released during the pass and resources still represented or previously orphaned in quarantine.
+The result is sticky: later reset calls make no provider calls, and the complete processor/backend
+instance must be discarded rather than reattached to newly initialized queues.
+
+This keeps synchronization at the existing owner boundary. Reset needs no per-record atomics or
+locks; provider completion tokens remain responsible for the cancellation/completion race.
+
 ### Submission acceptance
 
 A rejected submission guarantees that the backend accepted no execution and retained no resources.
@@ -176,6 +193,6 @@ baseline processor:
 4. Passes transfer and artifact regions directly to backend byte ports.
 5. Produces a response without knowing about rust-vmm or a host operating system.
 
-Submission/event retention and deterministic reset complete this engine before a thin rust-vmm
-adapter supplies `virtio-device`, `virtio-queue`, and `vm-memory` integration. Linux vhost-user and
-an in-kernel guest driver remain later platform layers.
+Submission/event retention and deterministic reset complete the engine. The next boundary is a thin
+rust-vmm adapter supplying `virtio-device`, `virtio-queue`, and `vm-memory` integration. Linux
+vhost-user and an in-kernel guest driver remain later platform layers.

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -243,7 +243,17 @@ A **reset** stops admission, disposes or quarantines in-flight state according t
 invalidates every guest-visible object ID, advances the device epoch, resets command queues, and
 returns the device to its initial negotiation state.
 
-No object ID created before reset may resolve after reset.
+The transport **MUST** stop fetching command chains and publishing completions before portable
+object teardown begins. Teardown **MUST** be bounded and child-before-parent: events precede their
+execution queues, programs, and buffers, and all context children precede the context.
+
+The device **MAY** reuse a backend instance only when every known resource is released
+successfully. An unresolved pending event, a rejected reset-time release, an indeterminate release,
+backend device loss, or an accounting contradiction requires discarding the complete backend
+instance. Once discard is required, repeated reset attempts **MUST NOT** invoke that backend again.
+
+Successful reinitialization **MUST** use a fresh nonzero object namespace. No object ID created
+before reset may resolve after reset.
 
 ## 5. Baseline capabilities and feature policy
 
@@ -471,6 +481,8 @@ model or is identified as an implementation helper.
 | `SubmitFailure` | Rejected versus indeterminate submission acceptance boundary |
 | `ReleaseFailure` | Rejected versus indeterminate resource-release boundary |
 | `Accelerator` | Accelerator backend contract |
+| `DeviceHealth` | Running, known-state reset required, or backend-discard-required processor state |
+| `ResourceCounts`, `ResetDisposition`, `ResetReport`, `ResetError` | Reset accounting, reuse decision, and namespace validation |
 | `Le16`, `Le32`, `Le64` | Wire implementation aliases; not semantic API |
 | `PROTOCOL_MAJOR`, `PROTOCOL_MINOR` | Candidate protocol version 1.0 |
 | `COMMAND_QUEUE` | Baseline command virtqueue index |

--- a/docs/virtqueue.md
+++ b/docs/virtqueue.md
@@ -196,6 +196,12 @@ When reset begins, the device:
 5. invalidates all object IDs and request tracking from the old reset epoch; and
 6. resets command-queue available/used state as required by the base transport.
 
+After steps 1 and 2 quiesce queue access, the transport gives exclusive ownership to the portable
+command processor for one bounded teardown pass. A reusable result permits queue and object-table
+reinitialization with a fresh namespace. A discard-required result forbids further backend calls;
+the transport discards that processor/backend instance and creates a new one before exposing new
+queues.
+
 Descriptor chains that were available or in progress when reset began are not completed after reset.
 Once the driver has observed reset completion, it may reclaim all queue memory and descriptors under
 the base Virtio reset rule. It **MUST NOT** expect response bytes or used entries for those chains.


### PR DESCRIPTION
## Summary

- add a bounded, child-before-parent `CommandProcessor::reset` transition
- renew object namespaces after complete teardown so every pre-reset ID is stale
- cancel pending events when supported and reclaim terminal resources exactly once
- report released and quarantined resource totals explicitly
- make backend discard sticky after unknown ownership, device loss, rejected reset release, or state contradiction
- block queued semantic work while recovery is required without adding locks, atomics, copies, or a hidden executor
- document the transport handoff and record reset requirements in the normative ledger

## Design

The transport first stops command-chain fetch and completion publication, then gives the portable processor exclusive ownership for one teardown pass. Events are resolved before execution queues, programs, buffers, and contexts. A fully drained graph can reuse the backend with a fresh object namespace; every unresolved or indeterminate graph requires discarding the complete processor/backend instance.

`BackendDiscardRequired` is sticky. Repeated reset calls return the same accounting report and make no provider calls. Provider completion tokens remain responsible for cancellation/completion races, so the portable state stays single-owner and synchronization-free.

## Validation

- `cargo +stable fmt --all -- --check`
- `cargo +stable clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo +stable doc --workspace --all-features --no-deps`
- `cargo +stable test --workspace --all-targets --all-features`
- `cargo +stable test --workspace --doc --all-features`
- `cargo +stable check --workspace --release --all-features`
- `cargo +1.85.0 check --workspace --all-targets --all-features`
- `cargo +1.85.0 test --workspace --all-features`
- portable `no_std` checks on `aarch64-unknown-none`, `riscv64gc-unknown-none-elf`, and `wasm32-unknown-unknown`
- Wasm all-features workspace check
- `python3 ci/check-normative-requirements.py --check`
- `bash ci/check-portable-dependencies.sh`

Closes #16
