### PR TITLE
Implement no-std reference guest client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,7 @@ jobs:
           -p virtio-accel-transport
           -p virtio-accel-core
           -p virtio-accel-device
+          -p virtio-accel-guest
           -p virtio-accel-split-queue
           -p virtio-accel
           --target ${{ matrix.target }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,7 @@ dependencies = [
  "serde_json",
  "virtio-accel-core",
  "virtio-accel-device",
+ "virtio-accel-guest",
  "virtio-accel-mock",
  "virtio-accel-proto",
  "virtio-accel-split-queue",
@@ -133,6 +134,17 @@ dependencies = [
  "virtio-accel-core",
  "virtio-accel-mock",
  "virtio-accel-proto",
+ "virtio-accel-transport",
+ "zerocopy",
+]
+
+[[package]]
+name = "virtio-accel-guest"
+version = "0.1.0"
+dependencies = [
+ "bitflags",
+ "virtio-accel-proto",
+ "virtio-accel-split-queue",
  "virtio-accel-transport",
  "zerocopy",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "conformance/rust-clean-room",
     "crates/virtio-accel-core",
     "crates/virtio-accel-device",
+    "crates/virtio-accel-guest",
     "crates/virtio-accel-mock",
     "crates/virtio-accel-proto",
     "crates/virtio-accel-split-queue",
@@ -32,6 +33,7 @@ zerocopy = { version = "0.8.54", default-features = false, features = ["derive"]
 virtio-accel-core = { path = "crates/virtio-accel-core" }
 virtio-accel-cleanroom = { path = "conformance/rust-clean-room" }
 virtio-accel-device = { path = "crates/virtio-accel-device" }
+virtio-accel-guest = { path = "crates/virtio-accel-guest" }
 virtio-accel-mock = { path = "crates/virtio-accel-mock" }
 virtio-accel-proto = { path = "crates/virtio-accel-proto" }
 virtio-accel-split-queue = { path = "crates/virtio-accel-split-queue" }
@@ -40,6 +42,7 @@ virtio-accel-transport = { path = "crates/virtio-accel-transport" }
 [dependencies]
 virtio-accel-core.workspace = true
 virtio-accel-device.workspace = true
+virtio-accel-guest.workspace = true
 virtio-accel-proto.workspace = true
 virtio-accel-split-queue.workspace = true
 virtio-accel-transport.workspace = true

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ claimed virtio device ID.
 - `virtio-accel-transport`: dependency-free `no_std` descriptor-chain, queue, reset, and
   notification ports.
 - `virtio-accel-split-queue`: `no_std + alloc` bounded in-memory split-ring reference model.
+- `virtio-accel-guest`: `no_std + alloc` typed reference client with bounded request tracking.
 - `virtio-accel-core`: `no_std` backend lifecycle, memory, program, queue, and event contracts.
 - `virtio-accel-device`: `no_std + alloc` device-owned state, including bounded generational IDs.
 - `virtio-accel-mock`: cross-platform in-memory backend that exercises the complete lifecycle.
@@ -31,6 +32,10 @@ virtio-accel-device ----------+-------+------> virtio-accel-core
           |                                          |
           +-----> virtio-accel-proto                 v
                                              provider adapters
+
+virtio-accel-guest -----------> virtio-accel-transport
+          |
+          +--------------------> virtio-accel-proto
 ```
 
 Arrows point from a crate to its dependency. The transport crate exposes reset-scoped chain

--- a/ci/check-portable-dependencies.sh
+++ b/ci/check-portable-dependencies.sh
@@ -6,6 +6,7 @@ readonly packages=(
   virtio-accel-proto
   virtio-accel-transport
   virtio-accel-core
+  virtio-accel-guest
   virtio-accel-split-queue
 )
 

--- a/conformance/v1.0/coverage.md
+++ b/conformance/v1.0/coverage.md
@@ -17,7 +17,7 @@ behavior is deliberately tracked by a later issue. The exact per-keyword ledger 
 | `wire-abi.md` sections 1-6: config, headers, namespaces, all payloads, statuses, limits, and reserved fields | `layout.json`, `vectors.json`, primary `zerocopy` assertions, and the manual dependency-free codec | Device-state limits that require live objects are exercised by #20 and threat-model issue #25 |
 | `wire-abi.md` section 7: preflight and response atomicity | Error-shape vectors and ownership-aware core error types | Writable-region preflight and post-mutation failure are VQ-012/VQ-020 in #18 and #20 |
 | `wire-abi.md` sections 8-9: versioned artifacts and change control | Checked-in inputs, drift tests, and coordinated-change documentation | Release freeze governance is finalized by #32 and #33 |
-| `virtqueue.md` sections 1-12 | Stable executable case identifiers `VQ-001` through `VQ-020` define the required assertions | Region ports are #17, split-ring model tests are #18, guest compatibility is #19, and full-path behavior is #20 |
+| `virtqueue.md` sections 1-12 | Stable executable cases plus portable guest tests cover segmented chains, out-of-order completion, bounded request-ID wrap, malformed responses, backpressure, and reset ownership | Full guest-to-command-engine behavior and response atomicity remain tracked by #20 |
 
 ## Independent implementation evidence
 

--- a/crates/virtio-accel-core/src/lib.rs
+++ b/crates/virtio-accel-core/src/lib.rs
@@ -507,7 +507,7 @@ impl<const N: usize> ByteSource for [u8; N] {
     }
 
     fn read_at(&self, offset: u64, target: &mut [u8]) -> Result<(), BackendError> {
-        self.as_slice().read_at(offset, target)
+        ByteSource::read_at(self.as_slice(), offset, target)
     }
 
     fn as_contiguous(&self) -> Option<&[u8]> {
@@ -603,7 +603,7 @@ impl<const N: usize> ByteSink for [u8; N] {
     }
 
     fn write_at(&mut self, offset: u64, source: &[u8]) -> Result<(), BackendError> {
-        self.as_mut_slice().write_at(offset, source)
+        ByteSink::write_at(self.as_mut_slice(), offset, source)
     }
 
     fn as_contiguous_mut(&mut self) -> Option<&mut [u8]> {

--- a/crates/virtio-accel-guest/Cargo.toml
+++ b/crates/virtio-accel-guest/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "virtio-accel-guest"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+description = "No-std reference guest client for virtio-accel protocol 1.0"
+publish = false
+
+[dependencies]
+bitflags.workspace = true
+virtio-accel-proto.workspace = true
+virtio-accel-transport.workspace = true
+zerocopy.workspace = true
+
+[dev-dependencies]
+virtio-accel-split-queue.workspace = true

--- a/crates/virtio-accel-guest/src/client.rs
+++ b/crates/virtio-accel-guest/src/client.rs
@@ -1,0 +1,1740 @@
+use alloc::vec::Vec;
+use core::mem::{self, size_of};
+
+use virtio_accel_proto::{
+    AllocateBufferRequest, CreateContextRequest, CreateQueueRequest, Le32, Le64,
+    LoadProgramRequest, ObjectPayload, RequestFlags, RequestHeader, ResponseHeader, StatusCode,
+    SubmitRequest, TransferBufferRequest, WireBinding, WireDeviceInfo, WireEventState, read_exact,
+};
+use virtio_accel_transport::{
+    ByteAccessError, ChainId, DriverChainBuffer, DriverQueue, NotificationRecheck,
+    PublishErrorKind, QueueControl, QueueEpoch, QueueError, QueueSize, QueueState, ReadableBytes,
+    UsedChain, UsedLength,
+};
+use zerocopy::{Immutable, IntoBytes};
+
+use crate::config::{GuestConfig, GuestConfigError};
+use crate::operation::{
+    AllocateBuffer, CancelEvent, CreateContext, CreateExecutionQueue, DestroyContext, DestroyEvent,
+    DestroyExecutionQueue, FreeBuffer, GetDeviceInfo, LoadProgram, Operation, OperationResult,
+    PollEvent, ReadBuffer, ResponseError, Submit, UnloadProgram, WriteBuffer,
+};
+use crate::types::{
+    AccessMode, Binding, Buffer, BufferDesc, BufferRange, BufferUsage, Context, DeviceInfo, Event,
+    ExecutionQueue, FailureDisposition, Program, ProgramDesc,
+};
+
+const REQUEST_HEADER_BYTES: u64 = size_of::<RequestHeader>() as u64;
+const RESPONSE_HEADER_BYTES: u64 = size_of::<ResponseHeader>() as u64;
+const COPY_SCRATCH_BYTES: usize = 256;
+
+/// Whether the client may publish new work.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ClientHealth {
+    /// Queue tracking and response framing remain trustworthy.
+    Running,
+    /// An unexpected or malformed completion requires a queue reset.
+    NeedsReset,
+}
+
+/// Failure to construct a bounded guest client.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ClientInitError {
+    /// Configuration or queue state is incompatible with the client.
+    Config(GuestConfigError),
+    /// Bounded in-flight tracking storage could not be allocated.
+    AllocationFailed,
+}
+
+/// Failure while restoring queue configuration after reset.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum QueueSetupError<E> {
+    /// Requested queue size contradicts the validated guest configuration.
+    Config(GuestConfigError),
+    /// Concrete queue configuration failed.
+    Queue(QueueError<E>),
+}
+
+/// Failure before request ownership transfers to the queue.
+#[derive(Debug, PartialEq, Eq)]
+pub enum StartErrorKind<QE, CE> {
+    /// A prior malformed completion requires reset.
+    NeedsReset,
+    /// Device information must be discovered first.
+    DiscoveryRequired,
+    /// Every bounded tracking slot is occupied.
+    InflightLimit,
+    /// No request identifier could be selected without aliasing live work.
+    RequestIdExhausted,
+    /// A typed handle belongs to a prior queue epoch.
+    StaleHandle,
+    /// Typed arguments contradict retained object bounds or usage.
+    InvalidArgument,
+    /// A request exceeds an advertised semantic device limit.
+    DeviceLimit,
+    /// The device-readable chain length is not the exact request frame length.
+    RequestCapacity {
+        /// Required exact frame length.
+        required: u64,
+        /// Supplied readable bytes.
+        available: u64,
+    },
+    /// The device-writable chain cannot hold the largest valid response.
+    ResponseCapacity {
+        /// Required response capacity.
+        required: u64,
+        /// Supplied writable bytes.
+        available: u64,
+    },
+    /// The caller-provided request source could not be read.
+    SourceAccess(ByteAccessError),
+    /// The chain request region could not be written.
+    ChainAccess(CE),
+    /// Queue publication failed before ownership transfer.
+    Publish(PublishErrorKind<QE>),
+}
+
+/// Failed request start with both caller-owned inputs returned.
+#[derive(Debug)]
+pub struct StartError<C, O, QE, CE> {
+    chain: C,
+    operation: O,
+    kind: StartErrorKind<QE, CE>,
+}
+
+impl<C, O, QE, CE> StartError<C, O, QE, CE> {
+    /// Borrow the failure classification.
+    pub const fn kind(&self) -> &StartErrorKind<QE, CE> {
+        &self.kind
+    }
+
+    /// Recover the unpublished chain, typed operation, and failure classification.
+    pub fn into_parts(self) -> (C, O, StartErrorKind<QE, CE>) {
+        (self.chain, self.operation, self.kind)
+    }
+}
+
+/// Result of starting one typed operation on queue `Q`.
+pub type StartResult<Q, O> = Result<
+    Pending<O>,
+    StartError<
+        <Q as DriverQueue>::Chain,
+        O,
+        <Q as DriverQueue>::Error,
+        <<Q as DriverQueue>::Chain as DriverChainBuffer>::Error,
+    >,
+>;
+
+/// Typed operation token retained until its matching completion is observed.
+#[derive(Debug)]
+pub struct Pending<O> {
+    slot: u16,
+    request_id: u64,
+    epoch: QueueEpoch,
+    operation: O,
+}
+
+impl<O> Pending<O> {
+    /// Nonzero wire request identifier.
+    pub const fn request_id(&self) -> u64 {
+        self.request_id
+    }
+
+    /// Queue epoch in which this request was published.
+    pub const fn epoch(&self) -> QueueEpoch {
+        self.epoch
+    }
+
+    /// Borrow operation metadata retained for response validation or recovery.
+    pub const fn operation(&self) -> &O {
+        &self.operation
+    }
+}
+
+/// Operation metadata recovered only after its queue epoch is stale.
+#[derive(Debug)]
+pub struct StaleOperation<O> {
+    request_id: u64,
+    epoch: QueueEpoch,
+    operation: O,
+}
+
+impl<O> StaleOperation<O> {
+    /// Request identifier from the invalidated queue epoch.
+    pub const fn request_id(&self) -> u64 {
+        self.request_id
+    }
+
+    /// Invalidated queue epoch.
+    pub const fn epoch(&self) -> QueueEpoch {
+        self.epoch
+    }
+
+    /// Borrow the invalidated operation metadata.
+    pub const fn operation(&self) -> &O {
+        &self.operation
+    }
+
+    /// Recover operation metadata for cleanup or inspection.
+    ///
+    /// Typed handles from this operation remain stale and cannot be republished in the new epoch.
+    pub fn into_operation(self) -> O {
+        self.operation
+    }
+}
+
+/// Terminal result for one matched request completion.
+#[derive(Debug)]
+pub enum Completion<O: Operation, C, CE> {
+    /// Protocol success with the reclaimed caller chain.
+    Success {
+        /// Typed response value. Bulk read bytes remain in `chain`.
+        output: O::Output,
+        /// Reclaimed caller-owned chain.
+        chain: C,
+    },
+    /// Well-formed protocol error; operation metadata is returned for retry decisions.
+    DeviceError {
+        /// Raw status, preserving unknown provider values.
+        status: StatusCode,
+        /// Whether typed operation ownership is retryable, invalid, or uncertain.
+        disposition: FailureDisposition,
+        /// Original typed operation.
+        operation: O,
+        /// Reclaimed caller-owned chain.
+        chain: C,
+    },
+    /// Malformed or inaccessible response; reset is required.
+    InvalidResponse {
+        /// Validation failure.
+        error: ResponseError<CE>,
+        /// Original typed operation.
+        operation: O,
+        /// Reclaimed caller-owned chain.
+        chain: C,
+    },
+}
+
+/// Result of synchronously polling one typed request.
+pub enum RequestPoll<O: Operation, C, QE, CE> {
+    /// No matching completion has arrived yet.
+    Pending(Pending<O>),
+    /// Matching request reached a terminal result.
+    Ready(Completion<O, C, CE>),
+    /// Used-ring access failed; the pending token remains valid for retry.
+    QueueError {
+        /// Original pending token.
+        pending: Pending<O>,
+        /// Queue failure.
+        error: QueueError<QE>,
+    },
+    /// Queue reset invalidated this operation.
+    Stale(StaleOperation<O>),
+    /// Queue health requires reset before more completion processing.
+    NeedsReset(Pending<O>),
+}
+
+/// Result of consuming at most one used-ring entry.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PumpResult {
+    /// No completion was available.
+    Idle,
+    /// One tracked completion was retained for its pending token.
+    Completion {
+        /// Request identifier associated with the completed chain.
+        request_id: u64,
+    },
+    /// A used chain had no live matching publication.
+    UnexpectedCompletion,
+    /// Client already requires reset.
+    NeedsReset,
+}
+
+enum Slot<C> {
+    Vacant,
+    InFlight { request_id: u64, chain_id: ChainId },
+    Completed { request_id: u64, used: UsedChain<C> },
+    Recovered(UsedChain<C>),
+}
+
+enum FrameWriteError<E> {
+    Chain(E),
+    Source(ByteAccessError),
+}
+
+/// Bounded, single-owner reference driver over a portable command queue.
+///
+/// The type performs no internal locking. Callers that share one client across execution contexts
+/// choose their own synchronization policy; ordinary single-owner polling needs none.
+pub struct GuestClient<Q: DriverQueue>
+where
+    Q::Chain: DriverChainBuffer,
+{
+    queue: Q,
+    config: GuestConfig,
+    device_info: Option<DeviceInfo>,
+    slots: Vec<Slot<Q::Chain>>,
+    next_request_id: u64,
+    health: ClientHealth,
+    unexpected: Option<UsedChain<Q::Chain>>,
+}
+
+impl<Q> GuestClient<Q>
+where
+    Q: DriverQueue,
+    Q::Chain: DriverChainBuffer,
+{
+    /// Construct a client after transport feature and queue setup.
+    pub fn new(queue: Q, config: GuestConfig) -> Result<Self, ClientInitError> {
+        config
+            .validate_queue(queue.state())
+            .map_err(ClientInitError::Config)?;
+        let count = usize::from(config.max_inflight());
+        let mut slots = Vec::new();
+        slots
+            .try_reserve_exact(count)
+            .map_err(|_| ClientInitError::AllocationFailed)?;
+        for _ in 0..count {
+            slots.push(Slot::Vacant);
+        }
+        Ok(Self {
+            queue,
+            config,
+            device_info: None,
+            slots,
+            next_request_id: 1,
+            health: ClientHealth::Running,
+            unexpected: None,
+        })
+    }
+
+    /// Current queue lifecycle snapshot.
+    pub fn queue_state(&self) -> QueueState {
+        self.queue.state()
+    }
+
+    /// Validated guest configuration.
+    pub const fn config(&self) -> GuestConfig {
+        self.config
+    }
+
+    /// Latest discovery result in the current epoch.
+    pub const fn device_info(&self) -> Option<DeviceInfo> {
+        self.device_info
+    }
+
+    /// Current response-tracking health.
+    pub const fn health(&self) -> ClientHealth {
+        self.health
+    }
+
+    /// Disable used notifications before draining completions.
+    pub fn disable_used_notifications(&mut self) -> Result<(), QueueError<Q::Error>> {
+        self.queue.disable_used_notifications()
+    }
+
+    /// Atomically enable used notifications and check for missed completions.
+    pub fn enable_used_notifications(
+        &mut self,
+    ) -> Result<NotificationRecheck, QueueError<Q::Error>> {
+        self.queue.enable_used_notifications()
+    }
+
+    /// Consume and classify at most one used-ring entry.
+    pub fn pump(&mut self) -> Result<PumpResult, QueueError<Q::Error>> {
+        if self.health == ClientHealth::NeedsReset {
+            return Ok(PumpResult::NeedsReset);
+        }
+        let Some(used) = self.queue.pop_used()? else {
+            return Ok(PumpResult::Idle);
+        };
+        let id = used.id();
+        let Some(index) = self
+            .slots
+            .iter()
+            .position(|slot| matches!(slot, Slot::InFlight { chain_id, .. } if *chain_id == id))
+        else {
+            self.unexpected = Some(used);
+            self.health = ClientHealth::NeedsReset;
+            return Ok(PumpResult::UnexpectedCompletion);
+        };
+        let Slot::InFlight { request_id, .. } = mem::replace(&mut self.slots[index], Slot::Vacant)
+        else {
+            unreachable!("matched slot must be in flight")
+        };
+        self.slots[index] = Slot::Completed { request_id, used };
+        Ok(PumpResult::Completion { request_id })
+    }
+
+    /// Poll one typed operation, consuming at most one queue completion.
+    pub fn poll<O: Operation>(
+        &mut self,
+        pending: Pending<O>,
+    ) -> RequestPoll<O, Q::Chain, Q::Error, <Q::Chain as DriverChainBuffer>::Error> {
+        if pending.epoch != self.queue.state().epoch() {
+            return RequestPoll::Stale(stale_operation(pending));
+        }
+        if self.health == ClientHealth::NeedsReset {
+            return RequestPoll::NeedsReset(pending);
+        }
+        if !self.pending_matches(&pending) {
+            return RequestPoll::Stale(stale_operation(pending));
+        }
+        if matches!(self.slots[usize::from(pending.slot)], Slot::InFlight { .. }) {
+            match self.pump() {
+                Err(error) => return RequestPoll::QueueError { pending, error },
+                Ok(PumpResult::UnexpectedCompletion | PumpResult::NeedsReset) => {
+                    return RequestPoll::NeedsReset(pending);
+                }
+                Ok(PumpResult::Idle | PumpResult::Completion { .. }) => {}
+            }
+        }
+        let index = usize::from(pending.slot);
+        if !matches!(self.slots[index], Slot::Completed { .. }) {
+            return RequestPoll::Pending(pending);
+        }
+        let Slot::Completed { request_id, used } =
+            mem::replace(&mut self.slots[index], Slot::Vacant)
+        else {
+            unreachable!("checked slot must contain a completion")
+        };
+        if request_id != pending.request_id {
+            self.slots[index] = Slot::Completed { request_id, used };
+            return RequestPoll::Stale(stale_operation(pending));
+        }
+        RequestPoll::Ready(self.decode_completion(pending, used))
+    }
+
+    /// Reset the queue and invalidate all pending operations and typed handles.
+    ///
+    /// Published chains are returned by the queue's reclaimed collection. Chains already popped
+    /// from the used ring are retained for [`Self::pop_recovered_completion`].
+    pub fn reset(&mut self, next_epoch: QueueEpoch) -> Result<Q::Reclaimed, QueueError<Q::Error>> {
+        let reclaimed = self.queue.reset(next_epoch)?;
+        for slot in &mut self.slots {
+            let old = mem::replace(slot, Slot::Vacant);
+            *slot = match old {
+                Slot::Completed { used, .. } | Slot::Recovered(used) => Slot::Recovered(used),
+                Slot::Vacant | Slot::InFlight { .. } => Slot::Vacant,
+            };
+        }
+        self.device_info = None;
+        self.next_request_id = 1;
+        self.health = ClientHealth::Running;
+        Ok(reclaimed)
+    }
+
+    /// Configure and ready the command queue after transport reset.
+    pub fn reconfigure_queue(
+        &mut self,
+        size: QueueSize,
+    ) -> Result<(), QueueSetupError<<Q as DriverQueue>::Error>>
+    where
+        Q: QueueControl<Error = <Q as DriverQueue>::Error>,
+    {
+        self.config
+            .validate_size(size)
+            .map_err(QueueSetupError::Config)?;
+        self.queue.configure(size).map_err(QueueSetupError::Queue)?;
+        self.queue.set_ready(true).map_err(QueueSetupError::Queue)
+    }
+
+    /// Recover one completion that had been popped before reset invalidated its pending token.
+    pub fn pop_recovered_completion(&mut self) -> Option<UsedChain<Q::Chain>> {
+        let index = self
+            .slots
+            .iter()
+            .position(|slot| matches!(slot, Slot::Recovered(_)))?;
+        let Slot::Recovered(used) = mem::replace(&mut self.slots[index], Slot::Vacant) else {
+            unreachable!("matched slot must contain a recovered completion")
+        };
+        Some(used)
+    }
+
+    /// Recover the unexpected completion that forced reset.
+    pub fn take_unexpected_completion(&mut self) -> Option<UsedChain<Q::Chain>> {
+        self.unexpected.take()
+    }
+
+    /// Start protocol discovery.
+    pub fn get_device_info(&mut self, chain: Q::Chain) -> StartResult<Q, GetDeviceInfo> {
+        self.start_frame(
+            chain,
+            GetDeviceInfo,
+            0,
+            RESPONSE_HEADER_BYTES + size_of::<WireDeviceInfo>() as u64,
+            |_| Ok(()),
+        )
+    }
+
+    /// Start context creation.
+    pub fn create_context(&mut self, chain: Q::Chain) -> StartResult<Q, CreateContext> {
+        let request = CreateContextRequest {
+            flags: Le32::new(0),
+            reserved: Le32::new(0),
+        };
+        self.start_wire(
+            chain,
+            CreateContext,
+            &request,
+            RESPONSE_HEADER_BYTES + size_of::<ObjectPayload>() as u64,
+        )
+    }
+
+    /// Start context destruction, consuming the handle until completion or failure recovery.
+    pub fn destroy_context(
+        &mut self,
+        chain: Q::Chain,
+        context: Context,
+    ) -> StartResult<Q, DestroyContext> {
+        let stale = context.epoch() != self.queue.state().epoch();
+        let object = ObjectPayload {
+            object_id: Le64::new(context.raw()),
+        };
+        let operation = DestroyContext { context };
+        if stale {
+            return self.start_failure(chain, operation, StartErrorKind::StaleHandle);
+        }
+        self.start_wire(chain, operation, &object, RESPONSE_HEADER_BYTES)
+    }
+
+    /// Start a bounded buffer allocation.
+    pub fn allocate_buffer(
+        &mut self,
+        chain: Q::Chain,
+        context: &Context,
+        desc: BufferDesc,
+    ) -> StartResult<Q, AllocateBuffer> {
+        let operation = AllocateBuffer {
+            context: context.handle.id(),
+            desc,
+        };
+        if context.epoch() != self.queue.state().epoch() {
+            return self.start_failure(chain, operation, StartErrorKind::StaleHandle);
+        }
+        let Some(info) = self.device_info else {
+            return self.start_failure(chain, operation, StartErrorKind::DiscoveryRequired);
+        };
+        if desc.bytes > info.max_buffer_bytes || !info.supports_domain(desc.memory_domain) {
+            return self.start_failure(chain, operation, StartErrorKind::DeviceLimit);
+        }
+        let request = AllocateBufferRequest {
+            context_id: Le64::new(context.raw()),
+            bytes: Le64::new(desc.bytes),
+            alignment: Le64::new(desc.alignment),
+            memory_domain: desc.memory_domain as u8,
+            reserved0: [0; 7],
+            usage: Le32::new(desc.usage.bits()),
+            reserved1: Le32::new(0),
+        };
+        self.start_wire(
+            chain,
+            operation,
+            &request,
+            RESPONSE_HEADER_BYTES + size_of::<ObjectPayload>() as u64,
+        )
+    }
+
+    /// Start buffer release, consuming the handle until completion or failure recovery.
+    pub fn free_buffer(&mut self, chain: Q::Chain, buffer: Buffer) -> StartResult<Q, FreeBuffer> {
+        let stale = buffer.epoch() != self.queue.state().epoch();
+        let object = ObjectPayload {
+            object_id: Le64::new(buffer.raw()),
+        };
+        let operation = FreeBuffer { buffer };
+        if stale {
+            return self.start_failure(chain, operation, StartErrorKind::StaleHandle);
+        }
+        self.start_wire(chain, operation, &object, RESPONSE_HEADER_BYTES)
+    }
+
+    /// Start a copy from caller source bytes into a provider-owned buffer.
+    pub fn write_buffer<R: ReadableBytes + ?Sized>(
+        &mut self,
+        chain: Q::Chain,
+        buffer: &Buffer,
+        offset: u64,
+        source: &R,
+    ) -> StartResult<Q, WriteBuffer> {
+        let operation = WriteBuffer;
+        if buffer.epoch() != self.queue.state().epoch() {
+            return self.start_failure(chain, operation, StartErrorKind::StaleHandle);
+        }
+        let Ok(range) = BufferRange::new(offset, source.len()) else {
+            return self.start_failure(chain, operation, StartErrorKind::InvalidArgument);
+        };
+        if !range.fits(buffer.desc.bytes)
+            || !buffer
+                .desc
+                .usage
+                .contains(BufferUsage::TRANSFER_DESTINATION)
+        {
+            return self.start_failure(chain, operation, StartErrorKind::InvalidArgument);
+        }
+        let prefix = TransferBufferRequest {
+            buffer_id: Le64::new(buffer.raw()),
+            offset: Le64::new(offset),
+            bytes: Le64::new(source.len()),
+        };
+        let Some(payload) = (size_of::<TransferBufferRequest>() as u64).checked_add(source.len())
+        else {
+            return self.start_failure(chain, operation, StartErrorKind::DeviceLimit);
+        };
+        self.start_frame(chain, operation, payload, RESPONSE_HEADER_BYTES, |chain| {
+            write_wire(chain, REQUEST_HEADER_BYTES, &prefix).map_err(FrameWriteError::Chain)?;
+            copy_source(
+                chain,
+                REQUEST_HEADER_BYTES + size_of::<TransferBufferRequest>() as u64,
+                source,
+            )
+        })
+    }
+
+    /// Start a zero-copy buffer write from an already prepared request-chain tail.
+    ///
+    /// Bytes beginning after the transfer prefix are left untouched and become the write payload.
+    pub fn write_buffer_prepared(
+        &mut self,
+        chain: Q::Chain,
+        buffer: &Buffer,
+        range: BufferRange,
+    ) -> StartResult<Q, WriteBuffer> {
+        let operation = WriteBuffer;
+        if buffer.epoch() != self.queue.state().epoch() {
+            return self.start_failure(chain, operation, StartErrorKind::StaleHandle);
+        }
+        if !range.fits(buffer.desc.bytes)
+            || !buffer
+                .desc
+                .usage
+                .contains(BufferUsage::TRANSFER_DESTINATION)
+        {
+            return self.start_failure(chain, operation, StartErrorKind::InvalidArgument);
+        }
+        let prefix = TransferBufferRequest {
+            buffer_id: Le64::new(buffer.raw()),
+            offset: Le64::new(range.offset),
+            bytes: Le64::new(range.bytes),
+        };
+        let Some(payload) = (size_of::<TransferBufferRequest>() as u64).checked_add(range.bytes)
+        else {
+            return self.start_failure(chain, operation, StartErrorKind::DeviceLimit);
+        };
+        self.start_frame(chain, operation, payload, RESPONSE_HEADER_BYTES, |chain| {
+            write_wire(chain, REQUEST_HEADER_BYTES, &prefix).map_err(FrameWriteError::Chain)
+        })
+    }
+
+    /// Start a provider-buffer read whose bytes remain in the reclaimed chain.
+    pub fn read_buffer(
+        &mut self,
+        chain: Q::Chain,
+        buffer: &Buffer,
+        range: BufferRange,
+    ) -> StartResult<Q, ReadBuffer> {
+        let operation = ReadBuffer { bytes: range.bytes };
+        if buffer.epoch() != self.queue.state().epoch() {
+            return self.start_failure(chain, operation, StartErrorKind::StaleHandle);
+        }
+        if !range.fits(buffer.desc.bytes)
+            || !buffer.desc.usage.contains(BufferUsage::TRANSFER_SOURCE)
+        {
+            return self.start_failure(chain, operation, StartErrorKind::InvalidArgument);
+        }
+        let request = TransferBufferRequest {
+            buffer_id: Le64::new(buffer.raw()),
+            offset: Le64::new(range.offset),
+            bytes: Le64::new(range.bytes),
+        };
+        let Some(response_bytes) = RESPONSE_HEADER_BYTES.checked_add(range.bytes) else {
+            return self.start_failure(chain, operation, StartErrorKind::DeviceLimit);
+        };
+        self.start_wire(chain, operation, &request, response_bytes)
+    }
+
+    /// Start loading an opaque program artifact directly from caller bytes.
+    pub fn load_program<R: ReadableBytes + ?Sized>(
+        &mut self,
+        chain: Q::Chain,
+        context: &Context,
+        desc: ProgramDesc,
+        artifact: &R,
+    ) -> StartResult<Q, LoadProgram> {
+        let operation = LoadProgram {
+            context: context.handle.id(),
+            desc,
+        };
+        if context.epoch() != self.queue.state().epoch() {
+            return self.start_failure(chain, operation, StartErrorKind::StaleHandle);
+        }
+        let Some(info) = self.device_info else {
+            return self.start_failure(chain, operation, StartErrorKind::DiscoveryRequired);
+        };
+        if artifact.is_empty() {
+            return self.start_failure(chain, operation, StartErrorKind::InvalidArgument);
+        }
+        if artifact.len() > info.max_artifact_bytes {
+            return self.start_failure(chain, operation, StartErrorKind::DeviceLimit);
+        }
+        let request = LoadProgramRequest {
+            context_id: Le64::new(context.raw()),
+            format: Le32::new(desc.format.get()),
+            flags: Le32::new(0),
+            target: core::array::from_fn(|index| Le32::new(desc.target[index])),
+            payload_bytes: Le64::new(artifact.len()),
+            resident_bytes: Le64::new(desc.resident_bytes.get()),
+        };
+        let payload = size_of::<LoadProgramRequest>() as u64 + artifact.len();
+        self.start_frame(
+            chain,
+            operation,
+            payload,
+            RESPONSE_HEADER_BYTES + size_of::<ObjectPayload>() as u64,
+            |chain| {
+                write_wire(chain, REQUEST_HEADER_BYTES, &request)
+                    .map_err(FrameWriteError::Chain)?;
+                copy_source(
+                    chain,
+                    REQUEST_HEADER_BYTES + size_of::<LoadProgramRequest>() as u64,
+                    artifact,
+                )
+            },
+        )
+    }
+
+    /// Start a zero-copy program load from an already prepared request-chain tail.
+    ///
+    /// Artifact bytes beginning after the fixed load prefix are left untouched.
+    pub fn load_program_prepared(
+        &mut self,
+        chain: Q::Chain,
+        context: &Context,
+        desc: ProgramDesc,
+        artifact_bytes: u64,
+    ) -> StartResult<Q, LoadProgram> {
+        let operation = LoadProgram {
+            context: context.handle.id(),
+            desc,
+        };
+        if context.epoch() != self.queue.state().epoch() {
+            return self.start_failure(chain, operation, StartErrorKind::StaleHandle);
+        }
+        let Some(info) = self.device_info else {
+            return self.start_failure(chain, operation, StartErrorKind::DiscoveryRequired);
+        };
+        if artifact_bytes == 0 {
+            return self.start_failure(chain, operation, StartErrorKind::InvalidArgument);
+        }
+        if artifact_bytes > info.max_artifact_bytes {
+            return self.start_failure(chain, operation, StartErrorKind::DeviceLimit);
+        }
+        let request = LoadProgramRequest {
+            context_id: Le64::new(context.raw()),
+            format: Le32::new(desc.format.get()),
+            flags: Le32::new(0),
+            target: core::array::from_fn(|index| Le32::new(desc.target[index])),
+            payload_bytes: Le64::new(artifact_bytes),
+            resident_bytes: Le64::new(desc.resident_bytes.get()),
+        };
+        self.start_frame(
+            chain,
+            operation,
+            size_of::<LoadProgramRequest>() as u64 + artifact_bytes,
+            RESPONSE_HEADER_BYTES + size_of::<ObjectPayload>() as u64,
+            |chain| {
+                write_wire(chain, REQUEST_HEADER_BYTES, &request).map_err(FrameWriteError::Chain)
+            },
+        )
+    }
+
+    /// Start program release, consuming the handle until completion or failure recovery.
+    pub fn unload_program(
+        &mut self,
+        chain: Q::Chain,
+        program: Program,
+    ) -> StartResult<Q, UnloadProgram> {
+        let stale = program.epoch() != self.queue.state().epoch();
+        let object = ObjectPayload {
+            object_id: Le64::new(program.raw()),
+        };
+        let operation = UnloadProgram { program };
+        if stale {
+            return self.start_failure(chain, operation, StartErrorKind::StaleHandle);
+        }
+        self.start_wire(chain, operation, &object, RESPONSE_HEADER_BYTES)
+    }
+
+    /// Start creation of an accelerator execution queue.
+    pub fn create_execution_queue(
+        &mut self,
+        chain: Q::Chain,
+        context: &Context,
+    ) -> StartResult<Q, CreateExecutionQueue> {
+        let operation = CreateExecutionQueue {
+            context: context.handle.id(),
+        };
+        if context.epoch() != self.queue.state().epoch() {
+            return self.start_failure(chain, operation, StartErrorKind::StaleHandle);
+        }
+        let request = CreateQueueRequest {
+            context_id: Le64::new(context.raw()),
+            flags: Le32::new(0),
+            reserved: Le32::new(0),
+        };
+        self.start_wire(
+            chain,
+            operation,
+            &request,
+            RESPONSE_HEADER_BYTES + size_of::<ObjectPayload>() as u64,
+        )
+    }
+
+    /// Start execution-queue release, consuming the handle until completion or failure recovery.
+    pub fn destroy_execution_queue(
+        &mut self,
+        chain: Q::Chain,
+        queue: ExecutionQueue,
+    ) -> StartResult<Q, DestroyExecutionQueue> {
+        let stale = queue.epoch() != self.queue.state().epoch();
+        let object = ObjectPayload {
+            object_id: Le64::new(queue.raw()),
+        };
+        let operation = DestroyExecutionQueue { queue };
+        if stale {
+            return self.start_failure(chain, operation, StartErrorKind::StaleHandle);
+        }
+        self.start_wire(chain, operation, &object, RESPONSE_HEADER_BYTES)
+    }
+
+    /// Start submission with bindings encoded directly into the caller chain.
+    pub fn submit(
+        &mut self,
+        chain: Q::Chain,
+        queue: &ExecutionQueue,
+        program: &Program,
+        bindings: &[Binding<'_>],
+        timeout_ns: u64,
+    ) -> StartResult<Q, Submit> {
+        let context = queue
+            .context
+            .expect("execution queue always retains context");
+        let operation = Submit { context };
+        let epoch = self.queue.state().epoch();
+        if queue.epoch() != epoch || program.epoch() != epoch {
+            return self.start_failure(chain, operation, StartErrorKind::StaleHandle);
+        }
+        if program.context != Some(context) || bindings.is_empty() {
+            return self.start_failure(chain, operation, StartErrorKind::InvalidArgument);
+        }
+        let Some(info) = self.device_info else {
+            return self.start_failure(chain, operation, StartErrorKind::DiscoveryRequired);
+        };
+        let Ok(binding_count) = u32::try_from(bindings.len()) else {
+            return self.start_failure(chain, operation, StartErrorKind::DeviceLimit);
+        };
+        if binding_count > info.max_bindings_per_submission {
+            return self.start_failure(chain, operation, StartErrorKind::DeviceLimit);
+        }
+        for (index, binding) in bindings.iter().enumerate() {
+            if binding.buffer.epoch() != epoch {
+                return self.start_failure(chain, operation, StartErrorKind::StaleHandle);
+            }
+            if binding.buffer.context != context
+                || !binding.range.fits(binding.buffer.desc.bytes)
+                || !usage_allows(binding.buffer.desc.usage, binding.access)
+                || bindings[..index]
+                    .iter()
+                    .any(|prior| prior.slot == binding.slot)
+            {
+                return self.start_failure(chain, operation, StartErrorKind::InvalidArgument);
+            }
+        }
+        let request = SubmitRequest {
+            queue_id: Le64::new(queue.raw()),
+            program_id: Le64::new(program.raw()),
+            binding_count: Le32::new(binding_count),
+            flags: Le32::new(0),
+            timeout_ns: Le64::new(timeout_ns),
+        };
+        let payload = size_of::<SubmitRequest>() as u64
+            + size_of::<WireBinding>() as u64 * u64::from(binding_count);
+        self.start_frame(
+            chain,
+            operation,
+            payload,
+            RESPONSE_HEADER_BYTES + size_of::<virtio_accel_proto::SubmitResponse>() as u64,
+            |chain| {
+                write_wire(chain, REQUEST_HEADER_BYTES, &request)
+                    .map_err(FrameWriteError::Chain)?;
+                let mut offset = REQUEST_HEADER_BYTES + size_of::<SubmitRequest>() as u64;
+                for binding in bindings {
+                    let wire = WireBinding {
+                        buffer_id: Le64::new(binding.buffer.raw()),
+                        offset: Le64::new(binding.range.offset),
+                        bytes: Le64::new(binding.range.bytes),
+                        slot: Le32::new(binding.slot),
+                        access: binding.access as u8,
+                        reserved: [0; 3],
+                    };
+                    write_wire(chain, offset, &wire).map_err(FrameWriteError::Chain)?;
+                    offset += size_of::<WireBinding>() as u64;
+                }
+                Ok(())
+            },
+        )
+    }
+
+    /// Start a nonblocking event-state poll.
+    pub fn poll_event(&mut self, chain: Q::Chain, event: &Event) -> StartResult<Q, PollEvent> {
+        if event.epoch() != self.queue.state().epoch() {
+            return self.start_failure(chain, PollEvent, StartErrorKind::StaleHandle);
+        }
+        let request = ObjectPayload {
+            object_id: Le64::new(event.raw()),
+        };
+        self.start_wire(
+            chain,
+            PollEvent,
+            &request,
+            RESPONSE_HEADER_BYTES + size_of::<WireEventState>() as u64,
+        )
+    }
+
+    /// Start event cancellation.
+    pub fn cancel_event(&mut self, chain: Q::Chain, event: &Event) -> StartResult<Q, CancelEvent> {
+        if event.epoch() != self.queue.state().epoch() {
+            return self.start_failure(chain, CancelEvent, StartErrorKind::StaleHandle);
+        }
+        let request = ObjectPayload {
+            object_id: Le64::new(event.raw()),
+        };
+        self.start_wire(chain, CancelEvent, &request, RESPONSE_HEADER_BYTES)
+    }
+
+    /// Start event release, consuming the handle until completion or failure recovery.
+    pub fn destroy_event(&mut self, chain: Q::Chain, event: Event) -> StartResult<Q, DestroyEvent> {
+        let stale = event.epoch() != self.queue.state().epoch();
+        let object = ObjectPayload {
+            object_id: Le64::new(event.raw()),
+        };
+        let operation = DestroyEvent { event };
+        if stale {
+            return self.start_failure(chain, operation, StartErrorKind::StaleHandle);
+        }
+        self.start_wire(chain, operation, &object, RESPONSE_HEADER_BYTES)
+    }
+
+    fn start_wire<O: Operation, T: IntoBytes + Immutable>(
+        &mut self,
+        chain: Q::Chain,
+        operation: O,
+        value: &T,
+        response_bytes: u64,
+    ) -> StartResult<Q, O> {
+        self.start_frame(
+            chain,
+            operation,
+            size_of::<T>() as u64,
+            response_bytes,
+            |chain| write_wire(chain, REQUEST_HEADER_BYTES, value).map_err(FrameWriteError::Chain),
+        )
+    }
+
+    fn start_frame<O: Operation>(
+        &mut self,
+        mut chain: Q::Chain,
+        operation: O,
+        payload_bytes: u64,
+        response_bytes: u64,
+        write_payload: impl FnOnce(
+            &mut Q::Chain,
+        ) -> Result<
+            (),
+            FrameWriteError<<Q::Chain as DriverChainBuffer>::Error>,
+        >,
+    ) -> StartResult<Q, O> {
+        if self.health == ClientHealth::NeedsReset {
+            return self.start_failure(chain, operation, StartErrorKind::NeedsReset);
+        }
+        if operation.requires_discovery() && self.device_info.is_none() {
+            return self.start_failure(chain, operation, StartErrorKind::DiscoveryRequired);
+        }
+        let Some(slot) = self
+            .slots
+            .iter()
+            .position(|slot| matches!(slot, Slot::Vacant))
+        else {
+            return self.start_failure(chain, operation, StartErrorKind::InflightLimit);
+        };
+        let readable_bytes = chain.device_readable_len();
+        let writable_bytes = chain.device_writable_len();
+        let Some(frame_bytes) = REQUEST_HEADER_BYTES.checked_add(payload_bytes) else {
+            return self.start_failure(
+                chain,
+                operation,
+                StartErrorKind::RequestCapacity {
+                    required: u64::MAX,
+                    available: readable_bytes,
+                },
+            );
+        };
+        let max_request = u64::from(self.config.wire().max_request_bytes.get());
+        let max_response = u64::from(self.config.wire().max_response_bytes.get());
+        if frame_bytes > max_request || frame_bytes != readable_bytes {
+            return self.start_failure(
+                chain,
+                operation,
+                StartErrorKind::RequestCapacity {
+                    required: frame_bytes,
+                    available: readable_bytes,
+                },
+            );
+        }
+        if response_bytes > max_response || writable_bytes < response_bytes {
+            return self.start_failure(
+                chain,
+                operation,
+                StartErrorKind::ResponseCapacity {
+                    required: response_bytes,
+                    available: writable_bytes,
+                },
+            );
+        }
+        let Ok(payload_bytes) = u32::try_from(payload_bytes) else {
+            return self.start_failure(
+                chain,
+                operation,
+                StartErrorKind::RequestCapacity {
+                    required: frame_bytes,
+                    available: readable_bytes,
+                },
+            );
+        };
+        let Some(request_id) = self.allocate_request_id() else {
+            return self.start_failure(chain, operation, StartErrorKind::RequestIdExhausted);
+        };
+        let header = RequestHeader::new(
+            operation.opcode(),
+            RequestFlags::empty(),
+            payload_bytes,
+            request_id,
+        );
+        if let Err(error) = write_wire(&mut chain, 0, &header) {
+            return self.start_failure(chain, operation, StartErrorKind::ChainAccess(error));
+        }
+        if let Err(error) = write_payload(&mut chain) {
+            let kind = match error {
+                FrameWriteError::Chain(error) => StartErrorKind::ChainAccess(error),
+                FrameWriteError::Source(error) => StartErrorKind::SourceAccess(error),
+            };
+            return self.start_failure(chain, operation, kind);
+        }
+        let published = match self.queue.publish(chain) {
+            Ok(published) => published,
+            Err(error) => {
+                let (chain, kind) = error.into_parts();
+                return self.start_failure(chain, operation, StartErrorKind::Publish(kind));
+            }
+        };
+        let epoch = published.id().epoch();
+        self.slots[slot] = Slot::InFlight {
+            request_id,
+            chain_id: published.id(),
+        };
+        Ok(Pending {
+            slot: slot as u16,
+            request_id,
+            epoch,
+            operation,
+        })
+    }
+
+    fn start_failure<O>(
+        &self,
+        chain: Q::Chain,
+        operation: O,
+        kind: StartErrorKind<Q::Error, <Q::Chain as DriverChainBuffer>::Error>,
+    ) -> StartResult<Q, O> {
+        Err(StartError {
+            chain,
+            operation,
+            kind,
+        })
+    }
+
+    fn allocate_request_id(&mut self) -> Option<u64> {
+        for _ in 0..=self.slots.len() {
+            let candidate = self.next_request_id.max(1);
+            self.next_request_id = candidate.wrapping_add(1).max(1);
+            if !self.slots.iter().any(|slot| {
+                matches!(slot, Slot::InFlight { request_id, .. } | Slot::Completed { request_id, .. } if *request_id == candidate)
+            }) {
+                return Some(candidate);
+            }
+        }
+        None
+    }
+
+    fn pending_matches<O>(&self, pending: &Pending<O>) -> bool {
+        self.slots
+            .get(usize::from(pending.slot))
+            .is_some_and(|slot| {
+                matches!(slot, Slot::InFlight { request_id, .. } | Slot::Completed { request_id, .. } if *request_id == pending.request_id)
+            })
+    }
+
+    fn decode_completion<O: Operation>(
+        &mut self,
+        pending: Pending<O>,
+        used: UsedChain<Q::Chain>,
+    ) -> Completion<O, Q::Chain, <Q::Chain as DriverChainBuffer>::Error> {
+        let (_, used_length, chain) = used.into_parts();
+        let result = self.validate_response(&pending, &chain, used_length);
+        match result {
+            Ok(OperationResult::Success(output)) => {
+                if O::output_requires_reset(&output) {
+                    self.health = ClientHealth::NeedsReset;
+                }
+                if let Some(info) = O::discovered_info(&output) {
+                    self.device_info = Some(info);
+                }
+                Completion::Success { output, chain }
+            }
+            Ok(OperationResult::DeviceError(status)) => {
+                let disposition = O::failure_disposition(status);
+                if disposition == FailureDisposition::Indeterminate {
+                    self.health = ClientHealth::NeedsReset;
+                }
+                Completion::DeviceError {
+                    status,
+                    disposition,
+                    operation: pending.operation,
+                    chain,
+                }
+            }
+            Err(error) => {
+                self.health = ClientHealth::NeedsReset;
+                Completion::InvalidResponse {
+                    error,
+                    operation: pending.operation,
+                    chain,
+                }
+            }
+        }
+    }
+
+    fn validate_response<O: Operation>(
+        &self,
+        pending: &Pending<O>,
+        chain: &Q::Chain,
+        used: UsedLength,
+    ) -> Result<OperationResult<O::Output>, ResponseError<<Q::Chain as DriverChainBuffer>::Error>>
+    {
+        if u64::from(used.get()) < RESPONSE_HEADER_BYTES {
+            return Err(ResponseError::UsedLength { used: used.get() });
+        }
+        if used.get() > self.config.wire().max_response_bytes.get() {
+            return Err(ResponseError::ResponseLimit);
+        }
+        let mut bytes = [0_u8; size_of::<ResponseHeader>()];
+        chain
+            .read_device_writable(0, &mut bytes)
+            .map_err(ResponseError::HeaderAccess)?;
+        let header =
+            read_exact::<ResponseHeader>(&bytes).map_err(|_| ResponseError::PayloadEncoding)?;
+        let actual_id = header.request_id.get();
+        if actual_id != pending.request_id {
+            return Err(ResponseError::RequestId {
+                expected: pending.request_id,
+                actual: actual_id,
+            });
+        }
+        if header.flags.get() != 0 {
+            return Err(ResponseError::Flags(header.flags.get()));
+        }
+        let expected_used = RESPONSE_HEADER_BYTES
+            .checked_add(u64::from(header.payload_bytes.get()))
+            .ok_or(ResponseError::UsedLength { used: used.get() })?;
+        if expected_used != u64::from(used.get()) {
+            return Err(ResponseError::UsedLength { used: used.get() });
+        }
+        pending.operation.decode(
+            chain,
+            StatusCode(header.status.get()),
+            header.payload_bytes.get(),
+            pending.epoch,
+            self.config,
+        )
+    }
+
+    #[cfg(test)]
+    fn set_next_request_id(&mut self, value: u64) {
+        self.next_request_id = value;
+    }
+}
+
+fn write_wire<C: DriverChainBuffer, T: IntoBytes + Immutable>(
+    chain: &mut C,
+    offset: u64,
+    value: &T,
+) -> Result<(), C::Error> {
+    chain.write_device_readable(offset, value.as_bytes())
+}
+
+fn copy_source<C: DriverChainBuffer, R: ReadableBytes + ?Sized>(
+    chain: &mut C,
+    destination_offset: u64,
+    source: &R,
+) -> Result<(), FrameWriteError<C::Error>> {
+    if let Some(bytes) = source.as_contiguous() {
+        return chain
+            .write_device_readable(destination_offset, bytes)
+            .map_err(FrameWriteError::Chain);
+    }
+    let mut scratch = [0_u8; COPY_SCRATCH_BYTES];
+    let mut copied = 0_u64;
+    while copied < source.len() {
+        let count = usize::try_from(core::cmp::min(
+            source.len() - copied,
+            COPY_SCRATCH_BYTES as u64,
+        ))
+        .expect("bounded copy chunk fits usize");
+        source
+            .read_at(copied, &mut scratch[..count])
+            .map_err(FrameWriteError::Source)?;
+        chain
+            .write_device_readable(destination_offset + copied, &scratch[..count])
+            .map_err(FrameWriteError::Chain)?;
+        copied += count as u64;
+    }
+    Ok(())
+}
+
+fn usage_allows(usage: BufferUsage, access: AccessMode) -> bool {
+    match access {
+        AccessMode::Read => {
+            usage.intersects(BufferUsage::PROGRAM_INPUT | BufferUsage::MUTABLE_STATE)
+        }
+        AccessMode::Write => {
+            usage.intersects(BufferUsage::PROGRAM_OUTPUT | BufferUsage::MUTABLE_STATE)
+        }
+        AccessMode::ReadWrite => usage.contains(BufferUsage::MUTABLE_STATE),
+    }
+}
+
+fn stale_operation<O>(pending: Pending<O>) -> StaleOperation<O> {
+    StaleOperation {
+        request_id: pending.request_id,
+        epoch: pending.epoch,
+        operation: pending.operation,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use core::num::{NonZeroU32, NonZeroU64};
+    use std::vec;
+    use std::vec::Vec;
+
+    use virtio_accel_proto::{Le16, PROTOCOL_MAJOR, PROTOCOL_MINOR, SubmitResponse, WireConfig};
+    use virtio_accel_split_queue::{Descriptor, DriverChain, SplitDeviceChain, SplitQueue};
+    use virtio_accel_transport::{
+        DeviceChain, DeviceQueue, DriverChainBuffer, QueueControl, QueueSize, WritableBytes,
+    };
+
+    use super::*;
+    use crate::types::{MemoryDomain, SubmissionOutcome};
+
+    type TestClient = GuestClient<SplitQueue>;
+
+    fn test_client(size: u16, max_inflight: u16, max_chain_descriptors: u16) -> TestClient {
+        let size = QueueSize::new(size).unwrap();
+        let mut queue = SplitQueue::new(size, max_chain_descriptors).unwrap();
+        QueueControl::configure(&mut queue, size).unwrap();
+        QueueControl::set_ready(&mut queue, true).unwrap();
+        let config = GuestConfig::new(
+            WireConfig {
+                protocol_major: Le16::new(PROTOCOL_MAJOR),
+                protocol_minor: Le16::new(PROTOCOL_MINOR),
+                command_queue_count: Le16::new(1),
+                max_chain_descriptors: Le16::new(max_chain_descriptors),
+                max_request_bytes: Le32::new(4_096),
+                max_response_bytes: Le32::new(4_096),
+            },
+            0,
+            max_inflight,
+        )
+        .unwrap();
+        GuestClient::new(queue, config).unwrap()
+    }
+
+    fn chain(request_bytes: usize, response_bytes: usize) -> DriverChain {
+        DriverChain::direct(vec![
+            Descriptor::readable(vec![0; request_bytes]),
+            Descriptor::writable(vec![0; response_bytes]),
+        ])
+        .unwrap()
+    }
+
+    fn prepared_chain(prefix_bytes: usize, payload: &[u8], response_bytes: usize) -> DriverChain {
+        DriverChain::direct(vec![
+            Descriptor::readable(vec![0; prefix_bytes]),
+            Descriptor::readable(payload.to_vec()),
+            Descriptor::writable(vec![0; response_bytes]),
+        ])
+        .unwrap()
+    }
+
+    fn device_info() -> WireDeviceInfo {
+        WireDeviceInfo {
+            uuid: [0x5a; 16],
+            class: Le16::new(1),
+            reserved: Le16::new(0),
+            vendor_id: Le32::new(0x1234),
+            device_id: Le32::new(0x5678),
+            capabilities: Le64::new((1 << 0) | (1 << 1) | (1 << 2) | (1 << 5)),
+            max_contexts: Le32::new(8),
+            max_buffers_per_context: Le32::new(8),
+            max_programs_per_context: Le32::new(8),
+            max_queues_per_context: Le32::new(8),
+            max_events_per_context: Le32::new(8),
+            max_bindings_per_submission: Le32::new(8),
+            max_buffer_bytes: Le64::new(4_096),
+            max_artifact_bytes: Le64::new(4_000),
+        }
+    }
+
+    fn pop_device_chain(client: &mut TestClient) -> SplitDeviceChain {
+        DeviceQueue::pop_available(&mut client.queue)
+            .unwrap()
+            .expect("published request")
+    }
+
+    fn complete_chain(
+        client: &mut TestClient,
+        mut chain: SplitDeviceChain,
+        status: StatusCode,
+        payload: &[u8],
+        response_id: Option<u64>,
+    ) -> Vec<u8> {
+        let request = {
+            let (_, request, response) = chain.io().unwrap().into_parts();
+            let mut request_bytes = vec![0; request.len() as usize];
+            request.read_at(0, &mut request_bytes).unwrap();
+            let header =
+                read_exact::<RequestHeader>(&request_bytes[..size_of::<RequestHeader>()]).unwrap();
+            let response_header = ResponseHeader::new(
+                status,
+                payload.len() as u32,
+                response_id.unwrap_or_else(|| header.request_id.get()),
+            );
+            response.write_at(0, response_header.as_bytes()).unwrap();
+            response.write_at(RESPONSE_HEADER_BYTES, payload).unwrap();
+            request_bytes
+        };
+        DeviceQueue::complete(
+            &mut client.queue,
+            chain,
+            UsedLength::new((RESPONSE_HEADER_BYTES as usize + payload.len()) as u32),
+        )
+        .unwrap();
+        request
+    }
+
+    fn complete_next(client: &mut TestClient, status: StatusCode, payload: &[u8]) -> Vec<u8> {
+        let chain = pop_device_chain(client);
+        complete_chain(client, chain, status, payload, None)
+    }
+
+    fn success<O: Operation>(
+        client: &mut TestClient,
+        pending: Pending<O>,
+    ) -> (O::Output, DriverChain) {
+        match client.poll(pending) {
+            RequestPoll::Ready(Completion::Success { output, chain }) => (output, chain),
+            RequestPoll::Pending(_) => panic!("request remained pending"),
+            RequestPoll::Ready(Completion::DeviceError { .. }) => panic!("unexpected device error"),
+            RequestPoll::Ready(Completion::InvalidResponse { .. }) => {
+                panic!("unexpected invalid response")
+            }
+            RequestPoll::QueueError { .. } => panic!("unexpected queue error"),
+            RequestPoll::Stale(_) => panic!("unexpected stale request"),
+            RequestPoll::NeedsReset(_) => panic!("unexpected reset requirement"),
+        }
+    }
+
+    fn discover(client: &mut TestClient) {
+        let pending = client
+            .get_device_info(chain(
+                size_of::<RequestHeader>(),
+                size_of::<ResponseHeader>() + size_of::<WireDeviceInfo>(),
+            ))
+            .unwrap();
+        let info = device_info();
+        complete_next(client, StatusCode::OK, info.as_bytes());
+        let (decoded, _) = success(client, pending);
+        assert_eq!(decoded.uuid, [0x5a; 16]);
+    }
+
+    fn object_payload(id: u64) -> ObjectPayload {
+        ObjectPayload {
+            object_id: Le64::new(id),
+        }
+    }
+
+    #[test]
+    fn out_of_order_completions_match_request_ids() {
+        let mut client = test_client(16, 8, 4);
+        let first = client
+            .get_device_info(chain(16, 16 + size_of::<WireDeviceInfo>()))
+            .unwrap();
+        let second = client
+            .get_device_info(chain(16, 16 + size_of::<WireDeviceInfo>()))
+            .unwrap();
+        let first_chain = pop_device_chain(&mut client);
+        let second_chain = pop_device_chain(&mut client);
+        let info = device_info();
+        complete_chain(
+            &mut client,
+            second_chain,
+            StatusCode::OK,
+            info.as_bytes(),
+            None,
+        );
+
+        let first = match client.poll(first) {
+            RequestPoll::Pending(pending) => pending,
+            _ => panic!("first request completed out of order"),
+        };
+        success(&mut client, second);
+        complete_chain(
+            &mut client,
+            first_chain,
+            StatusCode::OK,
+            info.as_bytes(),
+            None,
+        );
+        success(&mut client, first);
+        assert_eq!(client.health(), ClientHealth::Running);
+    }
+
+    #[test]
+    fn request_id_wrap_skips_live_ids() {
+        let mut client = test_client(16, 8, 4);
+        client.set_next_request_id(u64::MAX);
+        let first = client.get_device_info(chain(16, 92)).unwrap();
+        let second = client.get_device_info(chain(16, 92)).unwrap();
+        client.set_next_request_id(u64::MAX);
+        let third = client.get_device_info(chain(16, 92)).unwrap();
+        assert_eq!(first.request_id(), u64::MAX);
+        assert_eq!(second.request_id(), 1);
+        assert_eq!(third.request_id(), 2);
+
+        let next = client.queue_state().epoch().checked_next().unwrap();
+        assert_eq!(client.reset(next).unwrap().count(), 3);
+    }
+
+    #[test]
+    fn malformed_and_unknown_responses_never_create_values() {
+        let mut client = test_client(16, 8, 4);
+        let malformed = client.get_device_info(chain(16, 92)).unwrap();
+        let device_chain = pop_device_chain(&mut client);
+        let info = device_info();
+        complete_chain(
+            &mut client,
+            device_chain,
+            StatusCode::OK,
+            info.as_bytes(),
+            Some(malformed.request_id() + 1),
+        );
+        match client.poll(malformed) {
+            RequestPoll::Ready(Completion::InvalidResponse {
+                error: ResponseError::RequestId { .. },
+                ..
+            }) => {}
+            _ => panic!("wrong request ID was accepted"),
+        }
+        assert_eq!(client.health(), ClientHealth::NeedsReset);
+        let error = client.get_device_info(chain(16, 92)).unwrap_err();
+        assert!(matches!(error.kind(), StartErrorKind::NeedsReset));
+
+        let next = client.queue_state().epoch().checked_next().unwrap();
+        client.reset(next).unwrap();
+        client
+            .reconfigure_queue(QueueSize::new(16).unwrap())
+            .unwrap();
+        let unknown = client.get_device_info(chain(16, 92)).unwrap();
+        complete_next(&mut client, StatusCode(0x1234), &[]);
+        match client.poll(unknown) {
+            RequestPoll::Ready(Completion::DeviceError {
+                status,
+                disposition,
+                ..
+            }) => {
+                assert_eq!(status, StatusCode(0x1234));
+                assert_eq!(disposition, FailureDisposition::Unknown);
+            }
+            _ => panic!("unknown status was not preserved"),
+        }
+        assert!(client.device_info().is_none());
+    }
+
+    #[test]
+    fn reset_returns_queue_and_operation_ownership() {
+        let mut client = test_client(16, 8, 4);
+        discover(&mut client);
+        let create = client
+            .create_context(chain(16 + size_of::<CreateContextRequest>(), 24))
+            .unwrap();
+        complete_next(&mut client, StatusCode::OK, object_payload(7).as_bytes());
+        let (context, _) = success(&mut client, create);
+
+        let rejected = client.destroy_context(chain(24, 16), context).unwrap();
+        complete_next(&mut client, StatusCode::BUSY, &[]);
+        let context = match client.poll(rejected) {
+            RequestPoll::Ready(Completion::DeviceError {
+                status: StatusCode::BUSY,
+                disposition: FailureDisposition::Retryable,
+                operation,
+                ..
+            }) => operation.into_context(),
+            _ => panic!("rejected release was not returned as retryable"),
+        };
+
+        let destroy = client.destroy_context(chain(24, 16), context).unwrap();
+        let next = client.queue_state().epoch().checked_next().unwrap();
+        assert_eq!(client.reset(next).unwrap().count(), 1);
+        let stale = match client.poll(destroy) {
+            RequestPoll::Stale(pending) => pending,
+            _ => panic!("reset did not stale pending release"),
+        };
+        assert_eq!(stale.into_operation().into_context().raw(), 7);
+    }
+
+    #[test]
+    fn reset_recovers_a_completion_already_popped_from_the_used_ring() {
+        let mut client = test_client(16, 8, 4);
+        let pending = client.get_device_info(chain(16, 92)).unwrap();
+        let info = device_info();
+        complete_next(&mut client, StatusCode::OK, info.as_bytes());
+        assert_eq!(
+            client.pump().unwrap(),
+            PumpResult::Completion {
+                request_id: pending.request_id()
+            }
+        );
+
+        let next = client.queue_state().epoch().checked_next().unwrap();
+        assert_eq!(client.reset(next).unwrap().count(), 0);
+        assert!(matches!(client.poll(pending), RequestPoll::Stale(_)));
+        let recovered = client.pop_recovered_completion().unwrap();
+        assert_eq!(recovered.used().get(), 92);
+        assert!(client.pop_recovered_completion().is_none());
+    }
+
+    #[test]
+    fn device_loss_makes_release_ownership_indeterminate() {
+        let mut client = test_client(16, 8, 4);
+        discover(&mut client);
+        let create = client.create_context(chain(24, 24)).unwrap();
+        complete_next(&mut client, StatusCode::OK, object_payload(9).as_bytes());
+        let (context, _) = success(&mut client, create);
+
+        let destroy = client.destroy_context(chain(24, 16), context).unwrap();
+        complete_next(&mut client, StatusCode::DEVICE_LOST, &[]);
+        match client.poll(destroy) {
+            RequestPoll::Ready(Completion::DeviceError {
+                status: StatusCode::DEVICE_LOST,
+                disposition: FailureDisposition::Indeterminate,
+                operation,
+                ..
+            }) => assert_eq!(operation.into_context().raw(), 9),
+            _ => panic!("device loss did not preserve indeterminate ownership"),
+        }
+        assert_eq!(client.health(), ClientHealth::NeedsReset);
+    }
+
+    #[test]
+    fn prepublication_backpressure_returns_chain_and_operation() {
+        let mut client = test_client(4, 4, 2);
+        let _first = client.get_device_info(chain(16, 92)).unwrap();
+        let _second = client.get_device_info(chain(16, 92)).unwrap();
+        let error = client.get_device_info(chain(16, 92)).unwrap_err();
+        let (returned, _operation, kind) = error.into_parts();
+        assert_eq!(returned.device_readable_len(), 16);
+        assert!(matches!(
+            kind,
+            StartErrorKind::Publish(PublishErrorKind::InsufficientDescriptors)
+        ));
+    }
+
+    #[test]
+    fn complete_typed_lifecycle_uses_caller_owned_chain_storage() {
+        let mut client = test_client(16, 8, 4);
+        discover(&mut client);
+
+        let create_context = client.create_context(chain(24, 24)).unwrap();
+        complete_next(&mut client, StatusCode::OK, object_payload(1).as_bytes());
+        let (context, _) = success(&mut client, create_context);
+
+        let desc = BufferDesc::new(
+            64,
+            16,
+            MemoryDomain::Host,
+            BufferUsage::TRANSFER_SOURCE
+                | BufferUsage::TRANSFER_DESTINATION
+                | BufferUsage::PROGRAM_INPUT
+                | BufferUsage::PROGRAM_OUTPUT,
+        )
+        .unwrap();
+        let allocate = client
+            .allocate_buffer(
+                chain(16 + size_of::<AllocateBufferRequest>(), 24),
+                &context,
+                desc,
+            )
+            .unwrap();
+        complete_next(&mut client, StatusCode::OK, object_payload(2).as_bytes());
+        let (buffer, _) = success(&mut client, allocate);
+
+        let copied = b"copy";
+        let write = client
+            .write_buffer(
+                chain(16 + size_of::<TransferBufferRequest>() + copied.len(), 16),
+                &buffer,
+                0,
+                &copied[..],
+            )
+            .unwrap();
+        let request = complete_next(&mut client, StatusCode::OK, &[]);
+        assert_eq!(&request[40..], copied);
+        success(&mut client, write);
+
+        let prepared = b"direct";
+        let write = client
+            .write_buffer_prepared(
+                prepared_chain(40, prepared, 16),
+                &buffer,
+                BufferRange::new(4, prepared.len() as u64).unwrap(),
+            )
+            .unwrap();
+        let request = complete_next(&mut client, StatusCode::OK, &[]);
+        assert_eq!(&request[40..], prepared);
+        success(&mut client, write);
+
+        let read = client
+            .read_buffer(chain(40, 20), &buffer, BufferRange::new(0, 4).unwrap())
+            .unwrap();
+        complete_next(&mut client, StatusCode::OK, b"data");
+        let (read_output, read_chain) = success(&mut client, read);
+        assert_eq!(read_output.bytes, 4);
+        let mut read_bytes = [0; 4];
+        read_chain
+            .read_device_writable(RESPONSE_HEADER_BYTES, &mut read_bytes)
+            .unwrap();
+        assert_eq!(&read_bytes, b"data");
+
+        let program_desc = ProgramDesc::new(
+            NonZeroU32::new(1).unwrap(),
+            [0; 12],
+            NonZeroU64::new(32).unwrap(),
+        );
+        let artifact = b"program";
+        let load = client
+            .load_program_prepared(
+                prepared_chain(16 + size_of::<LoadProgramRequest>(), artifact, 24),
+                &context,
+                program_desc,
+                artifact.len() as u64,
+            )
+            .unwrap();
+        let request = complete_next(&mut client, StatusCode::OK, object_payload(3).as_bytes());
+        assert_eq!(&request[96..], artifact);
+        let (program, _) = success(&mut client, load);
+
+        let create_queue = client
+            .create_execution_queue(chain(16 + size_of::<CreateQueueRequest>(), 24), &context)
+            .unwrap();
+        complete_next(&mut client, StatusCode::OK, object_payload(4).as_bytes());
+        let (queue, _) = success(&mut client, create_queue);
+
+        let bindings = [Binding {
+            buffer: &buffer,
+            range: BufferRange::new(0, 16).unwrap(),
+            slot: 0,
+            access: AccessMode::Read,
+        }];
+        let submit = client
+            .submit(
+                chain(
+                    16 + size_of::<SubmitRequest>() + size_of::<WireBinding>(),
+                    16 + size_of::<SubmitResponse>(),
+                ),
+                &queue,
+                &program,
+                &bindings,
+                1_000_000,
+            )
+            .unwrap();
+        let submit_response = SubmitResponse {
+            event_id: Le64::new(5),
+        };
+        complete_next(&mut client, StatusCode::OK, submit_response.as_bytes());
+        let (outcome, _) = success(&mut client, submit);
+        let event = match outcome {
+            SubmissionOutcome::Accepted(event) => event,
+            SubmissionOutcome::Indeterminate { .. } => panic!("unexpected indeterminate submit"),
+        };
+
+        let poll = client.poll_event(chain(24, 24), &event).unwrap();
+        let state = WireEventState {
+            state: Le16::new(1),
+            error: Le16::new(0),
+            reserved: Le32::new(0),
+        };
+        complete_next(&mut client, StatusCode::OK, state.as_bytes());
+        assert_eq!(success(&mut client, poll).0, crate::EventState::Complete);
+
+        let cancel = client.cancel_event(chain(24, 16), &event).unwrap();
+        complete_next(&mut client, StatusCode::OK, &[]);
+        success(&mut client, cancel);
+
+        let destroy_event = client.destroy_event(chain(24, 16), event).unwrap();
+        complete_next(&mut client, StatusCode::OK, &[]);
+        success(&mut client, destroy_event);
+
+        let destroy_queue = client
+            .destroy_execution_queue(chain(24, 16), queue)
+            .unwrap();
+        complete_next(&mut client, StatusCode::OK, &[]);
+        success(&mut client, destroy_queue);
+
+        let unload = client.unload_program(chain(24, 16), program).unwrap();
+        complete_next(&mut client, StatusCode::OK, &[]);
+        success(&mut client, unload);
+
+        let free = client.free_buffer(chain(24, 16), buffer).unwrap();
+        complete_next(&mut client, StatusCode::OK, &[]);
+        success(&mut client, free);
+
+        let destroy_context = client.destroy_context(chain(24, 16), context).unwrap();
+        complete_next(&mut client, StatusCode::OK, &[]);
+        success(&mut client, destroy_context);
+    }
+
+    #[test]
+    fn mutable_state_allows_every_program_access_mode() {
+        assert!(usage_allows(BufferUsage::MUTABLE_STATE, AccessMode::Read));
+        assert!(usage_allows(BufferUsage::MUTABLE_STATE, AccessMode::Write));
+        assert!(usage_allows(
+            BufferUsage::MUTABLE_STATE,
+            AccessMode::ReadWrite
+        ));
+        assert!(!usage_allows(
+            BufferUsage::PROGRAM_INPUT | BufferUsage::PROGRAM_OUTPUT,
+            AccessMode::ReadWrite
+        ));
+    }
+}

--- a/crates/virtio-accel-guest/src/config.rs
+++ b/crates/virtio-accel-guest/src/config.rs
@@ -1,0 +1,74 @@
+use virtio_accel_proto::{ConfigError, WireConfig};
+use virtio_accel_transport::{QueueSize, QueueState};
+
+/// Validated protocol configuration and bounded guest tracking limit.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct GuestConfig {
+    wire: WireConfig,
+    max_inflight: u16,
+}
+
+impl GuestConfig {
+    /// Validate the device-specific configuration and offered feature bits.
+    ///
+    /// Protocol 1.0 accepts no device-specific transport feature bits, including unknown bits.
+    pub fn new(
+        wire: WireConfig,
+        offered_features: u64,
+        max_inflight: u16,
+    ) -> Result<Self, GuestConfigError> {
+        wire.validate().map_err(GuestConfigError::Wire)?;
+        if offered_features != 0 {
+            return Err(GuestConfigError::Features);
+        }
+        if max_inflight == 0 {
+            return Err(GuestConfigError::InflightLimit);
+        }
+        Ok(Self { wire, max_inflight })
+    }
+
+    /// Validated wire configuration.
+    pub const fn wire(self) -> WireConfig {
+        self.wire
+    }
+
+    /// Maximum requests retained by this client.
+    pub const fn max_inflight(self) -> u16 {
+        self.max_inflight
+    }
+
+    pub(crate) fn validate_queue(self, state: QueueState) -> Result<(), GuestConfigError> {
+        let size = state.size().ok_or(GuestConfigError::QueueNotConfigured)?;
+        if !state.ready() {
+            return Err(GuestConfigError::QueueNotReady);
+        }
+        self.validate_size(size)
+    }
+
+    pub(crate) fn validate_size(self, size: QueueSize) -> Result<(), GuestConfigError> {
+        if self.wire.max_chain_descriptors.get() > size.get() {
+            return Err(GuestConfigError::QueueSize);
+        }
+        if self.max_inflight > size.get() {
+            return Err(GuestConfigError::InflightLimit);
+        }
+        Ok(())
+    }
+}
+
+/// Invalid guest-visible configuration or negotiation result.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GuestConfigError {
+    /// Device-specific configuration violates protocol 1.0.
+    Wire(ConfigError),
+    /// Protocol 1.0 cannot accept any offered device-specific feature bit.
+    Features,
+    /// The command queue has no configured size.
+    QueueNotConfigured,
+    /// The command queue is not ready.
+    QueueNotReady,
+    /// The queue is smaller than the advertised descriptor-chain limit.
+    QueueSize,
+    /// The tracking limit is zero or exceeds queue capacity.
+    InflightLimit,
+}

--- a/crates/virtio-accel-guest/src/lib.rs
+++ b/crates/virtio-accel-guest/src/lib.rs
@@ -1,0 +1,31 @@
+//! No-std reference driver for portable virtio-accel protocol 1.0.
+//!
+//! Callers provide complete driver-owned chains. The client writes exact request frames into those
+//! chains, tracks bounded in-flight ownership, and validates all device-written bytes after used
+//! reclamation. It names no VMM, guest-memory library, operating system, or device backend.
+
+#![no_std]
+#![forbid(unsafe_code)]
+
+extern crate alloc;
+
+mod client;
+mod config;
+mod operation;
+mod types;
+
+pub use client::{
+    ClientHealth, ClientInitError, Completion, GuestClient, Pending, PumpResult, QueueSetupError,
+    RequestPoll, StaleOperation, StartError, StartErrorKind, StartResult,
+};
+pub use config::{GuestConfig, GuestConfigError};
+pub use operation::{
+    AllocateBuffer, CancelEvent, CreateContext, CreateExecutionQueue, DestroyContext, DestroyEvent,
+    DestroyExecutionQueue, FreeBuffer, GetDeviceInfo, LoadProgram, Operation, PollEvent,
+    ReadBuffer, ResponseError, Submit, UnloadProgram, WriteBuffer,
+};
+pub use types::{
+    AccessMode, Binding, Buffer, BufferDesc, BufferRange, BufferUsage, Context, DeviceInfo,
+    DeviceInfoError, Event, EventState, ExecutionQueue, FailureDisposition, MemoryDomain, Program,
+    ProgramDesc, ReadBufferOutput, SubmissionOutcome, ValueError,
+};

--- a/crates/virtio-accel-guest/src/operation.rs
+++ b/crates/virtio-accel-guest/src/operation.rs
@@ -1,0 +1,709 @@
+use core::mem::size_of;
+use core::num::NonZeroU64;
+
+use virtio_accel_proto::{
+    KnownEventState, KnownOpcode, ObjectPayload, StatusCode, SubmitResponse, WireDeviceInfo,
+    WireEventState, read_exact,
+};
+use virtio_accel_transport::{DriverChainBuffer, QueueEpoch};
+use zerocopy::FromBytes;
+
+use crate::config::GuestConfig;
+use crate::types::{
+    Buffer, BufferDesc, Context, DeviceInfo, DeviceInfoError, Event, EventState, ExecutionQueue,
+    FailureDisposition, Handle, Program, ProgramDesc, ReadBufferOutput, SubmissionOutcome,
+};
+
+const RESPONSE_HEADER_BYTES: u64 = 16;
+const MAX_FIXED_PAYLOAD_BYTES: usize = size_of::<WireDeviceInfo>();
+
+/// Malformed or inaccessible device response.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ResponseError<E> {
+    /// Used length cannot contain the required response header or exact payload.
+    UsedLength {
+        /// Published used length.
+        used: u32,
+    },
+    /// The response exceeds the negotiated frame limit.
+    ResponseLimit,
+    /// The response header cannot be read.
+    HeaderAccess(E),
+    /// The response payload cannot be read.
+    PayloadAccess(E),
+    /// Response request ID does not match the chain's request.
+    RequestId {
+        /// Expected request ID.
+        expected: u64,
+        /// Device-provided request ID.
+        actual: u64,
+    },
+    /// Protocol 1.0 response flags are nonzero.
+    Flags(u16),
+    /// Payload shape does not match the operation and status.
+    PayloadLength {
+        /// Required payload bytes.
+        expected: u64,
+        /// Device-provided payload bytes.
+        actual: u32,
+    },
+    /// A fixed payload cannot be decoded from its exact bytes.
+    PayloadEncoding,
+    /// A successful object-creation response returned object ID zero.
+    ObjectId,
+    /// Device discovery returned invalid limits or reserved values.
+    DeviceInfo(DeviceInfoError),
+    /// Event state uses an unknown numeric value.
+    EventState(u16),
+    /// Event state and error status contradict each other.
+    EventStatus {
+        /// Raw event state.
+        state: u16,
+        /// Raw event error status.
+        error: StatusCode,
+    },
+}
+
+#[doc(hidden)]
+pub enum OperationResult<T> {
+    Success(T),
+    DeviceError(StatusCode),
+}
+
+mod sealed {
+    pub trait Sealed {}
+}
+
+/// Sealed response contract for one typed pending operation.
+pub trait Operation: sealed::Sealed + Sized {
+    /// Validated successful response value.
+    type Output;
+
+    /// Command opcode represented by this operation.
+    fn opcode(&self) -> KnownOpcode;
+
+    /// Whether device discovery must complete before this operation can be published.
+    fn requires_discovery(&self) -> bool {
+        true
+    }
+
+    #[doc(hidden)]
+    fn decode<C: DriverChainBuffer>(
+        &self,
+        chain: &C,
+        status: StatusCode,
+        payload_bytes: u32,
+        epoch: QueueEpoch,
+        config: GuestConfig,
+    ) -> Result<OperationResult<Self::Output>, ResponseError<C::Error>>;
+
+    #[doc(hidden)]
+    fn discovered_info(_output: &Self::Output) -> Option<DeviceInfo> {
+        None
+    }
+
+    #[doc(hidden)]
+    fn failure_disposition(status: StatusCode) -> FailureDisposition {
+        if !status.is_known() {
+            FailureDisposition::Unknown
+        } else if status == StatusCode::STALE_OBJECT {
+            FailureDisposition::Invalidated
+        } else if status == StatusCode::DEVICE_LOST {
+            FailureDisposition::Indeterminate
+        } else {
+            FailureDisposition::Retryable
+        }
+    }
+
+    #[doc(hidden)]
+    fn output_requires_reset(_output: &Self::Output) -> bool {
+        false
+    }
+}
+
+macro_rules! empty_operation {
+    ($name:ident, $opcode:ident) => {
+        #[doc = concat!("Pending `", stringify!($opcode), "` operation.")]
+        #[derive(Debug)]
+        pub struct $name;
+
+        impl sealed::Sealed for $name {}
+
+        impl Operation for $name {
+            type Output = ();
+
+            fn opcode(&self) -> KnownOpcode {
+                KnownOpcode::$opcode
+            }
+
+            fn decode<C: DriverChainBuffer>(
+                &self,
+                _chain: &C,
+                status: StatusCode,
+                payload_bytes: u32,
+                _epoch: QueueEpoch,
+                _config: GuestConfig,
+            ) -> Result<OperationResult<Self::Output>, ResponseError<C::Error>> {
+                ordinary(status, payload_bytes, 0, || Ok(()))
+            }
+        }
+    };
+}
+
+/// Pending device-discovery operation.
+#[derive(Debug)]
+pub struct GetDeviceInfo;
+
+impl sealed::Sealed for GetDeviceInfo {}
+
+impl Operation for GetDeviceInfo {
+    type Output = DeviceInfo;
+
+    fn opcode(&self) -> KnownOpcode {
+        KnownOpcode::GetDeviceInfo
+    }
+
+    fn requires_discovery(&self) -> bool {
+        false
+    }
+
+    fn decode<C: DriverChainBuffer>(
+        &self,
+        chain: &C,
+        status: StatusCode,
+        payload_bytes: u32,
+        _epoch: QueueEpoch,
+        config: GuestConfig,
+    ) -> Result<OperationResult<Self::Output>, ResponseError<C::Error>> {
+        ordinary(
+            status,
+            payload_bytes,
+            size_of::<WireDeviceInfo>() as u64,
+            || {
+                let wire = read_payload::<WireDeviceInfo, C>(chain)?;
+                DeviceInfo::from_wire(wire, config.wire().max_request_bytes.get())
+                    .map_err(ResponseError::DeviceInfo)
+            },
+        )
+    }
+
+    fn discovered_info(output: &Self::Output) -> Option<DeviceInfo> {
+        Some(*output)
+    }
+}
+
+/// Pending context-creation operation.
+#[derive(Debug)]
+pub struct CreateContext;
+
+impl sealed::Sealed for CreateContext {}
+
+impl Operation for CreateContext {
+    type Output = Context;
+
+    fn opcode(&self) -> KnownOpcode {
+        KnownOpcode::CreateContext
+    }
+
+    fn decode<C: DriverChainBuffer>(
+        &self,
+        chain: &C,
+        status: StatusCode,
+        payload_bytes: u32,
+        epoch: QueueEpoch,
+        _config: GuestConfig,
+    ) -> Result<OperationResult<Self::Output>, ResponseError<C::Error>> {
+        ordinary_object(status, payload_bytes, chain, |id| Context {
+            handle: Handle::new(id, epoch),
+            context: None,
+        })
+    }
+}
+
+/// Pending context destruction; retained on failure for explicit retry.
+#[derive(Debug)]
+pub struct DestroyContext {
+    pub(crate) context: Context,
+}
+
+impl DestroyContext {
+    /// Inspect or recover the consumed context after failure.
+    ///
+    /// Retry it only when the completion disposition is `Retryable`.
+    pub fn into_context(self) -> Context {
+        self.context
+    }
+}
+
+impl sealed::Sealed for DestroyContext {}
+
+impl Operation for DestroyContext {
+    type Output = ();
+
+    fn opcode(&self) -> KnownOpcode {
+        KnownOpcode::DestroyContext
+    }
+
+    fn decode<C: DriverChainBuffer>(
+        &self,
+        _chain: &C,
+        status: StatusCode,
+        payload_bytes: u32,
+        _epoch: QueueEpoch,
+        _config: GuestConfig,
+    ) -> Result<OperationResult<Self::Output>, ResponseError<C::Error>> {
+        ordinary(status, payload_bytes, 0, || Ok(()))
+    }
+}
+
+/// Pending buffer allocation.
+#[derive(Debug)]
+pub struct AllocateBuffer {
+    pub(crate) context: NonZeroU64,
+    pub(crate) desc: BufferDesc,
+}
+
+impl sealed::Sealed for AllocateBuffer {}
+
+impl Operation for AllocateBuffer {
+    type Output = Buffer;
+
+    fn opcode(&self) -> KnownOpcode {
+        KnownOpcode::AllocateBuffer
+    }
+
+    fn decode<C: DriverChainBuffer>(
+        &self,
+        chain: &C,
+        status: StatusCode,
+        payload_bytes: u32,
+        epoch: QueueEpoch,
+        _config: GuestConfig,
+    ) -> Result<OperationResult<Self::Output>, ResponseError<C::Error>> {
+        ordinary_object(status, payload_bytes, chain, |id| Buffer {
+            handle: Handle::new(id, epoch),
+            context: self.context,
+            desc: self.desc,
+        })
+    }
+}
+
+/// Pending buffer release; retained on failure for explicit retry.
+#[derive(Debug)]
+pub struct FreeBuffer {
+    pub(crate) buffer: Buffer,
+}
+
+impl FreeBuffer {
+    /// Inspect or recover the consumed buffer after failure.
+    ///
+    /// Retry it only when the completion disposition is `Retryable`.
+    pub fn into_buffer(self) -> Buffer {
+        self.buffer
+    }
+}
+
+impl sealed::Sealed for FreeBuffer {}
+
+impl Operation for FreeBuffer {
+    type Output = ();
+
+    fn opcode(&self) -> KnownOpcode {
+        KnownOpcode::FreeBuffer
+    }
+
+    fn decode<C: DriverChainBuffer>(
+        &self,
+        _chain: &C,
+        status: StatusCode,
+        payload_bytes: u32,
+        _epoch: QueueEpoch,
+        _config: GuestConfig,
+    ) -> Result<OperationResult<Self::Output>, ResponseError<C::Error>> {
+        ordinary(status, payload_bytes, 0, || Ok(()))
+    }
+}
+
+empty_operation!(WriteBuffer, WriteBuffer);
+
+/// Pending buffer-read operation.
+#[derive(Debug)]
+pub struct ReadBuffer {
+    pub(crate) bytes: u64,
+}
+
+impl Operation for ReadBuffer {
+    type Output = ReadBufferOutput;
+
+    fn opcode(&self) -> KnownOpcode {
+        KnownOpcode::ReadBuffer
+    }
+
+    fn decode<C: DriverChainBuffer>(
+        &self,
+        _chain: &C,
+        status: StatusCode,
+        payload_bytes: u32,
+        _epoch: QueueEpoch,
+        _config: GuestConfig,
+    ) -> Result<OperationResult<Self::Output>, ResponseError<C::Error>> {
+        ordinary(status, payload_bytes, self.bytes, || {
+            Ok(ReadBufferOutput { bytes: self.bytes })
+        })
+    }
+}
+
+impl sealed::Sealed for ReadBuffer {}
+
+/// Pending program load.
+#[derive(Debug)]
+pub struct LoadProgram {
+    pub(crate) context: NonZeroU64,
+    pub(crate) desc: ProgramDesc,
+}
+
+impl sealed::Sealed for LoadProgram {}
+
+impl Operation for LoadProgram {
+    type Output = Program;
+
+    fn opcode(&self) -> KnownOpcode {
+        KnownOpcode::LoadProgram
+    }
+
+    fn decode<C: DriverChainBuffer>(
+        &self,
+        chain: &C,
+        status: StatusCode,
+        payload_bytes: u32,
+        epoch: QueueEpoch,
+        _config: GuestConfig,
+    ) -> Result<OperationResult<Self::Output>, ResponseError<C::Error>> {
+        let _ = self.desc;
+        ordinary_object(status, payload_bytes, chain, |id| Program {
+            handle: Handle::new(id, epoch),
+            context: Some(self.context),
+        })
+    }
+}
+
+/// Pending program unload; retained on failure for explicit retry.
+#[derive(Debug)]
+pub struct UnloadProgram {
+    pub(crate) program: Program,
+}
+
+impl UnloadProgram {
+    /// Inspect or recover the consumed program after failure.
+    ///
+    /// Retry it only when the completion disposition is `Retryable`.
+    pub fn into_program(self) -> Program {
+        self.program
+    }
+}
+
+impl sealed::Sealed for UnloadProgram {}
+
+impl Operation for UnloadProgram {
+    type Output = ();
+
+    fn opcode(&self) -> KnownOpcode {
+        KnownOpcode::UnloadProgram
+    }
+
+    fn decode<C: DriverChainBuffer>(
+        &self,
+        _chain: &C,
+        status: StatusCode,
+        payload_bytes: u32,
+        _epoch: QueueEpoch,
+        _config: GuestConfig,
+    ) -> Result<OperationResult<Self::Output>, ResponseError<C::Error>> {
+        ordinary(status, payload_bytes, 0, || Ok(()))
+    }
+}
+
+/// Pending accelerator execution-queue creation.
+#[derive(Debug)]
+pub struct CreateExecutionQueue {
+    pub(crate) context: NonZeroU64,
+}
+
+impl sealed::Sealed for CreateExecutionQueue {}
+
+impl Operation for CreateExecutionQueue {
+    type Output = ExecutionQueue;
+
+    fn opcode(&self) -> KnownOpcode {
+        KnownOpcode::CreateQueue
+    }
+
+    fn decode<C: DriverChainBuffer>(
+        &self,
+        chain: &C,
+        status: StatusCode,
+        payload_bytes: u32,
+        epoch: QueueEpoch,
+        _config: GuestConfig,
+    ) -> Result<OperationResult<Self::Output>, ResponseError<C::Error>> {
+        ordinary_object(status, payload_bytes, chain, |id| ExecutionQueue {
+            handle: Handle::new(id, epoch),
+            context: Some(self.context),
+        })
+    }
+}
+
+/// Pending execution-queue destruction; retained on failure for explicit retry.
+#[derive(Debug)]
+pub struct DestroyExecutionQueue {
+    pub(crate) queue: ExecutionQueue,
+}
+
+impl DestroyExecutionQueue {
+    /// Inspect or recover the consumed queue after failure.
+    ///
+    /// Retry it only when the completion disposition is `Retryable`.
+    pub fn into_queue(self) -> ExecutionQueue {
+        self.queue
+    }
+}
+
+impl sealed::Sealed for DestroyExecutionQueue {}
+
+impl Operation for DestroyExecutionQueue {
+    type Output = ();
+
+    fn opcode(&self) -> KnownOpcode {
+        KnownOpcode::DestroyQueue
+    }
+
+    fn decode<C: DriverChainBuffer>(
+        &self,
+        _chain: &C,
+        status: StatusCode,
+        payload_bytes: u32,
+        _epoch: QueueEpoch,
+        _config: GuestConfig,
+    ) -> Result<OperationResult<Self::Output>, ResponseError<C::Error>> {
+        ordinary(status, payload_bytes, 0, || Ok(()))
+    }
+}
+
+/// Pending submission admission.
+#[derive(Debug)]
+pub struct Submit {
+    pub(crate) context: NonZeroU64,
+}
+
+impl sealed::Sealed for Submit {}
+
+impl Operation for Submit {
+    type Output = SubmissionOutcome;
+
+    fn opcode(&self) -> KnownOpcode {
+        KnownOpcode::Submit
+    }
+
+    fn decode<C: DriverChainBuffer>(
+        &self,
+        chain: &C,
+        status: StatusCode,
+        payload_bytes: u32,
+        epoch: QueueEpoch,
+        _config: GuestConfig,
+    ) -> Result<OperationResult<Self::Output>, ResponseError<C::Error>> {
+        if status.is_success() {
+            expect_payload::<C::Error>(payload_bytes, size_of::<SubmitResponse>() as u64)?;
+            let event = decode_event(chain, epoch, self.context)?;
+            return Ok(OperationResult::Success(SubmissionOutcome::Accepted(event)));
+        }
+        if payload_bytes == 0 {
+            return Ok(OperationResult::DeviceError(status));
+        }
+        if !status.is_known() {
+            return Err(ResponseError::PayloadLength {
+                expected: 0,
+                actual: payload_bytes,
+            });
+        }
+        expect_payload::<C::Error>(payload_bytes, size_of::<SubmitResponse>() as u64)?;
+        let event = decode_event(chain, epoch, self.context)?;
+        Ok(OperationResult::Success(SubmissionOutcome::Indeterminate {
+            status,
+            event,
+        }))
+    }
+
+    fn output_requires_reset(output: &Self::Output) -> bool {
+        matches!(
+            output,
+            SubmissionOutcome::Indeterminate {
+                status: StatusCode::DEVICE_LOST,
+                ..
+            }
+        )
+    }
+}
+
+/// Pending nonblocking event poll.
+#[derive(Debug)]
+pub struct PollEvent;
+
+impl sealed::Sealed for PollEvent {}
+
+impl Operation for PollEvent {
+    type Output = EventState;
+
+    fn opcode(&self) -> KnownOpcode {
+        KnownOpcode::PollEvent
+    }
+
+    fn decode<C: DriverChainBuffer>(
+        &self,
+        chain: &C,
+        status: StatusCode,
+        payload_bytes: u32,
+        _epoch: QueueEpoch,
+        _config: GuestConfig,
+    ) -> Result<OperationResult<Self::Output>, ResponseError<C::Error>> {
+        ordinary(
+            status,
+            payload_bytes,
+            size_of::<WireEventState>() as u64,
+            || decode_event_state(chain),
+        )
+    }
+
+    fn output_requires_reset(output: &Self::Output) -> bool {
+        matches!(output, EventState::Failed(StatusCode::DEVICE_LOST))
+    }
+}
+
+empty_operation!(CancelEvent, CancelEvent);
+
+/// Pending event destruction; retained on failure for explicit retry.
+#[derive(Debug)]
+pub struct DestroyEvent {
+    pub(crate) event: Event,
+}
+
+impl DestroyEvent {
+    /// Inspect or recover the consumed event after failure.
+    ///
+    /// Retry it only when the completion disposition is `Retryable`.
+    pub fn into_event(self) -> Event {
+        self.event
+    }
+}
+
+impl sealed::Sealed for DestroyEvent {}
+
+impl Operation for DestroyEvent {
+    type Output = ();
+
+    fn opcode(&self) -> KnownOpcode {
+        KnownOpcode::DestroyEvent
+    }
+
+    fn decode<C: DriverChainBuffer>(
+        &self,
+        _chain: &C,
+        status: StatusCode,
+        payload_bytes: u32,
+        _epoch: QueueEpoch,
+        _config: GuestConfig,
+    ) -> Result<OperationResult<Self::Output>, ResponseError<C::Error>> {
+        ordinary(status, payload_bytes, 0, || Ok(()))
+    }
+}
+
+fn ordinary<T, E>(
+    status: StatusCode,
+    payload_bytes: u32,
+    success_bytes: u64,
+    success: impl FnOnce() -> Result<T, ResponseError<E>>,
+) -> Result<OperationResult<T>, ResponseError<E>> {
+    if !status.is_success() {
+        expect_payload::<E>(payload_bytes, 0)?;
+        return Ok(OperationResult::DeviceError(status));
+    }
+    expect_payload::<E>(payload_bytes, success_bytes)?;
+    success().map(OperationResult::Success)
+}
+
+fn ordinary_object<T, C: DriverChainBuffer>(
+    status: StatusCode,
+    payload_bytes: u32,
+    chain: &C,
+    construct: impl FnOnce(NonZeroU64) -> T,
+) -> Result<OperationResult<T>, ResponseError<C::Error>> {
+    ordinary(
+        status,
+        payload_bytes,
+        size_of::<ObjectPayload>() as u64,
+        || {
+            let object = read_payload::<ObjectPayload, C>(chain)?;
+            let id = NonZeroU64::new(object.object_id.get()).ok_or(ResponseError::ObjectId)?;
+            Ok(construct(id))
+        },
+    )
+}
+
+fn expect_payload<E>(actual: u32, expected: u64) -> Result<(), ResponseError<E>> {
+    if u64::from(actual) == expected {
+        Ok(())
+    } else {
+        Err(ResponseError::PayloadLength { expected, actual })
+    }
+}
+
+fn read_payload<T: FromBytes, C: DriverChainBuffer>(
+    chain: &C,
+) -> Result<T, ResponseError<C::Error>> {
+    let bytes = size_of::<T>();
+    if bytes > MAX_FIXED_PAYLOAD_BYTES {
+        return Err(ResponseError::PayloadEncoding);
+    }
+    let mut scratch = [0_u8; MAX_FIXED_PAYLOAD_BYTES];
+    chain
+        .read_device_writable(RESPONSE_HEADER_BYTES, &mut scratch[..bytes])
+        .map_err(ResponseError::PayloadAccess)?;
+    read_exact(&scratch[..bytes]).map_err(|_| ResponseError::PayloadEncoding)
+}
+
+fn decode_event<C: DriverChainBuffer>(
+    chain: &C,
+    epoch: QueueEpoch,
+    context: NonZeroU64,
+) -> Result<Event, ResponseError<C::Error>> {
+    let response = read_payload::<SubmitResponse, C>(chain)?;
+    let id = NonZeroU64::new(response.event_id.get()).ok_or(ResponseError::ObjectId)?;
+    Ok(Event {
+        handle: Handle::new(id, epoch),
+        context: Some(context),
+    })
+}
+
+fn decode_event_state<C: DriverChainBuffer>(
+    chain: &C,
+) -> Result<EventState, ResponseError<C::Error>> {
+    let value = read_payload::<WireEventState, C>(chain)?;
+    if value.reserved.get() != 0 {
+        return Err(ResponseError::PayloadEncoding);
+    }
+    let raw_state = value.state.get();
+    let error = StatusCode(value.error.get());
+    match value
+        .known_state()
+        .map_err(|_| ResponseError::EventState(raw_state))?
+    {
+        KnownEventState::Pending if error.is_success() => Ok(EventState::Pending),
+        KnownEventState::Complete if error.is_success() => Ok(EventState::Complete),
+        KnownEventState::Failed if !error.is_success() => Ok(EventState::Failed(error)),
+        KnownEventState::Cancelled if error.is_success() => Ok(EventState::Cancelled),
+        _ => Err(ResponseError::EventStatus {
+            state: raw_state,
+            error,
+        }),
+    }
+}

--- a/crates/virtio-accel-guest/src/types.rs
+++ b/crates/virtio-accel-guest/src/types.rs
@@ -1,0 +1,430 @@
+use bitflags::bitflags;
+use core::num::{NonZeroU32, NonZeroU64};
+
+use virtio_accel_proto::{HARD_MAX_BINDINGS, StatusCode, WireDeviceInfo};
+use virtio_accel_transport::QueueEpoch;
+
+const CAPABILITY_HOST_VISIBLE_MEMORY: u64 = 1 << 0;
+const CAPABILITY_DEVICE_LOCAL_MEMORY: u64 = 1 << 1;
+const CAPABILITY_EVENT_CANCELLATION: u64 = 1 << 2;
+const CAPABILITY_RESERVED_EXTERNAL_MEMORY: u64 = 1 << 3;
+const CAPABILITY_RESERVED_SECURE_CONTEXTS: u64 = 1 << 4;
+const CAPABILITY_SHARED_MEMORY: u64 = 1 << 5;
+const RESERVED_CAPABILITIES: u64 =
+    CAPABILITY_RESERVED_EXTERNAL_MEMORY | CAPABILITY_RESERVED_SECURE_CONTEXTS;
+
+bitflags! {
+    /// Protocol 1.0 buffer usage bits.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    pub struct BufferUsage: u32 {
+        const TRANSFER_SOURCE = 1 << 0;
+        const TRANSFER_DESTINATION = 1 << 1;
+        const PROGRAM_INPUT = 1 << 2;
+        const PROGRAM_OUTPUT = 1 << 3;
+        const MUTABLE_STATE = 1 << 4;
+    }
+}
+
+/// Requested provider-owned memory placement.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum MemoryDomain {
+    /// Host-preferred memory.
+    Host = 1,
+    /// Accelerator-local memory.
+    Device = 2,
+    /// Provider-owned host-visible, directly bindable memory.
+    Shared = 3,
+}
+
+/// Program binding access mode.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum AccessMode {
+    /// Program reads the buffer.
+    Read = 1,
+    /// Program writes the buffer.
+    Write = 2,
+    /// Program reads and writes the buffer.
+    ReadWrite = 3,
+}
+
+/// Locally invalid typed request value.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ValueError {
+    /// A required scalar is zero.
+    Zero,
+    /// A byte range overflows.
+    Overflow,
+    /// Alignment is not a nonzero power of two.
+    Alignment,
+    /// Buffer usage is empty or contains an unknown bit.
+    BufferUsage,
+}
+
+/// Guest-side ownership meaning of a well-formed non-success response.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FailureDisposition {
+    /// The device rejected the operation before consuming semantic ownership.
+    Retryable,
+    /// A referenced object is stale and must not be retried as live.
+    Invalidated,
+    /// Device loss leaves semantic ownership uncertain and requires reset.
+    Indeterminate,
+    /// An unknown status has no protocol 1.0 ownership meaning.
+    Unknown,
+}
+
+/// Requested buffer properties retained by the typed guest handle.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct BufferDesc {
+    /// Logical buffer bytes.
+    pub(crate) bytes: u64,
+    /// Required power-of-two alignment.
+    pub(crate) alignment: u64,
+    /// Requested memory placement.
+    pub(crate) memory_domain: MemoryDomain,
+    /// Declared operation usage.
+    pub(crate) usage: BufferUsage,
+}
+
+impl BufferDesc {
+    /// Construct a locally valid buffer request.
+    pub fn new(
+        bytes: u64,
+        alignment: u64,
+        memory_domain: MemoryDomain,
+        usage: BufferUsage,
+    ) -> Result<Self, ValueError> {
+        if bytes == 0 {
+            return Err(ValueError::Zero);
+        }
+        if !alignment.is_power_of_two() {
+            return Err(ValueError::Alignment);
+        }
+        if usage.is_empty() || BufferUsage::from_bits(usage.bits()).is_none() {
+            return Err(ValueError::BufferUsage);
+        }
+        Ok(Self {
+            bytes,
+            alignment,
+            memory_domain,
+            usage,
+        })
+    }
+
+    /// Logical buffer bytes.
+    pub const fn bytes(self) -> u64 {
+        self.bytes
+    }
+
+    /// Required power-of-two alignment.
+    pub const fn alignment(self) -> u64 {
+        self.alignment
+    }
+
+    /// Requested memory placement.
+    pub const fn memory_domain(self) -> MemoryDomain {
+        self.memory_domain
+    }
+
+    /// Declared operation usage.
+    pub const fn usage(self) -> BufferUsage {
+        self.usage
+    }
+}
+
+/// Nonempty checked buffer byte range.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct BufferRange {
+    /// Starting byte offset.
+    pub(crate) offset: u64,
+    /// Number of bytes.
+    pub(crate) bytes: u64,
+}
+
+impl BufferRange {
+    /// Construct a nonempty, non-overflowing range.
+    pub fn new(offset: u64, bytes: u64) -> Result<Self, ValueError> {
+        if bytes == 0 {
+            return Err(ValueError::Zero);
+        }
+        offset.checked_add(bytes).ok_or(ValueError::Overflow)?;
+        Ok(Self { offset, bytes })
+    }
+
+    /// Starting byte offset.
+    pub const fn offset(self) -> u64 {
+        self.offset
+    }
+
+    /// Number of bytes.
+    pub const fn bytes(self) -> u64 {
+        self.bytes
+    }
+
+    pub(crate) fn fits(self, limit: u64) -> bool {
+        self.offset
+            .checked_add(self.bytes)
+            .is_some_and(|end| end <= limit)
+    }
+}
+
+/// Opaque program envelope retained until program creation completes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ProgramDesc {
+    /// Provider-owned nonzero artifact format.
+    pub format: NonZeroU32,
+    /// Opaque provider-owned target words.
+    pub target: [u32; 12],
+    /// Declared nonzero resident-memory charge.
+    pub resident_bytes: NonZeroU64,
+}
+
+impl ProgramDesc {
+    /// Construct a program descriptor.
+    pub const fn new(format: NonZeroU32, target: [u32; 12], resident_bytes: NonZeroU64) -> Self {
+        Self {
+            format,
+            target,
+            resident_bytes,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct Handle {
+    id: NonZeroU64,
+    epoch: QueueEpoch,
+}
+
+impl Handle {
+    pub(crate) const fn new(id: NonZeroU64, epoch: QueueEpoch) -> Self {
+        Self { id, epoch }
+    }
+
+    pub(crate) const fn id(&self) -> NonZeroU64 {
+        self.id
+    }
+
+    pub(crate) const fn epoch(&self) -> QueueEpoch {
+        self.epoch
+    }
+}
+
+macro_rules! simple_handle {
+    ($name:ident, $doc:literal) => {
+        #[doc = $doc]
+        #[derive(Debug, PartialEq, Eq)]
+        pub struct $name {
+            pub(crate) handle: Handle,
+            pub(crate) context: Option<NonZeroU64>,
+        }
+
+        impl $name {
+            /// Raw opaque wire object ID.
+            pub const fn raw(&self) -> u64 {
+                self.handle.id().get()
+            }
+
+            /// Reset epoch in which this handle was created.
+            pub const fn epoch(&self) -> QueueEpoch {
+                self.handle.epoch()
+            }
+        }
+    };
+}
+
+simple_handle!(Context, "Guest-owned context handle.");
+simple_handle!(Program, "Guest-owned resident program handle.");
+simple_handle!(
+    ExecutionQueue,
+    "Guest-owned accelerator execution-queue handle."
+);
+simple_handle!(Event, "Guest-owned submission event handle.");
+
+/// Guest-owned buffer handle and retained bounds needed for local validation.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Buffer {
+    pub(crate) handle: Handle,
+    pub(crate) context: NonZeroU64,
+    pub(crate) desc: BufferDesc,
+}
+
+impl Buffer {
+    /// Raw opaque wire object ID.
+    pub const fn raw(&self) -> u64 {
+        self.handle.id().get()
+    }
+
+    /// Reset epoch in which this handle was created.
+    pub const fn epoch(&self) -> QueueEpoch {
+        self.handle.epoch()
+    }
+
+    /// Buffer properties accepted by the device.
+    pub const fn desc(&self) -> BufferDesc {
+        self.desc
+    }
+}
+
+/// One borrowed binding encoded directly into a submission chain.
+#[derive(Clone, Copy, Debug)]
+pub struct Binding<'a> {
+    /// Buffer retained by the event on successful or indeterminate admission.
+    pub buffer: &'a Buffer,
+    /// Bound nonempty range.
+    pub range: BufferRange,
+    /// Program-defined slot number.
+    pub slot: u32,
+    /// Program access mode.
+    pub access: AccessMode,
+}
+
+/// Validated device discovery result.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DeviceInfo {
+    /// Stable device UUID.
+    pub uuid: [u8; 16],
+    /// Extensible raw accelerator class.
+    pub class: u16,
+    /// Provider vendor identifier.
+    pub vendor_id: u32,
+    /// Provider device identifier.
+    pub device_id: u32,
+    /// Raw semantic capabilities, including unknown diagnostic bits.
+    pub capabilities: u64,
+    /// Device-wide live context limit.
+    pub max_contexts: u32,
+    /// Per-context live buffer limit.
+    pub max_buffers_per_context: u32,
+    /// Per-context live program limit.
+    pub max_programs_per_context: u32,
+    /// Per-context live execution-queue limit.
+    pub max_queues_per_context: u32,
+    /// Per-context live event limit.
+    pub max_events_per_context: u32,
+    /// Maximum bindings accepted by one submission.
+    pub max_bindings_per_submission: u32,
+    /// Maximum logical buffer allocation.
+    pub max_buffer_bytes: u64,
+    /// Maximum program artifact tail.
+    pub max_artifact_bytes: u64,
+}
+
+impl DeviceInfo {
+    pub(crate) fn from_wire(
+        wire: WireDeviceInfo,
+        max_request_bytes: u32,
+    ) -> Result<Self, DeviceInfoError> {
+        if wire.reserved.get() != 0 {
+            return Err(DeviceInfoError::Reserved);
+        }
+        let capabilities = wire.capabilities.get();
+        if capabilities & RESERVED_CAPABILITIES != 0 {
+            return Err(DeviceInfoError::ReservedCapabilities);
+        }
+        let limits = [
+            wire.max_contexts.get(),
+            wire.max_buffers_per_context.get(),
+            wire.max_programs_per_context.get(),
+            wire.max_queues_per_context.get(),
+            wire.max_events_per_context.get(),
+        ];
+        if limits.contains(&0) {
+            return Err(DeviceInfoError::ZeroLimit);
+        }
+        let max_bindings = wire.max_bindings_per_submission.get();
+        if !(1..=HARD_MAX_BINDINGS).contains(&max_bindings) {
+            return Err(DeviceInfoError::BindingLimit);
+        }
+        if wire.max_buffer_bytes.get() == 0 || wire.max_artifact_bytes.get() == 0 {
+            return Err(DeviceInfoError::ZeroLimit);
+        }
+        let artifact_frame = 16_u64
+            .checked_add(80)
+            .and_then(|bytes| bytes.checked_add(wire.max_artifact_bytes.get()))
+            .ok_or(DeviceInfoError::ArtifactLimit)?;
+        if artifact_frame > u64::from(max_request_bytes) {
+            return Err(DeviceInfoError::ArtifactLimit);
+        }
+        Ok(Self {
+            uuid: wire.uuid,
+            class: wire.class.get(),
+            vendor_id: wire.vendor_id.get(),
+            device_id: wire.device_id.get(),
+            capabilities,
+            max_contexts: wire.max_contexts.get(),
+            max_buffers_per_context: wire.max_buffers_per_context.get(),
+            max_programs_per_context: wire.max_programs_per_context.get(),
+            max_queues_per_context: wire.max_queues_per_context.get(),
+            max_events_per_context: wire.max_events_per_context.get(),
+            max_bindings_per_submission: max_bindings,
+            max_buffer_bytes: wire.max_buffer_bytes.get(),
+            max_artifact_bytes: wire.max_artifact_bytes.get(),
+        })
+    }
+
+    /// Whether event cancellation is semantically available.
+    pub const fn supports_event_cancellation(self) -> bool {
+        self.capabilities & CAPABILITY_EVENT_CANCELLATION != 0
+    }
+
+    pub(crate) const fn supports_domain(self, domain: MemoryDomain) -> bool {
+        let bit = match domain {
+            MemoryDomain::Host => CAPABILITY_HOST_VISIBLE_MEMORY,
+            MemoryDomain::Device => CAPABILITY_DEVICE_LOCAL_MEMORY,
+            MemoryDomain::Shared => CAPABILITY_SHARED_MEMORY,
+        };
+        self.capabilities & bit != 0
+    }
+}
+
+/// Invalid device-information payload.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DeviceInfoError {
+    /// Reserved structure bytes are nonzero.
+    Reserved,
+    /// A reserved semantic capability was advertised.
+    ReservedCapabilities,
+    /// A mandatory advertised limit is zero.
+    ZeroLimit,
+    /// Binding limit is outside protocol bounds.
+    BindingLimit,
+    /// Artifact limit does not fit the configured request frame.
+    ArtifactLimit,
+}
+
+/// Validated accelerator execution state.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EventState {
+    /// Execution remains pending.
+    Pending,
+    /// Execution completed successfully.
+    Complete,
+    /// Execution failed with an opaque protocol status.
+    Failed(StatusCode),
+    /// Execution was cancelled.
+    Cancelled,
+}
+
+/// Successful or ownership-indeterminate submission admission.
+#[derive(Debug, PartialEq, Eq)]
+pub enum SubmissionOutcome {
+    /// Backend admission was accepted.
+    Accepted(Event),
+    /// Admission could not be determined; the event retains all operation resources.
+    Indeterminate {
+        /// Mapped non-success admission status.
+        status: StatusCode,
+        /// Event that owns the possibly accepted operation.
+        event: Event,
+    },
+}
+
+/// Metadata for a successful `READ_BUFFER` response retained in its returned chain.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReadBufferOutput {
+    /// Payload bytes beginning at writable offset 16.
+    pub bytes: u64,
+}

--- a/crates/virtio-accel-split-queue/src/chain.rs
+++ b/crates/virtio-accel-split-queue/src/chain.rs
@@ -8,8 +8,8 @@ use core::sync::atomic::{AtomicU64, Ordering};
 
 use virtio_accel_transport::{
     ByteAccessError, ChainError, ChainId, ChainIo, ChainIoResult, ChainLayout, ChainRegion,
-    DeviceChain, MAX_SPLIT_QUEUE_SIZE, MalformedChain, QueueEpoch, ReadableBytes, WritableBytes,
-    validate_chain_layout,
+    DeviceChain, DriverChainBuffer, MAX_SPLIT_QUEUE_SIZE, MalformedChain, QueueEpoch,
+    ReadableBytes, WritableBytes, validate_chain_layout,
 };
 
 /// Descriptor continues through its `next` field.
@@ -290,6 +290,34 @@ impl DriverChain {
     }
 }
 
+impl DriverChainBuffer for DriverChain {
+    type Error = ByteAccessError;
+
+    fn device_readable_len(&self) -> u64 {
+        self.data
+            .analysis
+            .validation()
+            .map_or(0, ChainLayout::readable_bytes)
+    }
+
+    fn device_writable_len(&self) -> u64 {
+        self.data
+            .analysis
+            .validation()
+            .map_or(0, ChainLayout::writable_bytes)
+    }
+
+    fn write_device_readable(&mut self, offset: u64, source: &[u8]) -> Result<(), Self::Error> {
+        checked_logical_range(offset, source.len(), self.device_readable_len())?;
+        copy_to_descriptors(&self.data, false, offset, source)
+    }
+
+    fn read_device_writable(&self, offset: u64, target: &mut [u8]) -> Result<(), Self::Error> {
+        checked_logical_range(offset, target.len(), self.device_writable_len())?;
+        copy_from_descriptors(&self.data, true, offset, target)
+    }
+}
+
 /// Device-readable concatenation of a valid chain's readable descriptors.
 pub struct SplitSource {
     data: Rc<ChainData>,
@@ -360,7 +388,7 @@ impl WritableBytes for SplitSink {
     fn write_at(&mut self, offset: u64, source: &[u8]) -> Result<(), ByteAccessError> {
         self.check_epoch()?;
         checked_logical_range(offset, source.len(), self.len())?;
-        copy_to_descriptors(&self.data, offset, source)
+        copy_to_descriptors(&self.data, true, offset, source)
     }
 }
 
@@ -555,6 +583,7 @@ fn copy_from_descriptors(
 
 fn copy_to_descriptors(
     data: &ChainData,
+    writable: bool,
     offset: u64,
     source: &[u8],
 ) -> Result<(), ByteAccessError> {
@@ -565,7 +594,7 @@ fn copy_to_descriptors(
     let mut copied = 0;
     for index in data.analysis.order() {
         let descriptor = &data.descriptors[usize::from(*index)];
-        if !descriptor.is_writable() {
+        if descriptor.is_writable() != writable {
             continue;
         }
         if skip >= descriptor.len() {

--- a/crates/virtio-accel-transport/src/bytes.rs
+++ b/crates/virtio-accel-transport/src/bytes.rs
@@ -56,3 +56,67 @@ pub trait WritableBytes: fmt::Debug {
         None
     }
 }
+
+/// Driver-owned byte access for one unpublished or reclaimed descriptor chain.
+///
+/// The readable side is written by the driver and later read by the device. The writable side is
+/// written by the device and may be read by the driver only after used-ring reclamation. Methods
+/// are nonblocking and allocation-free; queue ownership prevents calls while a chain is published.
+pub trait DriverChainBuffer: fmt::Debug {
+    /// Concrete transport byte-access failure.
+    type Error;
+
+    /// Total bytes readable by the device.
+    fn device_readable_len(&self) -> u64;
+
+    /// Total bytes writable by the device.
+    fn device_writable_len(&self) -> u64;
+
+    /// Write an exact logical range into the device-readable side.
+    fn write_device_readable(&mut self, offset: u64, source: &[u8]) -> Result<(), Self::Error>;
+
+    /// Read an exact logical range from the device-writable side after completion.
+    fn read_device_writable(&self, offset: u64, target: &mut [u8]) -> Result<(), Self::Error>;
+}
+
+impl ReadableBytes for [u8] {
+    fn len(&self) -> u64 {
+        self.len() as u64
+    }
+
+    fn read_at(&self, offset: u64, target: &mut [u8]) -> Result<(), ByteAccessError> {
+        let start = usize::try_from(offset).map_err(|_| ByteAccessError::OutOfBounds)?;
+        let end = start
+            .checked_add(target.len())
+            .ok_or(ByteAccessError::OutOfBounds)?;
+        let source = self.get(start..end).ok_or(ByteAccessError::OutOfBounds)?;
+        target.copy_from_slice(source);
+        Ok(())
+    }
+
+    fn as_contiguous(&self) -> Option<&[u8]> {
+        Some(self)
+    }
+}
+
+impl WritableBytes for [u8] {
+    fn len(&self) -> u64 {
+        self.len() as u64
+    }
+
+    fn write_at(&mut self, offset: u64, source: &[u8]) -> Result<(), ByteAccessError> {
+        let start = usize::try_from(offset).map_err(|_| ByteAccessError::OutOfBounds)?;
+        let end = start
+            .checked_add(source.len())
+            .ok_or(ByteAccessError::OutOfBounds)?;
+        let target = self
+            .get_mut(start..end)
+            .ok_or(ByteAccessError::OutOfBounds)?;
+        target.copy_from_slice(source);
+        Ok(())
+    }
+
+    fn as_contiguous_mut(&mut self) -> Option<&mut [u8]> {
+        Some(self)
+    }
+}

--- a/crates/virtio-accel-transport/src/lib.rs
+++ b/crates/virtio-accel-transport/src/lib.rs
@@ -10,7 +10,7 @@ mod bytes;
 mod queue;
 mod regions;
 
-pub use bytes::{ByteAccessError, ReadableBytes, WritableBytes};
+pub use bytes::{ByteAccessError, DriverChainBuffer, ReadableBytes, WritableBytes};
 pub use queue::{
     ChainError, ChainId, ChainIo, ChainIoResult, DeviceChain, DeviceQueue, DriverQueue,
     MAX_SPLIT_QUEUE_SIZE, MalformedChain, NotificationHint, NotificationRecheck, PublishError,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -136,6 +136,13 @@ operation is nonblocking and heap-allocation-free: publish, pop, complete, notif
 notification recheck, and reset. Reset may move already-owned storage into a reclamation result but
 does not allocate or wait for a peer.
 
+`virtio-accel-guest` owns one portable driver queue without internal synchronization. It
+preallocates a caller-selected number of tracking slots, writes fixed prefixes directly into
+caller-owned chains, and retains bulk read responses in reclaimed chain storage. Prepared transfer
+and artifact tails are published without another payload copy. Non-`Copy` typed handles carry the
+queue reset epoch; release operations consume them and report whether a failure is retryable,
+invalidated, indeterminate, or an opaque unknown status.
+
 `virtio-accel-split-queue` is the deterministic executable implementation of that boundary. It
 preallocates descriptor ownership, chain records, available entries, and used entries at
 configuration. Its split-ring counters use wrapping `u16` arithmetic, direct chains retain their
@@ -222,8 +229,8 @@ transport-neutral region metadata re-exported by `virtio-accel-device`. Its base
 4. Passes transfer and artifact regions directly to backend byte ports.
 5. Produces a response without knowing about rust-vmm or a host operating system.
 
-Submission/event retention, deterministic reset, and the bounded split-virtqueue model complete the
-portable device side. The next boundary is the no-std reference guest in issue #19, followed by the
-full guest-to-command-engine lifecycle in issue #20. A thin rust-vmm adapter supplying
+Submission/event retention, deterministic reset, the bounded split-virtqueue model, and the no-std
+reference guest complete both portable queue endpoints. The next boundary is the full
+guest-to-command-engine lifecycle in issue #20. A thin rust-vmm adapter supplying
 `virtio-device`, `virtio-queue`, and `vm-memory` integration remains a later platform layer, as do
 Linux vhost-user and an in-kernel guest driver.

--- a/docs/portability.md
+++ b/docs/portability.md
@@ -13,7 +13,7 @@ Rust 2024 edition selected by the workspace. Every package inherits the same `ru
 | `style-and-api` | Current stable on Ubuntu | Formatting, complete normative-requirement ledger, Clippy with warnings denied, and warning-free public docs |
 | `native-test` | Current stable on Ubuntu, macOS, and Windows | All workspace unit, integration, target, feature, and documentation tests plus release-profile checking |
 | `msrv` | Rust 1.85.0 on Ubuntu | Every workspace target and test continues to compile at the declared MSRV |
-| `portable-target` | Stable `aarch64-unknown-none`, `riscv64gc-unknown-none-elf`, and `wasm32-unknown-unknown` | `cleanroom`, `proto`, `transport`, and `core` remain `no_std`; split-queue, device, and facade layers require at most `alloc`; Wasm also checks the std reference crates |
+| `portable-target` | Stable `aarch64-unknown-none`, `riscv64gc-unknown-none-elf`, and `wasm32-unknown-unknown` | `cleanroom`, `proto`, `transport`, and `core` remain `no_std`; guest, split-queue, device, and facade layers require at most `alloc`; Wasm also checks the std reference crates |
 | `feature-sets-and-dependencies` | Stable on Ubuntu | Every Cargo feature combination plus dependency and `std`/`alloc` leakage guards for the portable codecs, queue ports, and core |
 | `dependency-policy` | Cargo-deny with Rust 1.85.0 | Advisories, yanked crates, duplicate versions, wildcard requirements, licenses, and dependency sources |
 | `fuzz-smoke` | Nightly on Ubuntu when `fuzz/Cargo.toml` exists | Every fuzz target gets bounded smoke iterations; issue #26 activates the job by adding the fuzz workspace |
@@ -27,12 +27,11 @@ the concrete runner versions used for the release.
 | Tier | Crates | Allowed runtime surface |
 |---|---|---|
 | `core-only` | `virtio-accel-cleanroom`, `virtio-accel-proto`, `virtio-accel-transport`, `virtio-accel-core` | `core`; the clean-room codec and transport ports have no normal/build dependencies, while proc-macros used by other crates may execute with `std` on the build host |
-| `alloc-portable` | `virtio-accel-split-queue`, `virtio-accel-device`, `virtio-accel` | `core + alloc`; no OS, filesystem, sockets, threads, or host synchronization |
+| `alloc-portable` | `virtio-accel-guest`, `virtio-accel-split-queue`, `virtio-accel-device`, `virtio-accel` | `core + alloc`; no OS, filesystem, sockets, threads, or host synchronization |
 | `std-reference` | `virtio-accel-mock` | Portable `std`; no host-OS or vendor-specific API |
 
-The future reference guest also belongs to `alloc-portable`. Concrete VMM, kernel, OS, and vendor
-adapters are outside the portable-v1 milestone and must not become default dependencies of a
-portable crate.
+Concrete VMM, kernel, OS, and vendor adapters are outside the portable-v1 milestone and must not
+become default dependencies of a portable crate.
 
 ## Cargo feature policy
 
@@ -42,7 +41,7 @@ protocol interpretation.
 
 The portable dependency guard inspects normal and build target features for
 `virtio-accel-cleanroom`, `virtio-accel-proto`, `virtio-accel-transport`, and
-`virtio-accel-core`, and `virtio-accel-split-queue`; test-only development dependencies are
+`virtio-accel-core`, `virtio-accel-guest`, and `virtio-accel-split-queue`; test-only development dependencies are
 intentionally outside the target runtime graph. It additionally proves that the clean-room codec
 and transport ports have no normal or build dependencies at all. A dependency's host-side derive
 macro may use `std`, but the target graph for these crates must not enable a dependency feature
@@ -90,6 +89,7 @@ cargo check \
   -p virtio-accel-transport \
   -p virtio-accel-core \
   -p virtio-accel-device \
+  -p virtio-accel-guest \
   -p virtio-accel-split-queue \
   -p virtio-accel \
   --target aarch64-unknown-none \

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 
 pub use virtio_accel_core as core;
 pub use virtio_accel_device as device;
+pub use virtio_accel_guest as guest;
 pub use virtio_accel_proto as proto;
 pub use virtio_accel_split_queue as split_queue;
 pub use virtio_accel_transport as transport;


### PR DESCRIPTION
Closes #19

## Summary

- add the `no_std + alloc` `virtio-accel-guest` reference client with protocol/config negotiation and typed methods for all 15 protocol 1.0 opcodes
- add bounded in-flight tracking, nonzero request-ID wraparound without live aliasing, out-of-order completion matching, synchronous polling, notification rechecks, and reset recovery
- add non-`Copy`, reset-epoch-scoped handles and explicit retry, invalidated, indeterminate, and unknown failure dispositions for ownership-sensitive operations
- add caller-owned scatter/gather request construction, zero-copy prepared transfer/artifact tails, and bulk read responses retained in reclaimed chain storage
- add the portable `DriverChainBuffer` port and implement it for the split-queue model
- extend portability CI, dependency checks, architecture notes, and conformance coverage for the guest crate

## Design notes

The client is single-owner and contains no internal locks or atomics. It preallocates a caller-selected number of tracking slots; publication, polling, completion matching, and request construction do not allocate. Concrete shared transports remain free to implement their queue port with atomics at the actual ownership boundary.

Malformed responses never construct typed handles or event states. Device loss and malformed completion move the client to reset-required health, while prepublication failures return the untouched chain and operation for retry.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-targets --all-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps`
- `cargo test --workspace --doc --all-features`
- `cargo check --workspace --release --all-features`
- `cargo +1.85.0 check --workspace --all-targets --all-features`
- `cargo hack check --workspace --feature-powerset --no-dev-deps`
- `bash ci/check-portable-dependencies.sh`
- `python3 ci/check-normative-requirements.py --check`
- bare-metal checks for `aarch64-unknown-none` and `riscv64gc-unknown-none-elf`
