### PR TITLE
Define portable descriptor-chain and virtqueue ports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,7 @@ jobs:
           cargo check
           -p virtio-accel-cleanroom
           -p virtio-accel-proto
+          -p virtio-accel-transport
           -p virtio-accel-core
           -p virtio-accel-device
           -p virtio-accel

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,7 @@ dependencies = [
  "virtio-accel-device",
  "virtio-accel-mock",
  "virtio-accel-proto",
+ "virtio-accel-transport",
 ]
 
 [[package]]
@@ -130,6 +131,7 @@ dependencies = [
  "virtio-accel-core",
  "virtio-accel-mock",
  "virtio-accel-proto",
+ "virtio-accel-transport",
  "zerocopy",
 ]
 
@@ -149,6 +151,10 @@ dependencies = [
  "virtio-accel-cleanroom",
  "zerocopy",
 ]
+
+[[package]]
+name = "virtio-accel-transport"
+version = "0.1.0"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/virtio-accel-device",
     "crates/virtio-accel-mock",
     "crates/virtio-accel-proto",
+    "crates/virtio-accel-transport",
 ]
 resolver = "3"
 
@@ -32,11 +33,13 @@ virtio-accel-cleanroom = { path = "conformance/rust-clean-room" }
 virtio-accel-device = { path = "crates/virtio-accel-device" }
 virtio-accel-mock = { path = "crates/virtio-accel-mock" }
 virtio-accel-proto = { path = "crates/virtio-accel-proto" }
+virtio-accel-transport = { path = "crates/virtio-accel-transport" }
 
 [dependencies]
 virtio-accel-core.workspace = true
 virtio-accel-device.workspace = true
 virtio-accel-proto.workspace = true
+virtio-accel-transport.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ claimed virtio device ID.
 ## Workspace
 
 - `virtio-accel-proto`: `no_std`, pointer-free, little-endian protocol 1.0 wire structures.
+- `virtio-accel-transport`: dependency-free `no_std` descriptor-chain, queue, reset, and
+  notification ports.
 - `virtio-accel-core`: `no_std` backend lifecycle, memory, program, queue, and event contracts.
 - `virtio-accel-device`: `no_std + alloc` device-owned state, including bounded generational IDs.
 - `virtio-accel-mock`: cross-platform in-memory backend that exercises the complete lifecycle.
@@ -21,7 +23,10 @@ claimed virtio device ID.
 The crate dependency direction is:
 
 ```text
-transport adapters (future: rust-vmm, bare metal, tests)
+transport implementations (split ring, rust-vmm, bare metal)
+                         |
+                         v
+             virtio-accel-transport
                          |
                          v
               virtio-accel-device
@@ -33,8 +38,9 @@ transport adapters (future: rust-vmm, bare metal, tests)
                     provider adapters (future)
 ```
 
-Neither the wire protocol nor the device-state layer is allowed to leak transport descriptors or
-guest addresses into a provider backend.
+The transport crate exposes reset-scoped chain identities, flattened direction/length metadata, and
+owned publication/completion tokens. Neither it nor the device-state layer leaks guest addresses,
+ring pointers, or concrete descriptor types into the command engine or provider backend.
 
 ## Protocol 1.0 candidate surface
 

--- a/ci/check-normative-requirements.py
+++ b/ci/check-normative-requirements.py
@@ -49,15 +49,23 @@ COVERAGE: Final[dict[tuple[str, int], Coverage]] = {
     ),
     ("SPEC", 2): coverage(
         "mixed",
-        ("ci/check-portable-dependencies.sh", "docs/architecture.md"),
-        ("#17", "#20", "#21"),
-        "Portable dependency direction is enforced now; concrete transport and provider boundaries are tracked.",
+        (
+            "ci/check-portable-dependencies.sh",
+            "crates/virtio-accel-transport/src/lib.rs",
+            "docs/architecture.md",
+        ),
+        ("#20", "#21"),
+        "Portable queue and dependency boundaries are enforced now; concrete end-to-end and provider adapters remain tracked.",
     ),
     ("SPEC", 3): coverage(
         "mixed",
-        ("ci/check-portable-dependencies.sh", "docs/architecture.md"),
-        ("#17", "#20", "#21"),
-        "Layer dependencies are enforceable now; runtime adapter boundaries require their implementations.",
+        (
+            "ci/check-portable-dependencies.sh",
+            "crates/virtio-accel-transport/src/queue.rs",
+            "docs/architecture.md",
+        ),
+        ("#20", "#21"),
+        "Layer and ownership boundaries are enforceable now; runtime provider integration remains tracked.",
     ),
     ("SPEC", 4): coverage(
         "mixed",
@@ -203,26 +211,37 @@ COVERAGE: Final[dict[tuple[str, int], Coverage]] = {
     ("VIRTQ", 1): coverage(
         "tracked",
         ("docs/virtqueue.md",),
-        ("#17", "#18"),
+        ("#18",),
         "The negotiated reference profile is specified; transport feature enforcement requires the queue adapter.",
     ),
     ("VIRTQ", 2): coverage(
-        "tracked",
-        ("docs/virtqueue.md",),
-        ("#17", "#18"),
-        "The flattened region contract is specified and assigned to the region-port and split-ring implementations.",
+        "mixed",
+        (
+            "crates/virtio-accel-transport/src/queue.rs",
+            "crates/virtio-accel-transport/src/regions.rs",
+            "docs/virtqueue.md",
+        ),
+        ("#18",),
+        "The flattened address-free region and chain contracts are executable; concrete descriptor mapping remains tracked.",
     ),
     ("VIRTQ", 3): coverage(
-        "tracked",
-        ("docs/virtqueue.md",),
-        ("#17", "#18"),
-        "Topology and mapping rules have stable VQ cases but require executable descriptor-chain ports.",
+        "mixed",
+        (
+            "crates/virtio-accel-device/src/frame.rs",
+            "crates/virtio-accel-transport/src/regions.rs",
+        ),
+        ("#18",),
+        "Direction, count, length, and byte-port totals are executable; split-ring topology and mapping remain tracked.",
     ),
     ("VIRTQ", 4): coverage(
-        "tracked",
-        ("conformance/rust-clean-room/tests/vectors.rs",),
-        ("#17", "#18"),
-        "Frame exactness is executable; cross-region presentation requires the region adapter and split-ring model.",
+        "mixed",
+        (
+            "conformance/rust-clean-room/tests/vectors.rs",
+            "crates/virtio-accel-device/src/frame.rs",
+            "crates/virtio-accel-transport/src/regions.rs",
+        ),
+        ("#18",),
+        "Frame exactness and cross-region port validation are executable; descriptor-backed presentation remains tracked.",
     ),
     ("VIRTQ", 5): coverage(
         "tracked",
@@ -243,16 +262,16 @@ COVERAGE: Final[dict[tuple[str, int], Coverage]] = {
         "Stable VQ ordering cases exist; concurrent publication and completion behavior awaits the queue model.",
     ),
     ("VIRTQ", 8): coverage(
-        "tracked",
-        ("docs/virtqueue.md",),
+        "mixed",
+        ("crates/virtio-accel-transport/src/queue.rs", "docs/virtqueue.md"),
         ("#19", "#20"),
-        "Backpressure semantics are specified and assigned to the guest and full-path implementations.",
+        "Publication ownership and retryable backpressure types are executable; guest behavior and full-path tests remain tracked.",
     ),
     ("VIRTQ", 9): coverage(
-        "tracked",
-        ("docs/virtqueue.md",),
+        "mixed",
+        ("crates/virtio-accel-transport/src/queue.rs", "docs/virtqueue.md"),
         ("#18", "#19"),
-        "Notification invariants are specified and assigned to split-ring and guest implementations.",
+        "Notification decisions and mandatory recheck results are executable at the port boundary; ring implementations remain tracked.",
     ),
     ("VIRTQ", 10): coverage(
         "tracked",
@@ -261,10 +280,14 @@ COVERAGE: Final[dict[tuple[str, int], Coverage]] = {
         "Malformed frame behavior is executable; malformed descriptor-chain isolation requires queue execution.",
     ),
     ("VIRTQ", 11): coverage(
-        "tracked",
-        ("docs/virtqueue.md",),
+        "mixed",
+        (
+            "crates/virtio-accel-transport/src/queue.rs",
+            "crates/virtio-accel-device/src/engine.rs",
+            "docs/virtqueue.md",
+        ),
         ("#18", "#19", "#20"),
-        "Reset cases are stable, while descriptor reclamation and late-completion exclusion require full implementations.",
+        "Reset epochs, consuming completion, reclamation ownership, and engine reset are executable; concrete ring and full-path reset remain tracked.",
     ),
     ("VIRTQ", 12): coverage(
         "tracked",
@@ -286,12 +309,13 @@ RESET_ENGINE_COVERAGE: Final = coverage(
 RESET_TRANSPORT_COVERAGE: Final = coverage(
     "mixed",
     (
+        "crates/virtio-accel-transport/src/queue.rs",
         "crates/virtio-accel-device/src/engine.rs",
         "crates/virtio-accel-device/tests/command_processor.rs",
         "docs/virtqueue.md",
     ),
-    ("#17", "#18"),
-    "The portable reset admission gate is executable; stopping queue fetch and publication requires the transport adapter and split-ring model.",
+    ("#18",),
+    "Queue reset epochs and the portable reset admission gate are executable; stopping concrete split-ring fetch and publication remains tracked.",
 )
 RESET_ENGINE_MARKERS: Final = (
     "Teardown **MUST** be bounded",

--- a/ci/check-portable-dependencies.sh
+++ b/ci/check-portable-dependencies.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 readonly packages=(
   virtio-accel-cleanroom
   virtio-accel-proto
+  virtio-accel-transport
   virtio-accel-core
 )
 
@@ -21,6 +22,14 @@ cleanroom_dependencies="$(sed '1d' <<<"$cleanroom_tree")"
 if [[ -n "$cleanroom_dependencies" ]]; then
   echo "virtio-accel-cleanroom must remain independent of every normal/build dependency:" >&2
   echo "$cleanroom_tree" >&2
+  exit 1
+fi
+
+transport_tree="$(cargo tree -p virtio-accel-transport -e normal,build --depth 1 --prefix none)"
+transport_dependencies="$(sed '1d' <<<"$transport_tree")"
+if [[ -n "$transport_dependencies" ]]; then
+  echo "virtio-accel-transport must remain independent of every normal/build dependency:" >&2
+  echo "$transport_tree" >&2
   exit 1
 fi
 

--- a/conformance/v1.0/requirements.json
+++ b/conformance/v1.0/requirements.json
@@ -112,14 +112,14 @@
         "status": "mixed",
         "evidence": [
           "ci/check-portable-dependencies.sh",
+          "crates/virtio-accel-transport/src/lib.rs",
           "docs/architecture.md"
         ],
         "issues": [
-          "#17",
           "#20",
           "#21"
         ],
-        "rationale": "Portable dependency direction is enforced now; concrete transport and provider boundaries are tracked."
+        "rationale": "Portable queue and dependency boundaries are enforced now; concrete end-to-end and provider adapters remain tracked."
       }
     },
     {
@@ -133,14 +133,14 @@
         "status": "mixed",
         "evidence": [
           "ci/check-portable-dependencies.sh",
+          "crates/virtio-accel-transport/src/queue.rs",
           "docs/architecture.md"
         ],
         "issues": [
-          "#17",
           "#20",
           "#21"
         ],
-        "rationale": "Layer dependencies are enforceable now; runtime adapter boundaries require their implementations."
+        "rationale": "Layer and ownership boundaries are enforceable now; runtime provider integration remains tracked."
       }
     },
     {
@@ -154,14 +154,14 @@
         "status": "mixed",
         "evidence": [
           "ci/check-portable-dependencies.sh",
+          "crates/virtio-accel-transport/src/queue.rs",
           "docs/architecture.md"
         ],
         "issues": [
-          "#17",
           "#20",
           "#21"
         ],
-        "rationale": "Layer dependencies are enforceable now; runtime adapter boundaries require their implementations."
+        "rationale": "Layer and ownership boundaries are enforceable now; runtime provider integration remains tracked."
       }
     },
     {
@@ -175,14 +175,14 @@
         "status": "mixed",
         "evidence": [
           "ci/check-portable-dependencies.sh",
+          "crates/virtio-accel-transport/src/queue.rs",
           "docs/architecture.md"
         ],
         "issues": [
-          "#17",
           "#20",
           "#21"
         ],
-        "rationale": "Layer dependencies are enforceable now; runtime adapter boundaries require their implementations."
+        "rationale": "Layer and ownership boundaries are enforceable now; runtime provider integration remains tracked."
       }
     },
     {
@@ -196,14 +196,14 @@
         "status": "mixed",
         "evidence": [
           "ci/check-portable-dependencies.sh",
+          "crates/virtio-accel-transport/src/queue.rs",
           "docs/architecture.md"
         ],
         "issues": [
-          "#17",
           "#20",
           "#21"
         ],
-        "rationale": "Layer dependencies are enforceable now; runtime adapter boundaries require their implementations."
+        "rationale": "Layer and ownership boundaries are enforceable now; runtime provider integration remains tracked."
       }
     },
     {
@@ -217,14 +217,14 @@
         "status": "mixed",
         "evidence": [
           "ci/check-portable-dependencies.sh",
+          "crates/virtio-accel-transport/src/queue.rs",
           "docs/architecture.md"
         ],
         "issues": [
-          "#17",
           "#20",
           "#21"
         ],
-        "rationale": "Layer dependencies are enforceable now; runtime adapter boundaries require their implementations."
+        "rationale": "Layer and ownership boundaries are enforceable now; runtime provider integration remains tracked."
       }
     },
     {
@@ -655,15 +655,15 @@
       "coverage": {
         "status": "mixed",
         "evidence": [
+          "crates/virtio-accel-transport/src/queue.rs",
           "crates/virtio-accel-device/src/engine.rs",
           "crates/virtio-accel-device/tests/command_processor.rs",
           "docs/virtqueue.md"
         ],
         "issues": [
-          "#17",
           "#18"
         ],
-        "rationale": "The portable reset admission gate is executable; stopping queue fetch and publication requires the transport adapter and split-ring model."
+        "rationale": "Queue reset epochs and the portable reset admission gate are executable; stopping concrete split-ring fetch and publication remains tracked."
       }
     },
     {
@@ -1491,9 +1491,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-A6D1EA8B8FFD",
+      "id": "REQ-SPEC-3123035A074A",
       "source": "docs/specification.md",
-      "line": 438,
+      "line": 439,
       "section": "10. Portability requirements",
       "keyword": "MUST NOT",
       "statement": "Platform adapters depend inward on the portable layers. A portable layer **MUST NOT** conditionally",
@@ -1509,9 +1509,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-ABF529AA1C73",
+      "id": "REQ-SPEC-7D81F01D02EB",
       "source": "docs/specification.md",
-      "line": 454,
+      "line": 455,
       "section": "11. Tracked completion work",
       "keyword": "MAY",
       "statement": "No implementation **MAY** advertise a reserved optional feature merely because a Rust constant",
@@ -2261,7 +2261,6 @@
           "docs/virtqueue.md"
         ],
         "issues": [
-          "#17",
           "#18"
         ],
         "rationale": "The negotiated reference profile is specified; transport feature enforcement requires the queue adapter."
@@ -2275,15 +2274,16 @@
       "keyword": "MUST NOT",
       "statement": "The command engine sees region lengths and byte access only. It **MUST NOT** receive guest physical",
       "coverage": {
-        "status": "tracked",
+        "status": "mixed",
         "evidence": [
+          "crates/virtio-accel-transport/src/queue.rs",
+          "crates/virtio-accel-transport/src/regions.rs",
           "docs/virtqueue.md"
         ],
         "issues": [
-          "#17",
           "#18"
         ],
-        "rationale": "The flattened region contract is specified and assigned to the region-port and split-ring implementations."
+        "rationale": "The flattened address-free region and chain contracts are executable; concrete descriptor mapping remains tracked."
       }
     },
     {
@@ -2294,15 +2294,15 @@
       "keyword": "MUST",
       "statement": "The transport adapter **MUST** validate the descriptor topology and map every readable and required",
       "coverage": {
-        "status": "tracked",
+        "status": "mixed",
         "evidence": [
-          "docs/virtqueue.md"
+          "crates/virtio-accel-device/src/frame.rs",
+          "crates/virtio-accel-transport/src/regions.rs"
         ],
         "issues": [
-          "#17",
           "#18"
         ],
-        "rationale": "Topology and mapping rules have stable VQ cases but require executable descriptor-chain ports."
+        "rationale": "Direction, count, length, and byte-port totals are executable; split-ring topology and mapping remain tracked."
       }
     },
     {
@@ -2313,15 +2313,16 @@
       "keyword": "MUST",
       "statement": "is request-header byte zero. The readable total **MUST** equal:",
       "coverage": {
-        "status": "tracked",
+        "status": "mixed",
         "evidence": [
-          "conformance/rust-clean-room/tests/vectors.rs"
+          "conformance/rust-clean-room/tests/vectors.rs",
+          "crates/virtio-accel-device/src/frame.rs",
+          "crates/virtio-accel-transport/src/regions.rs"
         ],
         "issues": [
-          "#17",
           "#18"
         ],
-        "rationale": "Frame exactness is executable; cross-region presentation requires the region adapter and split-ring model."
+        "rationale": "Frame exactness and cross-region port validation are executable; descriptor-backed presentation remains tracked."
       }
     },
     {
@@ -2446,15 +2447,16 @@
       "keyword": "MUST",
       "statement": "- A driver with no free descriptor head or insufficient writable buffers **MUST** retain the command",
       "coverage": {
-        "status": "tracked",
+        "status": "mixed",
         "evidence": [
+          "crates/virtio-accel-transport/src/queue.rs",
           "docs/virtqueue.md"
         ],
         "issues": [
           "#19",
           "#20"
         ],
-        "rationale": "Backpressure semantics are specified and assigned to the guest and full-path implementations."
+        "rationale": "Publication ownership and retryable backpressure types are executable; guest behavior and full-path tests remain tracked."
       }
     },
     {
@@ -2465,15 +2467,16 @@
       "keyword": "MUST NOT",
       "statement": "- It **MUST NOT** publish a partial command or reuse descriptors still owned by the device.",
       "coverage": {
-        "status": "tracked",
+        "status": "mixed",
         "evidence": [
+          "crates/virtio-accel-transport/src/queue.rs",
           "docs/virtqueue.md"
         ],
         "issues": [
           "#19",
           "#20"
         ],
-        "rationale": "Backpressure semantics are specified and assigned to the guest and full-path implementations."
+        "rationale": "Publication ownership and retryable backpressure types are executable; guest behavior and full-path tests remain tracked."
       }
     },
     {
@@ -2503,8 +2506,10 @@
       "keyword": "MUST NOT",
       "statement": "the base Virtio reset rule. It **MUST NOT** expect response bytes or used entries for those chains.",
       "coverage": {
-        "status": "tracked",
+        "status": "mixed",
         "evidence": [
+          "crates/virtio-accel-transport/src/queue.rs",
+          "crates/virtio-accel-device/src/engine.rs",
           "docs/virtqueue.md"
         ],
         "issues": [
@@ -2512,7 +2517,7 @@
           "#19",
           "#20"
         ],
-        "rationale": "Reset cases are stable, while descriptor reclamation and late-completion exclusion require full implementations."
+        "rationale": "Reset epochs, consuming completion, reclamation ownership, and engine reset are executable; concrete ring and full-path reset remain tracked."
       }
     },
     {

--- a/crates/virtio-accel-device/Cargo.toml
+++ b/crates/virtio-accel-device/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 [dependencies]
 virtio-accel-core.workspace = true
 virtio-accel-proto.workspace = true
+virtio-accel-transport.workspace = true
 zerocopy.workspace = true
 
 [dev-dependencies]

--- a/crates/virtio-accel-device/src/frame.rs
+++ b/crates/virtio-accel-device/src/frame.rs
@@ -60,7 +60,7 @@ pub fn preflight_command_frame<'a>(
             return Ok(FramePreflight::Unusable(UnusableFrame::ChainLayout(error)));
         }
     };
-    if let Err(error) = layout.validate_ports(request, response) {
+    if let Err(error) = layout.validate_port_lengths(request.len(), response.len()) {
         return Ok(FramePreflight::Unusable(UnusableFrame::ChainLayout(error)));
     }
 

--- a/crates/virtio-accel-device/src/regions.rs
+++ b/crates/virtio-accel-device/src/regions.rs
@@ -1,146 +1,14 @@
-//! Transport-neutral descriptor metadata and segmented byte ports.
+//! Segmented byte ports over transport-neutral descriptor metadata.
 //!
-//! Layout validation is allocation-free and visits each descriptor once. Each segmented port
-//! access scans at most the segment list and copies only the requested range; constructors reject
-//! empty, zero-length, and overflowing segment collections.
+//! Each segmented port access scans at most the segment list and copies only the requested range;
+//! constructors reject empty, zero-length, and overflowing segment collections.
 
 use core::cmp::min;
 
 use virtio_accel_core::{BackendError, ByteSink, ByteSource};
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum RegionDirection {
-    DeviceReadable,
-    DeviceWritable,
-}
-
-/// Direction and length of one flattened chain region, without any transport identity or address.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct ChainRegion {
-    pub direction: RegionDirection,
-    pub bytes: u64,
-}
-
-impl ChainRegion {
-    pub const fn readable(bytes: u64) -> Self {
-        Self {
-            direction: RegionDirection::DeviceReadable,
-            bytes,
-        }
-    }
-
-    pub const fn writable(bytes: u64) -> Self {
-        Self {
-            direction: RegionDirection::DeviceWritable,
-            bytes,
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum ChainLayoutError {
-    DescriptorCount,
-    ZeroLength,
-    Direction,
-    LengthOverflow,
-    PortLengthMismatch,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct ChainLayout {
-    descriptor_count: u16,
-    readable_descriptors: u16,
-    writable_descriptors: u16,
-    readable_bytes: u64,
-    writable_bytes: u64,
-}
-
-impl ChainLayout {
-    pub const fn descriptor_count(self) -> u16 {
-        self.descriptor_count
-    }
-
-    pub const fn readable_descriptors(self) -> u16 {
-        self.readable_descriptors
-    }
-
-    pub const fn writable_descriptors(self) -> u16 {
-        self.writable_descriptors
-    }
-
-    pub const fn readable_bytes(self) -> u64 {
-        self.readable_bytes
-    }
-
-    pub const fn writable_bytes(self) -> u64 {
-        self.writable_bytes
-    }
-
-    pub fn validate_ports(
-        self,
-        request: &dyn ByteSource,
-        response: &dyn ByteSink,
-    ) -> Result<(), ChainLayoutError> {
-        if request.len() != self.readable_bytes || response.len() != self.writable_bytes {
-            return Err(ChainLayoutError::PortLengthMismatch);
-        }
-        Ok(())
-    }
-}
-
-/// Validate transport-neutral descriptor metadata before any frame bytes are decoded.
-///
-/// The descriptors contain only direction and length. Guest addresses, queue indices, and mapping
-/// details remain owned by the transport adapter.
-pub fn validate_chain_layout(
-    regions: &[ChainRegion],
-    max_descriptors: u16,
-) -> Result<ChainLayout, ChainLayoutError> {
-    if regions.len() < 2 || regions.len() > usize::from(max_descriptors) {
-        return Err(ChainLayoutError::DescriptorCount);
-    }
-
-    let mut readable_descriptors = 0_u16;
-    let mut writable_descriptors = 0_u16;
-    let mut readable_bytes = 0_u64;
-    let mut writable_bytes = 0_u64;
-    let mut saw_writable = false;
-
-    for region in regions {
-        if region.bytes == 0 {
-            return Err(ChainLayoutError::ZeroLength);
-        }
-        match region.direction {
-            RegionDirection::DeviceReadable => {
-                if saw_writable {
-                    return Err(ChainLayoutError::Direction);
-                }
-                readable_descriptors += 1;
-                readable_bytes = readable_bytes
-                    .checked_add(region.bytes)
-                    .ok_or(ChainLayoutError::LengthOverflow)?;
-            }
-            RegionDirection::DeviceWritable => {
-                saw_writable = true;
-                writable_descriptors += 1;
-                writable_bytes = writable_bytes
-                    .checked_add(region.bytes)
-                    .ok_or(ChainLayoutError::LengthOverflow)?;
-            }
-        }
-    }
-
-    if readable_descriptors == 0 || writable_descriptors == 0 {
-        return Err(ChainLayoutError::Direction);
-    }
-    Ok(ChainLayout {
-        descriptor_count: regions.len() as u16,
-        readable_descriptors,
-        writable_descriptors,
-        readable_bytes,
-        writable_bytes,
-    })
-}
+pub use virtio_accel_transport::{
+    ChainLayout, ChainLayoutError, ChainRegion, RegionDirection, validate_chain_layout,
+};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SegmentedRegionError {
@@ -370,50 +238,6 @@ fn checked_range_u64(offset: u64, bytes: u64, len: u64) -> Result<(), BackendErr
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn chain_layout_rejects_direction_and_length_errors() {
-        assert_eq!(
-            validate_chain_layout(&[ChainRegion::readable(16)], 8),
-            Err(ChainLayoutError::DescriptorCount)
-        );
-        assert_eq!(
-            validate_chain_layout(
-                &[
-                    ChainRegion::readable(16),
-                    ChainRegion::writable(16),
-                    ChainRegion::readable(1),
-                ],
-                8,
-            ),
-            Err(ChainLayoutError::Direction)
-        );
-        assert_eq!(
-            validate_chain_layout(&[ChainRegion::readable(0), ChainRegion::writable(16),], 8,),
-            Err(ChainLayoutError::ZeroLength)
-        );
-        assert_eq!(
-            validate_chain_layout(
-                &[
-                    ChainRegion::readable(u64::MAX),
-                    ChainRegion::readable(1),
-                    ChainRegion::writable(16),
-                ],
-                8,
-            ),
-            Err(ChainLayoutError::LengthOverflow)
-        );
-
-        let layout =
-            validate_chain_layout(&[ChainRegion::readable(16), ChainRegion::writable(16)], 8)
-                .unwrap();
-        let request = [0_u8; 15];
-        let response = [0_u8; 16];
-        assert_eq!(
-            layout.validate_ports(&request, &response),
-            Err(ChainLayoutError::PortLengthMismatch)
-        );
-    }
 
     #[test]
     fn segmented_ports_cross_every_boundary() {

--- a/crates/virtio-accel-transport/Cargo.toml
+++ b/crates/virtio-accel-transport/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "virtio-accel-transport"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+description = "Portable descriptor-chain and virtqueue port contracts"
+publish = false
+
+[dependencies]

--- a/crates/virtio-accel-transport/src/lib.rs
+++ b/crates/virtio-accel-transport/src/lib.rs
@@ -1,0 +1,20 @@
+//! Portable descriptor-chain, queue, and notification contracts.
+//!
+//! This crate owns no guest addresses, mappings, ring layout, threads, or global runtime. Concrete
+//! transports retain those details and expose only validated chain metadata plus owned queue tokens.
+
+#![no_std]
+#![forbid(unsafe_code)]
+
+mod queue;
+mod regions;
+
+pub use queue::{
+    ChainError, ChainId, ChainIo, ChainIoResult, DeviceChain, DeviceQueue, DriverQueue,
+    MAX_SPLIT_QUEUE_SIZE, MalformedChain, NotificationHint, NotificationRecheck, PublishError,
+    PublishErrorKind, PublishedChain, QueueConfigError, QueueControl, QueueEpoch, QueueError,
+    QueuePort, QueueSize, QueueState, ReclaimedChain, UsedChain, UsedLength,
+};
+pub use regions::{
+    ChainLayout, ChainLayoutError, ChainRegion, RegionDirection, validate_chain_layout,
+};

--- a/crates/virtio-accel-transport/src/queue.rs
+++ b/crates/virtio-accel-transport/src/queue.rs
@@ -1,0 +1,925 @@
+//! Ownership-safe virtqueue lifecycle and notification ports.
+
+use core::num::{NonZeroU16, NonZeroU64};
+
+use crate::{ChainLayoutError, ChainRegion};
+
+/// Maximum queue size permitted by the split-ring index representation.
+pub const MAX_SPLIT_QUEUE_SIZE: u16 = 32_768;
+
+/// Valid nonzero, power-of-two split-virtqueue size.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
+pub struct QueueSize(NonZeroU16);
+
+impl QueueSize {
+    /// Validate a split-virtqueue size.
+    pub const fn new(value: u16) -> Option<Self> {
+        if value.is_power_of_two() && value <= MAX_SPLIT_QUEUE_SIZE {
+            match NonZeroU16::new(value) {
+                Some(value) => Some(Self(value)),
+                None => None,
+            }
+        } else {
+            None
+        }
+    }
+
+    /// Return the validated queue size.
+    pub const fn get(self) -> u16 {
+        self.0.get()
+    }
+}
+
+/// Monotonic queue-reset epoch used to reject stale chain operations.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
+pub struct QueueEpoch(NonZeroU64);
+
+impl QueueEpoch {
+    /// Initial epoch for a newly constructed queue.
+    pub const INITIAL: Self = match NonZeroU64::new(1) {
+        Some(value) => Self(value),
+        None => panic!("one is nonzero"),
+    };
+
+    /// Construct a nonzero epoch.
+    pub const fn new(value: u64) -> Option<Self> {
+        match NonZeroU64::new(value) {
+            Some(value) => Some(Self(value)),
+            None => None,
+        }
+    }
+
+    /// Return the raw epoch value.
+    pub const fn get(self) -> u64 {
+        self.0.get()
+    }
+
+    /// Return the next epoch, or `None` if the epoch space is exhausted.
+    pub const fn checked_next(self) -> Option<Self> {
+        match self.get().checked_add(1) {
+            Some(value) => Self::new(value),
+            None => None,
+        }
+    }
+}
+
+/// Opaque queue-chain identity scoped to one reset epoch.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct ChainId {
+    epoch: QueueEpoch,
+    token: u64,
+}
+
+impl ChainId {
+    /// Construct an identity from an epoch and transport-owned token.
+    pub const fn new(epoch: QueueEpoch, token: u64) -> Self {
+        Self { epoch, token }
+    }
+
+    /// Epoch in which this chain was published.
+    pub const fn epoch(self) -> QueueEpoch {
+        self.epoch
+    }
+
+    /// Opaque transport token, such as a split-ring descriptor head.
+    pub const fn token(self) -> u64 {
+        self.token
+    }
+}
+
+/// Exact number of device-written bytes published with a used chain.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
+pub struct UsedLength(u32);
+
+impl UsedLength {
+    /// Construct an exact used length.
+    pub const fn new(bytes: u32) -> Self {
+        Self(bytes)
+    }
+
+    /// Return the used byte count.
+    pub const fn get(self) -> u32 {
+        self.0
+    }
+}
+
+/// Validated queue configuration and lifecycle snapshot.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct QueueState {
+    max_size: QueueSize,
+    size: Option<QueueSize>,
+    ready: bool,
+    epoch: QueueEpoch,
+}
+
+impl QueueState {
+    /// Construct an unconfigured queue state.
+    pub const fn unconfigured(max_size: QueueSize, epoch: QueueEpoch) -> Self {
+        Self {
+            max_size,
+            size: None,
+            ready: false,
+            epoch,
+        }
+    }
+
+    /// Construct and validate a queue-state snapshot.
+    pub const fn new(
+        max_size: QueueSize,
+        size: Option<QueueSize>,
+        ready: bool,
+        epoch: QueueEpoch,
+    ) -> Result<Self, QueueConfigError> {
+        if let Some(size) = size {
+            if size.get() > max_size.get() {
+                return Err(QueueConfigError::SizeExceedsMaximum);
+            }
+        }
+        if ready && size.is_none() {
+            return Err(QueueConfigError::ReadyWithoutSize);
+        }
+        Ok(Self {
+            max_size,
+            size,
+            ready,
+            epoch,
+        })
+    }
+
+    /// Maximum queue size supported by the implementation.
+    pub const fn max_size(self) -> QueueSize {
+        self.max_size
+    }
+
+    /// Configured queue size, if any.
+    pub const fn size(self) -> Option<QueueSize> {
+        self.size
+    }
+
+    /// Whether descriptor publication and consumption are enabled.
+    pub const fn ready(self) -> bool {
+        self.ready
+    }
+
+    /// Current reset epoch.
+    pub const fn epoch(self) -> QueueEpoch {
+        self.epoch
+    }
+}
+
+/// Invalid queue configuration.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum QueueConfigError {
+    /// The configured queue size exceeds the implementation maximum.
+    SizeExceedsMaximum,
+    /// A queue cannot become ready before a size is configured.
+    ReadyWithoutSize,
+    /// A reset attempted to reuse or move backwards from the current epoch.
+    NonIncreasingEpoch,
+}
+
+/// Portable queue operation failure.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum QueueError<E> {
+    /// The queue is not configured and ready for the requested operation.
+    NotReady,
+    /// The queue configuration is invalid.
+    InvalidConfiguration(QueueConfigError),
+    /// An operation belongs to a different reset epoch.
+    ResetRace {
+        /// Epoch carried by the operation.
+        operation: QueueEpoch,
+        /// Current queue epoch.
+        current: QueueEpoch,
+    },
+    /// Completion used length exceeds writable chain capacity.
+    UsedLengthExceeded {
+        /// Attempted used length.
+        used: UsedLength,
+        /// Writable capacity of the consumed chain.
+        capacity: u64,
+    },
+    /// Concrete transport failure.
+    Transport(E),
+}
+
+/// Structurally malformed descriptor-chain classification.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MalformedChain {
+    /// A descriptor chain contains a loop.
+    DescriptorLoop,
+    /// A descriptor index is outside the configured queue.
+    DescriptorIndex,
+    /// The flattened descriptor count is invalid.
+    DescriptorCount,
+    /// A descriptor has zero length.
+    ZeroLength,
+    /// Readable and writable descriptor ordering is invalid.
+    Direction,
+    /// Descriptor byte totals overflow.
+    LengthOverflow,
+    /// Mapped byte ports do not match descriptor byte totals.
+    PortLengthMismatch,
+    /// An indirect descriptor was offered without negotiation.
+    IndirectUnsupported,
+    /// An indirect descriptor table is structurally invalid.
+    IndirectMalformed,
+    /// A descriptor range cannot be mapped for the required access.
+    Address,
+}
+
+impl From<ChainLayoutError> for MalformedChain {
+    fn from(error: ChainLayoutError) -> Self {
+        match error {
+            ChainLayoutError::DescriptorCount => Self::DescriptorCount,
+            ChainLayoutError::ZeroLength => Self::ZeroLength,
+            ChainLayoutError::Direction => Self::Direction,
+            ChainLayoutError::LengthOverflow => Self::LengthOverflow,
+            ChainLayoutError::PortLengthMismatch => Self::PortLengthMismatch,
+        }
+    }
+}
+
+/// Failure to expose one consumed chain as validated byte ports.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ChainError<E> {
+    /// The chain is malformed and should be completed with used length zero when recoverable.
+    Malformed(MalformedChain),
+    /// Reset invalidated this chain before byte access.
+    ResetRace {
+        /// Epoch carried by the chain.
+        chain: QueueEpoch,
+        /// Current queue epoch.
+        current: QueueEpoch,
+    },
+    /// Concrete transport or memory-access failure.
+    Transport(E),
+}
+
+/// Borrowed regions and byte ports for one consumed device chain.
+///
+/// The source and sink types remain generic so this crate does not depend on command semantics or a
+/// particular guest-memory library.
+#[derive(Debug)]
+pub struct ChainIo<'a, R: ?Sized, W: ?Sized> {
+    regions: &'a [ChainRegion],
+    request: &'a R,
+    response: &'a mut W,
+}
+
+impl<'a, R: ?Sized, W: ?Sized> ChainIo<'a, R, W> {
+    /// Construct a borrowed chain view after topology and mapping validation.
+    pub fn new(regions: &'a [ChainRegion], request: &'a R, response: &'a mut W) -> Self {
+        Self {
+            regions,
+            request,
+            response,
+        }
+    }
+
+    /// Consume the view into its region metadata, readable port, and writable port.
+    pub fn into_parts(self) -> (&'a [ChainRegion], &'a R, &'a mut W) {
+        (self.regions, self.request, self.response)
+    }
+}
+
+/// Result of exposing one consumed chain as mapped byte ports.
+pub type ChainIoResult<'a, R, W, E> = Result<ChainIo<'a, R, W>, ChainError<E>>;
+
+/// Consumed device-side descriptor chain.
+///
+/// Implementations must keep the mapped bytes alive until this value is consumed by
+/// [`DeviceQueue::complete`] or dropped during reset. The value must not be `Copy`; consuming it at
+/// completion makes double completion impossible in safe implementations.
+pub trait DeviceChain {
+    /// Device-readable byte-port type.
+    type Request: ?Sized;
+    /// Device-writable byte-port type.
+    type Response: ?Sized;
+    /// Concrete transport or memory-access error.
+    type Error;
+
+    /// Return this chain's reset-scoped identity.
+    ///
+    /// This operation must not block or allocate.
+    fn id(&self) -> ChainId;
+
+    /// Expose mapped request and response ports.
+    ///
+    /// This operation must not block or allocate. A reset-race result must expose no guest bytes.
+    fn io(&mut self) -> ChainIoResult<'_, Self::Request, Self::Response, Self::Error>;
+}
+
+/// Whether the peer should be notified after a publication operation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum NotificationHint {
+    /// Notification is suppressed by current queue state.
+    Suppressed,
+    /// The peer should be notified after the publication barrier.
+    Notify,
+}
+
+/// Result of atomically enabling notifications and rechecking queue state.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum NotificationRecheck {
+    /// No work appeared before notification enablement became visible.
+    Idle,
+    /// Work is already pending and must be processed without sleeping.
+    WorkPending,
+}
+
+/// Read-only state shared by driver, device, and configuration ports.
+pub trait QueuePort {
+    /// Return a coherent queue-state snapshot.
+    ///
+    /// This operation must not block or allocate. Implementations using shared state must use
+    /// acquire ordering sufficient to observe the corresponding configuration and reset writes.
+    fn state(&self) -> QueueState;
+}
+
+/// Queue configuration control plane.
+pub trait QueueControl: QueuePort {
+    /// Concrete transport configuration error.
+    type Error;
+
+    /// Configure queue size while the queue is not ready.
+    ///
+    /// This operation must not block. It may allocate storage bounded by `size`; implementations
+    /// must report allocation failure through `Error` without changing the prior configuration.
+    fn configure(&mut self, size: QueueSize) -> Result<(), QueueError<Self::Error>>;
+
+    /// Enable or disable queue descriptor processing.
+    ///
+    /// This operation must not block or allocate. Making the queue ready is a release boundary for
+    /// the configured queue state.
+    fn set_ready(&mut self, ready: bool) -> Result<(), QueueError<Self::Error>>;
+}
+
+/// Successful driver publication.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PublishedChain {
+    id: ChainId,
+    notification: NotificationHint,
+}
+
+impl PublishedChain {
+    /// Construct a publication result.
+    pub const fn new(id: ChainId, notification: NotificationHint) -> Self {
+        Self { id, notification }
+    }
+
+    /// Published chain identity.
+    pub const fn id(self) -> ChainId {
+        self.id
+    }
+
+    /// Notification decision made after publishing the available index.
+    pub const fn notification(self) -> NotificationHint {
+        self.notification
+    }
+}
+
+/// Pre-publication failure classification.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PublishErrorKind<E> {
+    /// The queue is not configured and ready.
+    NotReady,
+    /// No free descriptor head or available-ring slot exists.
+    QueueFull,
+    /// The supplied command lacks enough descriptors or writable capacity.
+    InsufficientDescriptors,
+    /// Reset invalidated publication before ownership could transfer.
+    ResetRace {
+        /// Epoch in which publication began.
+        operation: QueueEpoch,
+        /// Current queue epoch.
+        current: QueueEpoch,
+    },
+    /// Concrete transport failure before ownership transfer.
+    Transport(E),
+}
+
+/// Failed driver publication that returns the unpublished chain for retry or reclamation.
+#[derive(Debug, PartialEq, Eq)]
+pub struct PublishError<C, E> {
+    chain: C,
+    kind: PublishErrorKind<E>,
+}
+
+impl<C, E> PublishError<C, E> {
+    /// Construct a publication failure that retains caller ownership.
+    pub const fn new(chain: C, kind: PublishErrorKind<E>) -> Self {
+        Self { chain, kind }
+    }
+
+    /// Borrow the unpublished chain.
+    pub const fn chain(&self) -> &C {
+        &self.chain
+    }
+
+    /// Borrow the failure classification.
+    pub const fn kind(&self) -> &PublishErrorKind<E> {
+        &self.kind
+    }
+
+    /// Recover the unpublished chain and failure classification.
+    pub fn into_parts(self) -> (C, PublishErrorKind<E>) {
+        (self.chain, self.kind)
+    }
+}
+
+/// Driver-owned chain returned by used-ring consumption.
+#[derive(Debug, PartialEq, Eq)]
+pub struct UsedChain<C> {
+    id: ChainId,
+    used: UsedLength,
+    chain: C,
+}
+
+impl<C> UsedChain<C> {
+    /// Construct a used-chain result.
+    pub const fn new(id: ChainId, used: UsedLength, chain: C) -> Self {
+        Self { id, used, chain }
+    }
+
+    /// Returned chain identity.
+    pub const fn id(&self) -> ChainId {
+        self.id
+    }
+
+    /// Exact number of bytes written by the device.
+    pub const fn used(&self) -> UsedLength {
+        self.used
+    }
+
+    /// Borrow the returned driver chain.
+    pub const fn chain(&self) -> &C {
+        &self.chain
+    }
+
+    /// Recover the identity, used length, and driver chain.
+    pub fn into_parts(self) -> (ChainId, UsedLength, C) {
+        (self.id, self.used, self.chain)
+    }
+}
+
+/// Published driver chain reclaimed during reset without a used entry.
+#[derive(Debug, PartialEq, Eq)]
+pub struct ReclaimedChain<C> {
+    id: ChainId,
+    chain: C,
+}
+
+impl<C> ReclaimedChain<C> {
+    /// Construct a reset-reclamation result.
+    pub const fn new(id: ChainId, chain: C) -> Self {
+        Self { id, chain }
+    }
+
+    /// Reclaimed chain identity.
+    pub const fn id(&self) -> ChainId {
+        self.id
+    }
+
+    /// Recover the identity and driver chain.
+    pub fn into_parts(self) -> (ChainId, C) {
+        (self.id, self.chain)
+    }
+}
+
+/// Driver-side descriptor publication and used-ring consumption.
+///
+/// A successful [`DriverQueue::publish`] transfers exclusive chain ownership to the queue until
+/// [`DriverQueue::pop_used`] or [`DriverQueue::reset`] returns it. Implementations must publish all
+/// descriptor contents and the available index before returning a notification decision. A
+/// successful used pop is an acquire boundary for response bytes written before device completion.
+pub trait DriverQueue: QueuePort {
+    /// Driver-owned command and descriptor resources.
+    type Chain;
+    /// Owned collection of chains reclaimed by reset.
+    type Reclaimed: IntoIterator<Item = ReclaimedChain<Self::Chain>>;
+    /// Concrete transport failure.
+    type Error;
+
+    /// Publish a complete chain or return it unchanged on pre-publication backpressure.
+    ///
+    /// This operation must not block or allocate. Success is a release boundary for descriptor and
+    /// request writes. Failure must not transfer ownership or expose a partial chain to the device.
+    fn publish(
+        &mut self,
+        chain: Self::Chain,
+    ) -> Result<PublishedChain, PublishError<Self::Chain, Self::Error>>;
+
+    /// Consume one used entry and recover the corresponding driver chain.
+    ///
+    /// This operation must not block or allocate. It is an acquire boundary for the used entry and
+    /// response bytes. Independent completions may be returned out of publication order.
+    fn pop_used(&mut self) -> Result<Option<UsedChain<Self::Chain>>, QueueError<Self::Error>>;
+
+    /// Disable used-ring notifications before draining completions.
+    ///
+    /// This operation must not block or allocate.
+    fn disable_used_notifications(&mut self) -> Result<(), QueueError<Self::Error>>;
+
+    /// Enable used-ring notifications and atomically recheck for missed completions.
+    ///
+    /// This operation must not block or allocate. `WorkPending` requires the caller to continue
+    /// draining rather than sleep.
+    fn enable_used_notifications(&mut self)
+    -> Result<NotificationRecheck, QueueError<Self::Error>>;
+
+    /// Invalidate the old epoch and recover every chain still owned by the queue.
+    ///
+    /// This operation must not block or allocate. It may move existing queue-owned storage into the
+    /// returned collection. `next_epoch` must be greater than the current epoch. No old used entry
+    /// or response write may become visible after success.
+    fn reset(&mut self, next_epoch: QueueEpoch)
+    -> Result<Self::Reclaimed, QueueError<Self::Error>>;
+}
+
+/// Device-side available-ring consumption and completion publication.
+///
+/// A successful [`DeviceQueue::pop_available`] acquires request and descriptor writes made before
+/// driver publication. [`DeviceQueue::complete`] consumes the chain, publishes response bytes and
+/// the used index with release ordering, and only then returns a notification decision.
+pub trait DeviceQueue: QueuePort {
+    /// Owned consumed-chain type.
+    type Chain: DeviceChain;
+    /// Concrete transport failure.
+    type Error;
+
+    /// Consume one available descriptor chain.
+    ///
+    /// This operation must not block or allocate. Chains are returned in available-ring order.
+    fn pop_available(&mut self) -> Result<Option<Self::Chain>, QueueError<Self::Error>>;
+
+    /// Publish one chain completion and consume its ownership token.
+    ///
+    /// This operation must not block or allocate. It must reject a stale epoch without writing
+    /// guest bytes, a used entry, or a notification. `used` must not exceed writable capacity.
+    fn complete(
+        &mut self,
+        chain: Self::Chain,
+        used: UsedLength,
+    ) -> Result<NotificationHint, QueueError<Self::Error>>;
+
+    /// Disable available-ring notifications before draining work.
+    ///
+    /// This operation must not block or allocate.
+    fn disable_available_notifications(&mut self) -> Result<(), QueueError<Self::Error>>;
+
+    /// Enable available-ring notifications and atomically recheck for missed work.
+    ///
+    /// This operation must not block or allocate. `WorkPending` requires the caller to continue
+    /// draining rather than sleep.
+    fn enable_available_notifications(
+        &mut self,
+    ) -> Result<NotificationRecheck, QueueError<Self::Error>>;
+
+    /// Invalidate all consumed chains from the old epoch and return the queue to its base state.
+    ///
+    /// This operation must not block or allocate. `next_epoch` must be greater than the current
+    /// epoch. No later completion from the old epoch may write guest memory or publish a used entry.
+    fn reset(&mut self, next_epoch: QueueEpoch) -> Result<(), QueueError<Self::Error>>;
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use std::collections::VecDeque;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::vec::Vec;
+
+    use super::*;
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct TestPayload {
+        request: [u8; 4],
+        response: [u8; 4],
+    }
+
+    #[derive(Debug)]
+    struct TestDeviceChain {
+        id: ChainId,
+        current_epoch: Arc<AtomicU64>,
+        payload: TestPayload,
+    }
+
+    impl DeviceChain for TestDeviceChain {
+        type Request = [u8; 4];
+        type Response = [u8; 4];
+        type Error = ();
+
+        fn id(&self) -> ChainId {
+            self.id
+        }
+
+        fn io(
+            &mut self,
+        ) -> Result<ChainIo<'_, Self::Request, Self::Response>, ChainError<Self::Error>> {
+            let current = QueueEpoch::new(self.current_epoch.load(Ordering::Acquire)).unwrap();
+            if current != self.id.epoch() {
+                return Err(ChainError::ResetRace {
+                    chain: self.id.epoch(),
+                    current,
+                });
+            }
+            static REGIONS: [ChainRegion; 2] = [ChainRegion::readable(4), ChainRegion::writable(4)];
+            Ok(ChainIo::new(
+                &REGIONS,
+                &self.payload.request,
+                &mut self.payload.response,
+            ))
+        }
+    }
+
+    struct TestQueue {
+        state: QueueState,
+        current_epoch: Arc<AtomicU64>,
+        next_token: u64,
+        available: VecDeque<(ChainId, TestPayload)>,
+        used: VecDeque<UsedChain<TestPayload>>,
+    }
+
+    impl TestQueue {
+        fn new() -> Self {
+            let epoch = QueueEpoch::INITIAL;
+            Self {
+                state: QueueState::unconfigured(QueueSize::new(8).unwrap(), epoch),
+                current_epoch: Arc::new(AtomicU64::new(epoch.get())),
+                next_token: 0,
+                available: VecDeque::new(),
+                used: VecDeque::new(),
+            }
+        }
+
+        fn check_ready(&self) -> Result<(), QueueError<()>> {
+            if self.state.ready() {
+                Ok(())
+            } else {
+                Err(QueueError::NotReady)
+            }
+        }
+
+        fn advance_epoch(&mut self, next_epoch: QueueEpoch) -> Result<(), QueueError<()>> {
+            if next_epoch <= self.state.epoch() {
+                return Err(QueueError::InvalidConfiguration(
+                    QueueConfigError::NonIncreasingEpoch,
+                ));
+            }
+            self.state = QueueState::unconfigured(self.state.max_size(), next_epoch);
+            self.current_epoch
+                .store(next_epoch.get(), Ordering::Release);
+            Ok(())
+        }
+    }
+
+    impl QueuePort for TestQueue {
+        fn state(&self) -> QueueState {
+            self.state
+        }
+    }
+
+    impl QueueControl for TestQueue {
+        type Error = ();
+
+        fn configure(&mut self, size: QueueSize) -> Result<(), QueueError<Self::Error>> {
+            if self.state.ready() || size > self.state.max_size() {
+                return Err(QueueError::InvalidConfiguration(
+                    QueueConfigError::SizeExceedsMaximum,
+                ));
+            }
+            self.state =
+                QueueState::new(self.state.max_size(), Some(size), false, self.state.epoch())
+                    .unwrap();
+            Ok(())
+        }
+
+        fn set_ready(&mut self, ready: bool) -> Result<(), QueueError<Self::Error>> {
+            self.state = QueueState::new(
+                self.state.max_size(),
+                self.state.size(),
+                ready,
+                self.state.epoch(),
+            )
+            .map_err(QueueError::InvalidConfiguration)?;
+            Ok(())
+        }
+    }
+
+    impl DriverQueue for TestQueue {
+        type Chain = TestPayload;
+        type Reclaimed = Vec<ReclaimedChain<Self::Chain>>;
+        type Error = ();
+
+        fn publish(
+            &mut self,
+            chain: Self::Chain,
+        ) -> Result<PublishedChain, PublishError<Self::Chain, Self::Error>> {
+            if !self.state.ready() {
+                return Err(PublishError::new(chain, PublishErrorKind::NotReady));
+            }
+            if self.available.len() >= usize::from(self.state.size().unwrap().get()) {
+                return Err(PublishError::new(chain, PublishErrorKind::QueueFull));
+            }
+            let id = ChainId::new(self.state.epoch(), self.next_token);
+            self.next_token += 1;
+            self.available.push_back((id, chain));
+            Ok(PublishedChain::new(id, NotificationHint::Notify))
+        }
+
+        fn pop_used(&mut self) -> Result<Option<UsedChain<Self::Chain>>, QueueError<Self::Error>> {
+            self.check_ready()?;
+            Ok(self.used.pop_front())
+        }
+
+        fn disable_used_notifications(&mut self) -> Result<(), QueueError<Self::Error>> {
+            self.check_ready()
+        }
+
+        fn enable_used_notifications(
+            &mut self,
+        ) -> Result<NotificationRecheck, QueueError<Self::Error>> {
+            self.check_ready()?;
+            Ok(if self.used.is_empty() {
+                NotificationRecheck::Idle
+            } else {
+                NotificationRecheck::WorkPending
+            })
+        }
+
+        fn reset(
+            &mut self,
+            next_epoch: QueueEpoch,
+        ) -> Result<Self::Reclaimed, QueueError<Self::Error>> {
+            self.advance_epoch(next_epoch)?;
+            let reclaimed = self
+                .available
+                .drain(..)
+                .map(|(id, chain)| ReclaimedChain::new(id, chain))
+                .collect();
+            self.used.clear();
+            Ok(reclaimed)
+        }
+    }
+
+    impl DeviceQueue for TestQueue {
+        type Chain = TestDeviceChain;
+        type Error = ();
+
+        fn pop_available(&mut self) -> Result<Option<Self::Chain>, QueueError<Self::Error>> {
+            self.check_ready()?;
+            Ok(self
+                .available
+                .pop_front()
+                .map(|(id, payload)| TestDeviceChain {
+                    id,
+                    current_epoch: Arc::clone(&self.current_epoch),
+                    payload,
+                }))
+        }
+
+        fn complete(
+            &mut self,
+            chain: Self::Chain,
+            used: UsedLength,
+        ) -> Result<NotificationHint, QueueError<Self::Error>> {
+            if chain.id.epoch() != self.state.epoch() {
+                return Err(QueueError::ResetRace {
+                    operation: chain.id.epoch(),
+                    current: self.state.epoch(),
+                });
+            }
+            if u64::from(used.get()) > chain.payload.response.len() as u64 {
+                return Err(QueueError::UsedLengthExceeded {
+                    used,
+                    capacity: chain.payload.response.len() as u64,
+                });
+            }
+            self.used
+                .push_back(UsedChain::new(chain.id, used, chain.payload));
+            Ok(NotificationHint::Notify)
+        }
+
+        fn disable_available_notifications(&mut self) -> Result<(), QueueError<Self::Error>> {
+            self.check_ready()
+        }
+
+        fn enable_available_notifications(
+            &mut self,
+        ) -> Result<NotificationRecheck, QueueError<Self::Error>> {
+            self.check_ready()?;
+            Ok(if self.available.is_empty() {
+                NotificationRecheck::Idle
+            } else {
+                NotificationRecheck::WorkPending
+            })
+        }
+
+        fn reset(&mut self, next_epoch: QueueEpoch) -> Result<(), QueueError<Self::Error>> {
+            self.advance_epoch(next_epoch)?;
+            self.available.clear();
+            self.used.clear();
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn queue_sizes_and_states_are_validated() {
+        assert_eq!(QueueSize::new(0), None);
+        assert_eq!(QueueSize::new(3), None);
+        assert_eq!(QueueSize::new(MAX_SPLIT_QUEUE_SIZE + 1), None);
+
+        let max = QueueSize::new(8).unwrap();
+        let too_large = QueueSize::new(16).unwrap();
+        assert_eq!(
+            QueueState::new(max, Some(too_large), false, QueueEpoch::INITIAL),
+            Err(QueueConfigError::SizeExceedsMaximum)
+        );
+        assert_eq!(
+            QueueState::new(max, None, true, QueueEpoch::INITIAL),
+            Err(QueueConfigError::ReadyWithoutSize)
+        );
+    }
+
+    #[test]
+    fn publication_transfers_ownership_until_used() {
+        let mut queue = TestQueue::new();
+        QueueControl::configure(&mut queue, QueueSize::new(2).unwrap()).unwrap();
+        QueueControl::set_ready(&mut queue, true).unwrap();
+
+        let published = DriverQueue::publish(
+            &mut queue,
+            TestPayload {
+                request: *b"ping",
+                response: [0; 4],
+            },
+        )
+        .unwrap();
+        assert_eq!(published.notification(), NotificationHint::Notify);
+
+        let mut chain = DeviceQueue::pop_available(&mut queue).unwrap().unwrap();
+        assert_eq!(chain.id(), published.id());
+        let (regions, request, response) = chain.io().unwrap().into_parts();
+        assert_eq!(regions.len(), 2);
+        assert_eq!(request, b"ping");
+        response.copy_from_slice(b"pong");
+        DeviceQueue::complete(&mut queue, chain, UsedLength::new(4)).unwrap();
+
+        let used = DriverQueue::pop_used(&mut queue).unwrap().unwrap();
+        assert_eq!(used.id(), published.id());
+        assert_eq!(used.used(), UsedLength::new(4));
+        assert_eq!(used.chain().response, *b"pong");
+    }
+
+    #[test]
+    fn publication_backpressure_returns_the_chain() {
+        let mut queue = TestQueue::new();
+        let payload = TestPayload {
+            request: *b"ping",
+            response: [0; 4],
+        };
+        let error = DriverQueue::publish(&mut queue, payload).unwrap_err();
+        let (payload, kind) = error.into_parts();
+        assert_eq!(kind, PublishErrorKind::NotReady);
+        assert_eq!(payload.request, *b"ping");
+    }
+
+    #[test]
+    fn reset_epoch_rejects_late_completion() {
+        let mut queue = TestQueue::new();
+        QueueControl::configure(&mut queue, QueueSize::new(2).unwrap()).unwrap();
+        QueueControl::set_ready(&mut queue, true).unwrap();
+        DriverQueue::publish(
+            &mut queue,
+            TestPayload {
+                request: *b"ping",
+                response: [0; 4],
+            },
+        )
+        .unwrap();
+        let mut chain = DeviceQueue::pop_available(&mut queue).unwrap().unwrap();
+        let old_epoch = chain.id().epoch();
+        let next_epoch = old_epoch.checked_next().unwrap();
+
+        DeviceQueue::reset(&mut queue, next_epoch).unwrap();
+        assert!(matches!(
+            chain.io(),
+            Err(ChainError::ResetRace { chain, current })
+                if chain == old_epoch && current == next_epoch
+        ));
+        assert_eq!(
+            DeviceQueue::complete(&mut queue, chain, UsedLength::new(0)),
+            Err(QueueError::ResetRace {
+                operation: old_epoch,
+                current: next_epoch,
+            })
+        );
+        assert!(queue.used.is_empty());
+    }
+}

--- a/crates/virtio-accel-transport/src/regions.rs
+++ b/crates/virtio-accel-transport/src/regions.rs
@@ -1,0 +1,203 @@
+//! Transport-neutral flattened descriptor metadata.
+
+/// Direction of one flattened descriptor-backed byte region.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RegionDirection {
+    /// Bytes are readable by the device and contain request data.
+    DeviceReadable,
+    /// Bytes are writable by the device and contain response data.
+    DeviceWritable,
+}
+
+/// Direction and length of one flattened chain region, without an address or transport identity.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ChainRegion {
+    /// Direction in which the device may access this region.
+    pub direction: RegionDirection,
+    /// Nonzero region length in bytes.
+    pub bytes: u64,
+}
+
+impl ChainRegion {
+    /// Construct a device-readable region.
+    pub const fn readable(bytes: u64) -> Self {
+        Self {
+            direction: RegionDirection::DeviceReadable,
+            bytes,
+        }
+    }
+
+    /// Construct a device-writable region.
+    pub const fn writable(bytes: u64) -> Self {
+        Self {
+            direction: RegionDirection::DeviceWritable,
+            bytes,
+        }
+    }
+}
+
+/// Failure to validate the device-specific flattened chain layout.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ChainLayoutError {
+    /// The chain contains fewer than two or more than the configured maximum descriptors.
+    DescriptorCount,
+    /// A descriptor has zero length.
+    ZeroLength,
+    /// A readable descriptor follows a writable descriptor, or one direction is missing.
+    Direction,
+    /// A readable or writable byte total overflowed `u64`.
+    LengthOverflow,
+    /// The mapped byte ports do not exactly match the flattened descriptor totals.
+    PortLengthMismatch,
+}
+
+/// Validated counts and byte totals for one flattened descriptor chain.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ChainLayout {
+    descriptor_count: u16,
+    readable_descriptors: u16,
+    writable_descriptors: u16,
+    readable_bytes: u64,
+    writable_bytes: u64,
+}
+
+impl ChainLayout {
+    /// Total flattened descriptor count.
+    pub const fn descriptor_count(self) -> u16 {
+        self.descriptor_count
+    }
+
+    /// Number of device-readable descriptors.
+    pub const fn readable_descriptors(self) -> u16 {
+        self.readable_descriptors
+    }
+
+    /// Number of device-writable descriptors.
+    pub const fn writable_descriptors(self) -> u16 {
+        self.writable_descriptors
+    }
+
+    /// Total device-readable bytes.
+    pub const fn readable_bytes(self) -> u64 {
+        self.readable_bytes
+    }
+
+    /// Total device-writable bytes.
+    pub const fn writable_bytes(self) -> u64 {
+        self.writable_bytes
+    }
+
+    /// Validate mapped byte-port lengths against this layout.
+    pub const fn validate_port_lengths(
+        self,
+        request_bytes: u64,
+        response_bytes: u64,
+    ) -> Result<(), ChainLayoutError> {
+        if request_bytes != self.readable_bytes || response_bytes != self.writable_bytes {
+            return Err(ChainLayoutError::PortLengthMismatch);
+        }
+        Ok(())
+    }
+}
+
+/// Validate transport-neutral descriptor metadata before frame bytes are decoded.
+///
+/// This operation is nonblocking, performs no allocation, and visits each region once. Guest
+/// addresses, descriptor indices, and mapping details remain owned by the transport adapter.
+pub fn validate_chain_layout(
+    regions: &[ChainRegion],
+    max_descriptors: u16,
+) -> Result<ChainLayout, ChainLayoutError> {
+    if regions.len() < 2 || regions.len() > usize::from(max_descriptors) {
+        return Err(ChainLayoutError::DescriptorCount);
+    }
+
+    let mut readable_descriptors = 0_u16;
+    let mut writable_descriptors = 0_u16;
+    let mut readable_bytes = 0_u64;
+    let mut writable_bytes = 0_u64;
+    let mut saw_writable = false;
+
+    for region in regions {
+        if region.bytes == 0 {
+            return Err(ChainLayoutError::ZeroLength);
+        }
+        match region.direction {
+            RegionDirection::DeviceReadable => {
+                if saw_writable {
+                    return Err(ChainLayoutError::Direction);
+                }
+                readable_descriptors += 1;
+                readable_bytes = readable_bytes
+                    .checked_add(region.bytes)
+                    .ok_or(ChainLayoutError::LengthOverflow)?;
+            }
+            RegionDirection::DeviceWritable => {
+                saw_writable = true;
+                writable_descriptors += 1;
+                writable_bytes = writable_bytes
+                    .checked_add(region.bytes)
+                    .ok_or(ChainLayoutError::LengthOverflow)?;
+            }
+        }
+    }
+
+    if readable_descriptors == 0 || writable_descriptors == 0 {
+        return Err(ChainLayoutError::Direction);
+    }
+
+    Ok(ChainLayout {
+        descriptor_count: regions.len() as u16,
+        readable_descriptors,
+        writable_descriptors,
+        readable_bytes,
+        writable_bytes,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chain_layout_rejects_direction_and_length_errors() {
+        assert_eq!(
+            validate_chain_layout(&[ChainRegion::readable(16)], 8),
+            Err(ChainLayoutError::DescriptorCount)
+        );
+        assert_eq!(
+            validate_chain_layout(
+                &[
+                    ChainRegion::readable(16),
+                    ChainRegion::writable(16),
+                    ChainRegion::readable(1),
+                ],
+                8,
+            ),
+            Err(ChainLayoutError::Direction)
+        );
+        assert_eq!(
+            validate_chain_layout(&[ChainRegion::readable(0), ChainRegion::writable(16)], 8),
+            Err(ChainLayoutError::ZeroLength)
+        );
+        assert_eq!(
+            validate_chain_layout(
+                &[
+                    ChainRegion::readable(u64::MAX),
+                    ChainRegion::readable(1),
+                    ChainRegion::writable(16),
+                ],
+                8,
+            ),
+            Err(ChainLayoutError::LengthOverflow)
+        );
+
+        let layout =
+            validate_chain_layout(&[ChainRegion::readable(16), ChainRegion::writable(16)], 8)
+                .unwrap();
+        assert_eq!(
+            layout.validate_port_lengths(15, 16),
+            Err(ChainLayoutError::PortLengthMismatch)
+        );
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -119,6 +119,23 @@ Command virtqueue zero is the baseline bidirectional transport queue. One descri
 device-readable request bytes and device-writable response bytes. Completion may be out of
 submission order, keyed by the request ID.
 
+`virtio-accel-transport` defines the queue boundary without choosing a ring implementation or guest
+memory library. Driver publication transfers ownership of a complete chain until used-ring
+consumption or reset returns it. Device pop returns a non-`Copy` chain consumed by completion. Queue
+identities include a monotonic reset epoch, so stale completion is rejected before guest bytes, a
+used element, or a notification can be published.
+
+Publication and completion are release boundaries for request and response bytes; the corresponding
+pop operations are acquire boundaries. Notification enablement includes the required atomic recheck,
+represented explicitly as `Idle` or `WorkPending`. Concrete adapters may use atomics and atomic
+pointers for shared indices and ownership transfer, but the portable traits require no lock, thread,
+executor, or global runtime.
+
+Queue configuration may reserve storage bounded by the validated queue size. Every steady-state
+operation is nonblocking and heap-allocation-free: publish, pop, complete, notification suppression,
+notification recheck, and reset. Reset may move already-owned storage into a reclamation result but
+does not allocate or wait for a peer.
+
 The baseline `SUBMIT` command returns an event object; `POLL_EVENT` provides portable progress without
 requiring unsolicited device writes. Optional multi-queue and event-queue features are reserved for
 later validation. Split and packed virtqueue mechanics belong to transport adapters, not the command
@@ -131,7 +148,9 @@ Virtio queue index.
 
 The semantic hot path uses associated handle types and borrowed binding slices, avoiding trait-object
 dispatch and per-binding boxing. Wire decoding will operate directly over validated descriptor-backed
-regions. Object lookup is constant time and bounded by advertised limits.
+regions. Object lookup is constant time and bounded by advertised limits. The queue ports add no
+allocation or copy to the steady-state path; mapping implementations can present borrowed segmented
+byte ports directly to the command processor.
 
 `WRITE_BUFFER` and `READ_BUFFER` are the baseline's explicit content-copy boundaries. Device-local
 memory may require bounded staging during those operations. Allocation, submission, polling, and
@@ -184,8 +203,8 @@ discover an undocumented copy.
 
 ## Next implementation boundary
 
-The portable command engine depends only on `virtio-accel-proto` and `virtio-accel-core`. Its
-baseline processor:
+The portable command engine depends on `virtio-accel-proto`, `virtio-accel-core`, and the
+transport-neutral region metadata re-exported by `virtio-accel-device`. Its baseline processor:
 
 1. Decodes one bounded request from abstract readable/writable byte regions.
 2. Maintains typed object records and context dependency counts.
@@ -193,6 +212,7 @@ baseline processor:
 4. Passes transfer and artifact regions directly to backend byte ports.
 5. Produces a response without knowing about rust-vmm or a host operating system.
 
-Submission/event retention and deterministic reset complete the engine. The next boundary is a thin
-rust-vmm adapter supplying `virtio-device`, `virtio-queue`, and `vm-memory` integration. Linux
-vhost-user and an in-kernel guest driver remain later platform layers.
+Submission/event retention and deterministic reset complete the engine. The next boundary is the
+in-memory split-virtqueue model implementing the portable queue ports, followed by a thin rust-vmm
+adapter supplying `virtio-device`, `virtio-queue`, and `vm-memory` integration. Linux vhost-user and
+an in-kernel guest driver remain later platform layers.

--- a/docs/portability.md
+++ b/docs/portability.md
@@ -13,8 +13,8 @@ Rust 2024 edition selected by the workspace. Every package inherits the same `ru
 | `style-and-api` | Current stable on Ubuntu | Formatting, complete normative-requirement ledger, Clippy with warnings denied, and warning-free public docs |
 | `native-test` | Current stable on Ubuntu, macOS, and Windows | All workspace unit, integration, target, feature, and documentation tests plus release-profile checking |
 | `msrv` | Rust 1.85.0 on Ubuntu | Every workspace target and test continues to compile at the declared MSRV |
-| `portable-target` | Stable `aarch64-unknown-none`, `riscv64gc-unknown-none-elf`, and `wasm32-unknown-unknown` | `cleanroom`, `proto`, and `core` remain `no_std`; device/facade layers require at most `alloc`; Wasm also checks the std reference crates |
-| `feature-sets-and-dependencies` | Stable on Ubuntu | Every Cargo feature combination plus dependency and `std`/`alloc` leakage guards for the portable codecs and core |
+| `portable-target` | Stable `aarch64-unknown-none`, `riscv64gc-unknown-none-elf`, and `wasm32-unknown-unknown` | `cleanroom`, `proto`, `transport`, and `core` remain `no_std`; device/facade layers require at most `alloc`; Wasm also checks the std reference crates |
+| `feature-sets-and-dependencies` | Stable on Ubuntu | Every Cargo feature combination plus dependency and `std`/`alloc` leakage guards for the portable codecs, queue ports, and core |
 | `dependency-policy` | Cargo-deny with Rust 1.85.0 | Advisories, yanked crates, duplicate versions, wildcard requirements, licenses, and dependency sources |
 | `fuzz-smoke` | Nightly on Ubuntu when `fuzz/Cargo.toml` exists | Every fuzz target gets bounded smoke iterations; issue #26 activates the job by adding the fuzz workspace |
 
@@ -26,13 +26,13 @@ the concrete runner versions used for the release.
 
 | Tier | Crates | Allowed runtime surface |
 |---|---|---|
-| `core-only` | `virtio-accel-cleanroom`, `virtio-accel-proto`, `virtio-accel-core` | `core`; the clean-room codec has no normal/build dependencies, while proc-macros used by other crates may execute with `std` on the build host |
+| `core-only` | `virtio-accel-cleanroom`, `virtio-accel-proto`, `virtio-accel-transport`, `virtio-accel-core` | `core`; the clean-room codec and transport ports have no normal/build dependencies, while proc-macros used by other crates may execute with `std` on the build host |
 | `alloc-portable` | `virtio-accel-device`, `virtio-accel` | `core + alloc`; no OS, filesystem, sockets, threads, or host synchronization |
 | `std-reference` | `virtio-accel-mock` | Portable `std`; no host-OS or vendor-specific API |
 
-Future reference guest and queue crates belong to `alloc-portable`. Concrete VMM, kernel, OS, and
-vendor adapters are outside the portable-v1 milestone and must not become default dependencies of a
-portable crate.
+Future reference guest and split-ring implementation crates belong to `alloc-portable`. Concrete
+VMM, kernel, OS, and vendor adapters are outside the portable-v1 milestone and must not become
+default dependencies of a portable crate.
 
 ## Cargo feature policy
 
@@ -41,11 +41,11 @@ additive: disabling default features may remove convenience behavior but must no
 protocol interpretation.
 
 The portable dependency guard inspects normal and build target features for
-`virtio-accel-cleanroom`, `virtio-accel-proto`, and `virtio-accel-core`; test-only development
-dependencies are intentionally outside the target runtime graph. It additionally proves that the
-clean-room codec has no normal or build dependencies at all. A dependency’s host-side derive macro
-may use `std`, but the target graph for these crates must not enable a dependency feature named
-`std` or `alloc`.
+`virtio-accel-cleanroom`, `virtio-accel-proto`, `virtio-accel-transport`, and
+`virtio-accel-core`; test-only development dependencies are intentionally outside the target
+runtime graph. It additionally proves that the clean-room codec and transport ports have no normal
+or build dependencies at all. A dependency’s host-side derive macro may use `std`, but the target
+graph for these crates must not enable a dependency feature named `std` or `alloc`.
 
 ## Dependency policy
 
@@ -86,6 +86,7 @@ rustup target add aarch64-unknown-none riscv64gc-unknown-none-elf wasm32-unknown
 cargo check \
   -p virtio-accel-cleanroom \
   -p virtio-accel-proto \
+  -p virtio-accel-transport \
   -p virtio-accel-core \
   -p virtio-accel-device \
   -p virtio-accel \

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -430,7 +430,8 @@ indeterminate.
 
 Portable crates **MUST NOT** select an operating system, VMM, kernel, vendor API, or global runtime.
 
-- `virtio-accel-proto` and `virtio-accel-core` require neither `std` nor `alloc`.
+- `virtio-accel-proto`, `virtio-accel-transport`, and `virtio-accel-core` require neither `std` nor
+  `alloc`.
 - `virtio-accel-device` and the future reference guest/queue layers may require `alloc` but not
   `std`.
 - reference host tooling and mock backends may require `std`.
@@ -507,7 +508,11 @@ model or is identified as an implementation helper.
 | `SubmitResponse` | Event ownership payload for accepted or indeterminate submission |
 | `WireEventState`, `KnownEventState`, `UnknownEventState` | Event-poll response payload and extensible raw state handling |
 | `DecodeError`, `read_exact`, `checked_array_bytes` | Protocol decoding helpers; implementation-only |
-| `ChainRegion`, `ChainLayout`, `SegmentedSource`, `SegmentedSink` | Transport-neutral flattened-chain metadata and test/reference byte ports |
+| `QueueSize`, `QueueState`, `QueueEpoch`, `QueueControl` | Validated Virtio queue configuration and reset lifecycle |
+| `ChainId`, `ChainRegion`, `ChainLayout`, `ChainIo`, `DeviceChain` | Reset-scoped descriptor-chain identity, flattened metadata, and mapped byte-port presentation |
+| `DriverQueue`, `PublishedChain`, `UsedChain`, `ReclaimedChain`, `PublishError` | Ownership-preserving driver publication, completion, reset reclamation, and retryable backpressure |
+| `DeviceQueue`, `UsedLength`, `NotificationHint`, `NotificationRecheck` | Consuming device completion, exact used length, and lost-wakeup-safe notification decisions |
+| `SegmentedSource`, `SegmentedSink` | Device test/reference byte ports over segmented storage |
 | `FrameDecoder`, `DecodedRequest`, `DecodedRequestBody`, `FramePreflight` | Complete untrusted request validation before semantic dispatch |
 | `ResponseWriter`, `ResponsePayload` | Bounded response framing and exact direct payload destination |
 | `ObjectNamespace`, `ObjectKind`, `ObjectId` | Device-private namespaced typed object identity |

--- a/docs/virtqueue.md
+++ b/docs/virtqueue.md
@@ -255,6 +255,24 @@ The portable conformance suite uses these stable case identifiers:
 
 The byte vectors under [`conformance/v1.0`](../conformance/v1.0/) cover protocol frames. Queue-model
 implementations consume the case identifiers above so the same behavioral scenarios can be reused
-by the in-memory split ring and future platform transports. Executable region/queue ports are
-tracked by issue #17, the split-ring assertions by #18, guest compatibility behavior by #19, and
-full-path assertions by #20.
+by the in-memory split ring and future platform transports. The dependency-free
+`virtio-accel-transport` crate provides the executable region, ownership, reset-epoch, backpressure,
+and notification port contracts. Split-ring assertions remain tracked by issue #18, guest
+compatibility behavior by #19, and full-path assertions by #20.
+
+## Appendix A: portable Rust queue-port mapping
+
+This appendix is non-normative. `DriverQueue::publish` consumes a complete driver chain on success
+and returns it unchanged through `PublishError` on pre-publication failure. `pop_used` or `reset`
+returns every successfully published chain, preventing safe callers from reusing descriptors while
+the device owns them.
+
+`DeviceQueue::pop_available` returns a non-`Copy` `DeviceChain`. Completion consumes that value and
+must compare its `ChainId` epoch with current `QueueState` before publishing bytes or ring state.
+`ChainIo` contains only flattened `ChainRegion` values and generic readable/writable byte ports; it
+cannot carry guest addresses or a concrete descriptor type.
+
+All steady-state queue-port methods are specified as nonblocking and allocation-free in their Rust
+documentation. Publication/completion establish release ordering, their peer-side pops establish
+acquire ordering, and notification enablement returns `WorkPending` when its mandatory recheck finds
+work that raced with suppression.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! Portable foundations for an experimental virtio accelerator device.
 //!
 //! The facade intentionally contains no transport, operating-system, or vendor implementation.
-//! Those adapters depend on the three layers re-exported here.
+//! Those adapters depend on the portable layers re-exported here.
 
 #![no_std]
 #![forbid(unsafe_code)]
@@ -9,3 +9,4 @@
 pub use virtio_accel_core as core;
 pub use virtio_accel_device as device;
 pub use virtio_accel_proto as proto;
+pub use virtio_accel_transport as transport;


### PR DESCRIPTION
## Summary

- add a dependency-free `no_std` `virtio-accel-transport` crate for queue configuration, descriptor-chain ownership, used lengths, notifications, and reset epochs
- move flattened chain metadata into the transport layer while preserving the existing device-crate re-exports
- encode retryable publication backpressure, consuming device completion, acquire/release boundaries, and atomic notification rechecks in the public contracts
- update portability guards, architecture/specification docs, and the normative conformance ledger

## Design notes

- successful driver publication transfers the complete chain until `pop_used` or reset returns it
- device completion consumes a non-`Copy` chain identity scoped to a monotonic reset epoch
- stale chains must fail byte access and completion before guest writes, used entries, or notifications
- steady-state operations are documented as nonblocking and heap-allocation-free; only bounded configuration may allocate
- request/response port types remain generic, so guest addresses, mappings, and backend semantics do not enter the transport crate

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps`
- `cargo test --workspace --all-targets --all-features`
- `cargo test --workspace --doc --all-features`
- `cargo check --workspace --release --all-features`
- Rust 1.85 workspace check and tests
- `aarch64-unknown-none`, `riscv64gc-unknown-none-elf`, and `wasm32-unknown-unknown` portable checks
- cargo-hack feature powerset
- normative ledger and portable dependency guards

Closes #17