### PR TITLE
Stabilize the Accelerator provider contract

### DIFF
--- a/ci/check-normative-requirements.py
+++ b/ci/check-normative-requirements.py
@@ -48,34 +48,36 @@ COVERAGE: Final[dict[tuple[str, int], Coverage]] = {
         rationale="Defines RFC 2119 and RFC 8174 terminology; it imposes no implementation behavior.",
     ),
     ("SPEC", 2): coverage(
-        "mixed",
+        "executable",
         (
             "ci/check-portable-dependencies.sh",
             "crates/virtio-accel-transport/src/lib.rs",
             "docs/architecture.md",
+            "tests/portable_end_to_end.rs",
         ),
-        ("#20", "#21"),
-        "Portable queue and dependency boundaries are enforced now; concrete end-to-end and provider adapters remain tracked.",
+        rationale="Portable dependency, provider, queue, and end-to-end boundaries are directly enforced; concrete platform adapters are outside portable v1.",
     ),
     ("SPEC", 3): coverage(
-        "mixed",
+        "executable",
         (
             "ci/check-portable-dependencies.sh",
             "crates/virtio-accel-transport/src/queue.rs",
             "docs/architecture.md",
+            "tests/portable_end_to_end.rs",
         ),
-        ("#20", "#21"),
-        "Layer and ownership boundaries are enforceable now; runtime provider integration remains tracked.",
+        rationale="Layer direction, queue ownership, provider ownership, and the complete portable lifecycle are executable.",
     ),
     ("SPEC", 4): coverage(
         "mixed",
         (
             "crates/virtio-accel-core/src/lib.rs",
+            "crates/virtio-accel-device/tests/command_processor.rs",
             "crates/virtio-accel-device/src/object_table.rs",
             "crates/virtio-accel-mock/src/lib.rs",
+            "tests/portable_end_to_end.rs",
         ),
-        ("#20", "#21", "#25"),
-        "Core ownership types and lifecycle tests exist; command-engine enforcement, complete backend policy, and retained-byte accounting remain tracked.",
+        ("#25",),
+        "Provider and command-engine lifecycle semantics are executable; the threat model and aggregate retained-byte policy remain tracked.",
     ),
     ("SPEC", 5): coverage(
         "mixed",
@@ -83,8 +85,8 @@ COVERAGE: Final[dict[tuple[str, int], Coverage]] = {
             "conformance/rust-clean-room/tests/vectors.rs",
             "crates/virtio-accel-proto/src/lib.rs",
         ),
-        ("#20", "#32"),
-        "Namespaces and reserved values are executable; runtime negotiation and future evolution remain tracked.",
+        ("#32",),
+        "Namespaces, reserved values, runtime capability selection, and negotiation are executable; future evolution remains tracked.",
     ),
     ("SPEC", 6): coverage(
         "mixed",
@@ -97,29 +99,33 @@ COVERAGE: Final[dict[tuple[str, int], Coverage]] = {
         "Version and exact-length behavior is executable; release governance and the final freeze remain tracked.",
     ),
     ("SPEC", 7): coverage(
-        "mixed",
+        "executable",
         (
             "crates/virtio-accel-core/src/lib.rs",
             "crates/virtio-accel-device/src/object_table.rs",
-            "crates/virtio-accel-mock/src/lib.rs",
+            "crates/virtio-accel-device/tests/command_processor.rs",
+            "tests/portable_end_to_end.rs",
         ),
-        ("#20", "#21"),
-        "Handle and generational-ID invariants are tested; end-to-end release recovery remains tracked.",
+        rationale="Handle ownership, generational IDs, rejected and indeterminate release, reset recovery, and transfer-failure publication are executable.",
     ),
     ("SPEC", 8): coverage(
-        "mixed",
-        ("crates/virtio-accel-core/src/lib.rs",),
-        ("#20", "#21"),
-        "Relative timeout semantics are tested; bounded polling and admission behavior require the command engine.",
+        "executable",
+        (
+            "crates/virtio-accel-core/src/lib.rs",
+            "crates/virtio-accel-device/tests/command_processor.rs",
+            "tests/portable_end_to_end.rs",
+        ),
+        rationale="Relative timeouts, bounded polling and cancellation, admission ownership, and end-to-end progress are executable.",
     ),
     ("SPEC", 9): coverage(
-        "mixed",
+        "executable",
         (
             "conformance/rust-clean-room/tests/vectors.rs",
             "crates/virtio-accel-core/src/lib.rs",
+            "crates/virtio-accel-device/tests/command_processor.rs",
+            "tests/portable_end_to_end.rs",
         ),
-        ("#20", "#21"),
-        "Wire error shapes and ownership-aware failures are executable; backend-to-device recovery is tracked.",
+        rationale="Wire error shapes, ownership-aware failures, deterministic provider mapping, and backend-to-device recovery are executable.",
     ),
     ("SPEC", 10): coverage(
         "executable",
@@ -133,7 +139,7 @@ COVERAGE: Final[dict[tuple[str, int], Coverage]] = {
     ("SPEC", 11): coverage(
         "mixed",
         ("ci/check-normative-requirements.py",),
-        ("#21", "#25", "#32", "#33"),
+        ("#25", "#32", "#33"),
         "The ledger prevents silent requirements; the section's named completion work remains explicitly tracked.",
     ),
     ("WIRE", 1): coverage(
@@ -174,27 +180,31 @@ COVERAGE: Final[dict[tuple[str, int], Coverage]] = {
         (
             "conformance/rust-clean-room/tests/vectors.rs",
             "crates/virtio-accel-proto/tests/semantic_interop.rs",
+            "crates/virtio-accel-device/tests/command_processor.rs",
+            "tests/portable_end_to_end.rs",
         ),
-        ("#20", "#25"),
-        "Every payload layout and scalar invariant is cross-decoded; live-object and advertised-quota checks are tracked.",
+        ("#25",),
+        "Every payload layout and scalar invariant is cross-decoded, and live-object and advertised-quota checks are executable; adversarial aggregate limits remain tracked.",
     ),
     ("WIRE", 6): coverage(
-        "mixed",
+        "executable",
         (
             "conformance/rust-clean-room/tests/vectors.rs",
             "crates/virtio-accel-core/src/lib.rs",
+            "crates/virtio-accel-device/tests/command_processor.rs",
         ),
-        ("#20", "#21"),
-        "Malformed input classifications and opaque statuses are executable; provider error mapping is tracked.",
+        rationale="Malformed input classifications, opaque statuses, and provider error mapping are executable.",
     ),
     ("WIRE", 7): coverage(
-        "mixed",
+        "executable",
         (
             "conformance/v1.0/vectors.json",
+            "crates/virtio-accel-device/src/response.rs",
+            "crates/virtio-accel-device/tests/command_processor.rs",
             "crates/virtio-accel-split-queue/src/queue.rs",
+            "tests/portable_end_to_end.rs",
         ),
-        ("#20",),
-        "Queue-level used accounting and preflight failures are executable; post-mutation command response atomicity requires full-path execution.",
+        rationale="Preflight, post-mutation response atomicity, exact used accounting, and short-completion rejection are executable through the full path.",
     ),
     ("WIRE", 8): coverage(
         "executable",
@@ -240,91 +250,99 @@ COVERAGE: Final[dict[tuple[str, int], Coverage]] = {
         rationale="Topology, direction, count, nonzero length, addressability, arithmetic, and command-frame limits are executable.",
     ),
     ("VIRTQ", 4): coverage(
-        "mixed",
+        "executable",
         (
             "conformance/rust-clean-room/tests/vectors.rs",
             "crates/virtio-accel-device/src/frame.rs",
             "crates/virtio-accel-split-queue/src/chain.rs",
             "crates/virtio-accel-split-queue/src/queue.rs",
             "crates/virtio-accel-transport/src/regions.rs",
+            "tests/portable_end_to_end.rs",
         ),
-        ("#20",),
-        "Descriptor-backed segmented presentation and frame exactness are executable; one-command full-path behavior remains tracked.",
+        rationale="Descriptor-backed segmented presentation, frame exactness, and complete command behavior are executable through the full path.",
     ),
     ("VIRTQ", 5): coverage(
-        "tracked",
+        "executable",
         (
             "conformance/rust-clean-room/tests/vectors.rs",
+            "crates/virtio-accel-device/tests/command_processor.rs",
             "crates/virtio-accel-split-queue/src/queue.rs",
+            "tests/portable_end_to_end.rs",
         ),
-        ("#20",),
-        "Queue ordering and semantic validation classifications are executable separately; full failure atomicity requires their integration.",
+        rationale="Queue ordering, semantic validation, and full-path failure atomicity are executable.",
     ),
     ("VIRTQ", 6): coverage(
-        "tracked",
+        "executable",
         (
             "conformance/rust-clean-room/tests/vectors.rs",
             "crates/virtio-accel-split-queue/src/chain.rs",
             "crates/virtio-accel-split-queue/src/queue.rs",
+            "tests/portable_end_to_end.rs",
         ),
-        ("#20",),
-        "Scatter writes and used-length accounting are executable; post-mutation command failure requires full-path execution.",
+        rationale="Scatter writes, used-length accounting, and post-mutation command failure are executable through the full path.",
     ),
     ("VIRTQ", 7): coverage(
-        "mixed",
+        "executable",
         (
             "crates/virtio-accel-split-queue/src/queue.rs",
             "docs/virtqueue.md",
+            "tests/portable_end_to_end.rs",
         ),
-        ("#20",),
-        "Available-order consumption and out-of-order used publication are executable; command/event distinction awaits the full path.",
+        rationale="Available-order consumption, out-of-order completion, and command/event distinction are executable through the full path.",
     ),
     ("VIRTQ", 8): coverage(
-        "mixed",
+        "executable",
         (
+            "crates/virtio-accel-guest/src/client.rs",
             "crates/virtio-accel-split-queue/src/queue.rs",
             "crates/virtio-accel-transport/src/queue.rs",
             "docs/virtqueue.md",
+            "tests/portable_end_to_end.rs",
         ),
-        ("#19", "#20"),
-        "Publication ownership and retryable backpressure types are executable; guest behavior and full-path tests remain tracked.",
+        rationale="Publication ownership, guest retryable backpressure, and full-path completion are executable.",
     ),
     ("VIRTQ", 9): coverage(
-        "mixed",
+        "executable",
         (
+            "crates/virtio-accel-guest/src/client.rs",
             "crates/virtio-accel-split-queue/src/queue.rs",
             "crates/virtio-accel-transport/src/queue.rs",
             "docs/virtqueue.md",
+            "tests/portable_end_to_end.rs",
         ),
-        ("#19",),
-        "Base split-ring suppression and mandatory rechecks are executable; guest-side notification behavior remains tracked.",
+        rationale="Split-ring suppression, guest notification decisions, mandatory rechecks, and lost-wakeup scenarios are executable.",
     ),
     ("VIRTQ", 10): coverage(
-        "mixed",
+        "executable",
         (
             "conformance/rust-clean-room/tests/vectors.rs",
             "crates/virtio-accel-split-queue/src/chain.rs",
             "crates/virtio-accel-split-queue/src/queue.rs",
+            "tests/portable_end_to_end.rs",
         ),
-        ("#20",),
-        "Malformed frames and descriptor chains are isolated separately; full command-chain continuation remains tracked.",
+        rationale="Malformed frames and descriptor chains are isolated while later command chains continue through the full path.",
     ),
     ("VIRTQ", 11): coverage(
-        "mixed",
+        "executable",
         (
+            "crates/virtio-accel-guest/src/client.rs",
             "crates/virtio-accel-transport/src/queue.rs",
             "crates/virtio-accel-split-queue/src/queue.rs",
             "crates/virtio-accel-device/src/engine.rs",
             "docs/virtqueue.md",
+            "tests/portable_end_to_end.rs",
         ),
-        ("#19", "#20"),
-        "Split-ring and engine reset are executable separately; guest reclamation and full-path reset remain tracked.",
+        rationale="Split-ring invalidation, guest reclamation, engine teardown, and full-path reset are executable.",
     ),
     ("VIRTQ", 12): coverage(
-        "tracked",
-        ("crates/virtio-accel-core/src/lib.rs",),
-        ("#20", "#25"),
-        "Ownership-aware failure types exist; DEVICE_NEEDS_RESET transitions require the command engine and threat limits.",
+        "mixed",
+        (
+            "crates/virtio-accel-core/src/lib.rs",
+            "crates/virtio-accel-device/src/engine.rs",
+            "tests/portable_end_to_end.rs",
+        ),
+        ("#25",),
+        "Ownership-aware failures and DEVICE_NEEDS_RESET transitions are executable; the adversarial resource policy remains tracked.",
     ),
 }
 
@@ -337,23 +355,45 @@ RESET_ENGINE_COVERAGE: Final = coverage(
     ),
     rationale="The reset engine and tests enforce bounded child-before-parent teardown, sticky backend discard, explicit quarantine accounting, and fresh object namespaces.",
 )
+PROVIDER_CAPABILITY_COVERAGE: Final = coverage(
+    "executable",
+    (
+        "crates/virtio-accel-core/src/lib.rs",
+        "crates/virtio-accel-device/src/decoder.rs",
+        "crates/virtio-accel-device/src/engine.rs",
+        "crates/virtio-accel-device/tests/command_processor.rs",
+        "crates/virtio-accel-guest/src/client.rs",
+        "crates/virtio-accel-mock/src/lib.rs",
+    ),
+    rationale="Construction-time metadata checks and operation preflight tests enforce stable limits, usable memory domains, reserved flags, and capability-to-method consistency.",
+)
 RESET_TRANSPORT_COVERAGE: Final = coverage(
-    "mixed",
+    "executable",
     (
         "crates/virtio-accel-transport/src/queue.rs",
         "crates/virtio-accel-split-queue/src/queue.rs",
         "crates/virtio-accel-device/src/engine.rs",
         "crates/virtio-accel-device/tests/command_processor.rs",
         "docs/virtqueue.md",
+        "tests/portable_end_to_end.rs",
     ),
-    ("#20",),
-    "The split model stops fetch and publication while atomically invalidating old byte ports; full transport-to-engine reset remains tracked.",
+    rationale="The full path stops fetch and publication, atomically invalidates old byte ports, tears down backend state, and reclaims guest ownership.",
 )
 RESET_ENGINE_MARKERS: Final = (
     "Teardown **MUST** be bounded",
     "The device **MAY** reuse a backend instance",
     "repeated reset attempts **MUST NOT** invoke that backend again",
     "Successful reinitialization **MUST** use a fresh nonzero object namespace",
+)
+PROVIDER_CAPABILITY_MARKERS: Final = (
+    "If the backend does not advertise semantic event-cancellation capability",
+    "The device **MUST** reject an allocation for an unsupported memory domain",
+    "A baseline backend **MUST** advertise at least one assigned memory-domain capability",
+    "resource-count, binding-count, and byte limit in `DeviceInfo`",
+    "capabilities, and limits **MUST** remain stable",
+    "If `EVENT_CANCELLATION` is absent",
+    "invocation. If it is present, the backend",
+    "**MUST** reject nonempty values before backend invocation",
 )
 
 
@@ -363,6 +403,9 @@ def requirement_coverage(source_code: str, number: int, statement: str) -> Cover
             return RESET_TRANSPORT_COVERAGE
         if any(marker in statement for marker in RESET_ENGINE_MARKERS):
             return RESET_ENGINE_COVERAGE
+    if source_code == "SPEC" and number == 5:
+        if any(marker in statement for marker in PROVIDER_CAPABILITY_MARKERS):
+            return PROVIDER_CAPABILITY_COVERAGE
     return COVERAGE.get((source_code, number))
 
 

--- a/conformance/v1.0/coverage.md
+++ b/conformance/v1.0/coverage.md
@@ -8,14 +8,14 @@ behavior is deliberately tracked by a later issue. The exact per-keyword ledger 
 
 | Normative area | Current executable evidence | Tracked completion rationale |
 |---|---|---|
-| `specification.md` sections 2-3: scope and layer boundaries | Workspace dependency direction, `no_std` target checks, the clean-room dependency guard, and the full reference guest-to-backend path | Concrete provider boundary audits continue in #21 |
-| Section 4: contexts, buffers, programs, queues, submissions, and events | `virtio-accel-core`, object-table, mock lifecycle, and full serialized split-queue lifecycle tests | Remaining backend semantics are #21 |
+| `specification.md` sections 2-3: scope and layer boundaries | Workspace dependency direction, `no_std` target checks, the clean-room dependency guard, the audited provider trait, and the full reference guest-to-backend path | Concrete platform adapters remain intentionally outside portable v1 |
+| Section 4: contexts, buffers, programs, queues, submissions, and events | `virtio-accel-core`, construction-time metadata validation, object-table and mock lifecycle tests, and full serialized split-queue scenarios | Deterministic reference execution and the reusable backend suite are #22 and #24 |
 | Section 5: mandatory baseline, reserved features, flags, and scalar namespaces | Primary ABI namespace tests plus clean-room request validation and edge vectors | Optional features remain unadvertised; their future policy is #32 |
 | Section 6: versions, exact lengths, unknown values, and extension rules | Config/version edge vectors, both codecs, immutable manifests, and layout assertions | Candidate-to-stable freeze and clean-room review are audited again in #33 |
-| Sections 7-9: ownership, time, progress, and error truth | Generational-ID, timeout, mock lifecycle, unknown-status, indeterminate-submit, end-to-end recovery, and response-atomicity tests | Remaining backend policy details are #21 |
+| Sections 7-9: ownership, time, progress, and error truth | Per-method provider contracts plus generational-ID, timeout, mock lifecycle, unknown-status, indeterminate-submit, end-to-end recovery, and response-atomicity tests | Exhaustive provider fault injection and reusable conformance are #23 and #24 |
 | Section 10: portability | Stable/MSRV, Linux/macOS/Windows, Wasm, AArch64, RISC-V, feature, dependency, and documentation CI | Concrete OS/VMM adapters remain intentionally outside portable v1 |
 | `wire-abi.md` sections 1-6: config, headers, namespaces, all payloads, statuses, limits, and reserved fields | `layout.json`, `vectors.json`, primary `zerocopy` assertions, the manual dependency-free codec, and live-object end-to-end scenarios | Adversarial limit combinations remain part of threat-model issue #25 |
-| `wire-abi.md` section 7: preflight and response atomicity | Error-shape vectors, ownership-aware core error types, and end-to-end short-completion rejection | Post-mutation provider failures remain part of the backend audit in #21 |
+| `wire-abi.md` section 7: preflight and response atomicity | Error-shape vectors, ownership-aware core error types, explicit transfer-failure contracts, and end-to-end short-completion rejection | Exhaustive post-mutation fault injection is #23 |
 | `wire-abi.md` sections 8-9: versioned artifacts and change control | Checked-in inputs, drift tests, and coordinated-change documentation | Release freeze governance is finalized by #32 and #33 |
 | `virtqueue.md` sections 1-12 | Stable executable cases and `scenarios.json` drive the full reference guest, split queue, device loop, command engine, and backend through segmented chains, out-of-order completion, notification suppression, backpressure, short responses, timeout, cancellation, reset, and device loss | Concrete VMM adapter integration remains intentionally outside portable v1 |
 
@@ -46,5 +46,5 @@ field after the other implementation decodes the bytes. No Rust wire structure c
 boundary.
 
 The clean-room binding uniqueness check is intentionally allocation-free and quadratic. This crate
-is portable conformance evidence, not the production command-engine hot path; #20 may use a bounded
-set or table consistent with its resource accounting.
+is portable conformance evidence, not the production command-engine hot path; the command processor
+uses one bounded decoded-binding allocation and sorts it in place.

--- a/conformance/v1.0/requirements.json
+++ b/conformance/v1.0/requirements.json
@@ -1,7 +1,7 @@
 {
   "schema": "virtio-accel-normative-requirements-1",
   "generated_by": "ci/check-normative-requirements.py",
-  "requirement_count": 131,
+  "requirement_count": 141,
   "requirements": [
     {
       "id": "REQ-SPEC-A29885B44214",
@@ -109,17 +109,15 @@
       "keyword": "MUST NOT",
       "statement": "Adding an integration listed above **MUST NOT** change the portable object lifecycle by convention.",
       "coverage": {
-        "status": "mixed",
+        "status": "executable",
         "evidence": [
           "ci/check-portable-dependencies.sh",
           "crates/virtio-accel-transport/src/lib.rs",
-          "docs/architecture.md"
+          "docs/architecture.md",
+          "tests/portable_end_to_end.rs"
         ],
-        "issues": [
-          "#20",
-          "#21"
-        ],
-        "rationale": "Portable queue and dependency boundaries are enforced now; concrete end-to-end and provider adapters remain tracked."
+        "issues": [],
+        "rationale": "Portable dependency, provider, queue, and end-to-end boundaries are directly enforced; concrete platform adapters are outside portable v1."
       }
     },
     {
@@ -130,17 +128,15 @@
       "keyword": "MUST",
       "statement": "The driver **MUST** treat all device-written bytes as untrusted.",
       "coverage": {
-        "status": "mixed",
+        "status": "executable",
         "evidence": [
           "ci/check-portable-dependencies.sh",
           "crates/virtio-accel-transport/src/queue.rs",
-          "docs/architecture.md"
+          "docs/architecture.md",
+          "tests/portable_end_to_end.rs"
         ],
-        "issues": [
-          "#20",
-          "#21"
-        ],
-        "rationale": "Layer and ownership boundaries are enforceable now; runtime provider integration remains tracked."
+        "issues": [],
+        "rationale": "Layer direction, queue ownership, provider ownership, and the complete portable lifecycle are executable."
       }
     },
     {
@@ -151,17 +147,15 @@
       "keyword": "MUST",
       "statement": "The device **MUST** treat all driver-written bytes, lengths, counts, object IDs, flags, and timing as",
       "coverage": {
-        "status": "mixed",
+        "status": "executable",
         "evidence": [
           "ci/check-portable-dependencies.sh",
           "crates/virtio-accel-transport/src/queue.rs",
-          "docs/architecture.md"
+          "docs/architecture.md",
+          "tests/portable_end_to_end.rs"
         ],
-        "issues": [
-          "#20",
-          "#21"
-        ],
-        "rationale": "Layer and ownership boundaries are enforceable now; runtime provider integration remains tracked."
+        "issues": [],
+        "rationale": "Layer direction, queue ownership, provider ownership, and the complete portable lifecycle are executable."
       }
     },
     {
@@ -172,17 +166,15 @@
       "keyword": "MUST NOT",
       "statement": "A transport adapter **MUST NOT** expose guest addresses, descriptor objects, host mappings, or",
       "coverage": {
-        "status": "mixed",
+        "status": "executable",
         "evidence": [
           "ci/check-portable-dependencies.sh",
           "crates/virtio-accel-transport/src/queue.rs",
-          "docs/architecture.md"
+          "docs/architecture.md",
+          "tests/portable_end_to_end.rs"
         ],
-        "issues": [
-          "#20",
-          "#21"
-        ],
-        "rationale": "Layer and ownership boundaries are enforceable now; runtime provider integration remains tracked."
+        "issues": [],
+        "rationale": "Layer direction, queue ownership, provider ownership, and the complete portable lifecycle are executable."
       }
     },
     {
@@ -193,17 +185,15 @@
       "keyword": "MUST NOT",
       "statement": "The command engine **MUST NOT** depend on an operating system, VMM, kernel, guest-memory crate, vendor",
       "coverage": {
-        "status": "mixed",
+        "status": "executable",
         "evidence": [
           "ci/check-portable-dependencies.sh",
           "crates/virtio-accel-transport/src/queue.rs",
-          "docs/architecture.md"
+          "docs/architecture.md",
+          "tests/portable_end_to_end.rs"
         ],
-        "issues": [
-          "#20",
-          "#21"
-        ],
-        "rationale": "Layer and ownership boundaries are enforceable now; runtime provider integration remains tracked."
+        "issues": [],
+        "rationale": "Layer direction, queue ownership, provider ownership, and the complete portable lifecycle are executable."
       }
     },
     {
@@ -214,17 +204,15 @@
       "keyword": "MUST NOT",
       "statement": "A backend **MUST NOT** receive wire structures, object IDs, guest addresses, or virtqueue",
       "coverage": {
-        "status": "mixed",
+        "status": "executable",
         "evidence": [
           "ci/check-portable-dependencies.sh",
           "crates/virtio-accel-transport/src/queue.rs",
-          "docs/architecture.md"
+          "docs/architecture.md",
+          "tests/portable_end_to_end.rs"
         ],
-        "issues": [
-          "#20",
-          "#21"
-        ],
-        "rationale": "Layer and ownership boundaries are enforceable now; runtime provider integration remains tracked."
+        "issues": [],
+        "rationale": "Layer direction, queue ownership, provider ownership, and the complete portable lifecycle are executable."
       }
     },
     {
@@ -238,15 +226,15 @@
         "status": "mixed",
         "evidence": [
           "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
           "crates/virtio-accel-device/src/object_table.rs",
-          "crates/virtio-accel-mock/src/lib.rs"
+          "crates/virtio-accel-mock/src/lib.rs",
+          "tests/portable_end_to_end.rs"
         ],
         "issues": [
-          "#20",
-          "#21",
           "#25"
         ],
-        "rationale": "Core ownership types and lifecycle tests exist; command-engine enforcement, complete backend policy, and retained-byte accounting remain tracked."
+        "rationale": "Provider and command-engine lifecycle semantics are executable; the threat model and aggregate retained-byte policy remain tracked."
       }
     },
     {
@@ -260,15 +248,15 @@
         "status": "mixed",
         "evidence": [
           "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
           "crates/virtio-accel-device/src/object_table.rs",
-          "crates/virtio-accel-mock/src/lib.rs"
+          "crates/virtio-accel-mock/src/lib.rs",
+          "tests/portable_end_to_end.rs"
         ],
         "issues": [
-          "#20",
-          "#21",
           "#25"
         ],
-        "rationale": "Core ownership types and lifecycle tests exist; command-engine enforcement, complete backend policy, and retained-byte accounting remain tracked."
+        "rationale": "Provider and command-engine lifecycle semantics are executable; the threat model and aggregate retained-byte policy remain tracked."
       }
     },
     {
@@ -282,15 +270,15 @@
         "status": "mixed",
         "evidence": [
           "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
           "crates/virtio-accel-device/src/object_table.rs",
-          "crates/virtio-accel-mock/src/lib.rs"
+          "crates/virtio-accel-mock/src/lib.rs",
+          "tests/portable_end_to_end.rs"
         ],
         "issues": [
-          "#20",
-          "#21",
           "#25"
         ],
-        "rationale": "Core ownership types and lifecycle tests exist; command-engine enforcement, complete backend policy, and retained-byte accounting remain tracked."
+        "rationale": "Provider and command-engine lifecycle semantics are executable; the threat model and aggregate retained-byte policy remain tracked."
       }
     },
     {
@@ -304,15 +292,15 @@
         "status": "mixed",
         "evidence": [
           "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
           "crates/virtio-accel-device/src/object_table.rs",
-          "crates/virtio-accel-mock/src/lib.rs"
+          "crates/virtio-accel-mock/src/lib.rs",
+          "tests/portable_end_to_end.rs"
         ],
         "issues": [
-          "#20",
-          "#21",
           "#25"
         ],
-        "rationale": "Core ownership types and lifecycle tests exist; command-engine enforcement, complete backend policy, and retained-byte accounting remain tracked."
+        "rationale": "Provider and command-engine lifecycle semantics are executable; the threat model and aggregate retained-byte policy remain tracked."
       }
     },
     {
@@ -326,15 +314,15 @@
         "status": "mixed",
         "evidence": [
           "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
           "crates/virtio-accel-device/src/object_table.rs",
-          "crates/virtio-accel-mock/src/lib.rs"
+          "crates/virtio-accel-mock/src/lib.rs",
+          "tests/portable_end_to_end.rs"
         ],
         "issues": [
-          "#20",
-          "#21",
           "#25"
         ],
-        "rationale": "Core ownership types and lifecycle tests exist; command-engine enforcement, complete backend policy, and retained-byte accounting remain tracked."
+        "rationale": "Provider and command-engine lifecycle semantics are executable; the threat model and aggregate retained-byte policy remain tracked."
       }
     },
     {
@@ -348,15 +336,15 @@
         "status": "mixed",
         "evidence": [
           "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
           "crates/virtio-accel-device/src/object_table.rs",
-          "crates/virtio-accel-mock/src/lib.rs"
+          "crates/virtio-accel-mock/src/lib.rs",
+          "tests/portable_end_to_end.rs"
         ],
         "issues": [
-          "#20",
-          "#21",
           "#25"
         ],
-        "rationale": "Core ownership types and lifecycle tests exist; command-engine enforcement, complete backend policy, and retained-byte accounting remain tracked."
+        "rationale": "Provider and command-engine lifecycle semantics are executable; the threat model and aggregate retained-byte policy remain tracked."
       }
     },
     {
@@ -370,15 +358,15 @@
         "status": "mixed",
         "evidence": [
           "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
           "crates/virtio-accel-device/src/object_table.rs",
-          "crates/virtio-accel-mock/src/lib.rs"
+          "crates/virtio-accel-mock/src/lib.rs",
+          "tests/portable_end_to_end.rs"
         ],
         "issues": [
-          "#20",
-          "#21",
           "#25"
         ],
-        "rationale": "Core ownership types and lifecycle tests exist; command-engine enforcement, complete backend policy, and retained-byte accounting remain tracked."
+        "rationale": "Provider and command-engine lifecycle semantics are executable; the threat model and aggregate retained-byte policy remain tracked."
       }
     },
     {
@@ -392,15 +380,15 @@
         "status": "mixed",
         "evidence": [
           "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
           "crates/virtio-accel-device/src/object_table.rs",
-          "crates/virtio-accel-mock/src/lib.rs"
+          "crates/virtio-accel-mock/src/lib.rs",
+          "tests/portable_end_to_end.rs"
         ],
         "issues": [
-          "#20",
-          "#21",
           "#25"
         ],
-        "rationale": "Core ownership types and lifecycle tests exist; command-engine enforcement, complete backend policy, and retained-byte accounting remain tracked."
+        "rationale": "Provider and command-engine lifecycle semantics are executable; the threat model and aggregate retained-byte policy remain tracked."
       }
     },
     {
@@ -414,15 +402,15 @@
         "status": "mixed",
         "evidence": [
           "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
           "crates/virtio-accel-device/src/object_table.rs",
-          "crates/virtio-accel-mock/src/lib.rs"
+          "crates/virtio-accel-mock/src/lib.rs",
+          "tests/portable_end_to_end.rs"
         ],
         "issues": [
-          "#20",
-          "#21",
           "#25"
         ],
-        "rationale": "Core ownership types and lifecycle tests exist; command-engine enforcement, complete backend policy, and retained-byte accounting remain tracked."
+        "rationale": "Provider and command-engine lifecycle semantics are executable; the threat model and aggregate retained-byte policy remain tracked."
       }
     },
     {
@@ -436,15 +424,15 @@
         "status": "mixed",
         "evidence": [
           "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
           "crates/virtio-accel-device/src/object_table.rs",
-          "crates/virtio-accel-mock/src/lib.rs"
+          "crates/virtio-accel-mock/src/lib.rs",
+          "tests/portable_end_to_end.rs"
         ],
         "issues": [
-          "#20",
-          "#21",
           "#25"
         ],
-        "rationale": "Core ownership types and lifecycle tests exist; command-engine enforcement, complete backend policy, and retained-byte accounting remain tracked."
+        "rationale": "Provider and command-engine lifecycle semantics are executable; the threat model and aggregate retained-byte policy remain tracked."
       }
     },
     {
@@ -458,15 +446,15 @@
         "status": "mixed",
         "evidence": [
           "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
           "crates/virtio-accel-device/src/object_table.rs",
-          "crates/virtio-accel-mock/src/lib.rs"
+          "crates/virtio-accel-mock/src/lib.rs",
+          "tests/portable_end_to_end.rs"
         ],
         "issues": [
-          "#20",
-          "#21",
           "#25"
         ],
-        "rationale": "Core ownership types and lifecycle tests exist; command-engine enforcement, complete backend policy, and retained-byte accounting remain tracked."
+        "rationale": "Provider and command-engine lifecycle semantics are executable; the threat model and aggregate retained-byte policy remain tracked."
       }
     },
     {
@@ -480,15 +468,15 @@
         "status": "mixed",
         "evidence": [
           "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
           "crates/virtio-accel-device/src/object_table.rs",
-          "crates/virtio-accel-mock/src/lib.rs"
+          "crates/virtio-accel-mock/src/lib.rs",
+          "tests/portable_end_to_end.rs"
         ],
         "issues": [
-          "#20",
-          "#21",
           "#25"
         ],
-        "rationale": "Core ownership types and lifecycle tests exist; command-engine enforcement, complete backend policy, and retained-byte accounting remain tracked."
+        "rationale": "Provider and command-engine lifecycle semantics are executable; the threat model and aggregate retained-byte policy remain tracked."
       }
     },
     {
@@ -502,15 +490,15 @@
         "status": "mixed",
         "evidence": [
           "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
           "crates/virtio-accel-device/src/object_table.rs",
-          "crates/virtio-accel-mock/src/lib.rs"
+          "crates/virtio-accel-mock/src/lib.rs",
+          "tests/portable_end_to_end.rs"
         ],
         "issues": [
-          "#20",
-          "#21",
           "#25"
         ],
-        "rationale": "Core ownership types and lifecycle tests exist; command-engine enforcement, complete backend policy, and retained-byte accounting remain tracked."
+        "rationale": "Provider and command-engine lifecycle semantics are executable; the threat model and aggregate retained-byte policy remain tracked."
       }
     },
     {
@@ -524,15 +512,15 @@
         "status": "mixed",
         "evidence": [
           "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
           "crates/virtio-accel-device/src/object_table.rs",
-          "crates/virtio-accel-mock/src/lib.rs"
+          "crates/virtio-accel-mock/src/lib.rs",
+          "tests/portable_end_to_end.rs"
         ],
         "issues": [
-          "#20",
-          "#21",
           "#25"
         ],
-        "rationale": "Core ownership types and lifecycle tests exist; command-engine enforcement, complete backend policy, and retained-byte accounting remain tracked."
+        "rationale": "Provider and command-engine lifecycle semantics are executable; the threat model and aggregate retained-byte policy remain tracked."
       }
     },
     {
@@ -546,15 +534,15 @@
         "status": "mixed",
         "evidence": [
           "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
           "crates/virtio-accel-device/src/object_table.rs",
-          "crates/virtio-accel-mock/src/lib.rs"
+          "crates/virtio-accel-mock/src/lib.rs",
+          "tests/portable_end_to_end.rs"
         ],
         "issues": [
-          "#20",
-          "#21",
           "#25"
         ],
-        "rationale": "Core ownership types and lifecycle tests exist; command-engine enforcement, complete backend policy, and retained-byte accounting remain tracked."
+        "rationale": "Provider and command-engine lifecycle semantics are executable; the threat model and aggregate retained-byte policy remain tracked."
       }
     },
     {
@@ -568,15 +556,15 @@
         "status": "mixed",
         "evidence": [
           "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
           "crates/virtio-accel-device/src/object_table.rs",
-          "crates/virtio-accel-mock/src/lib.rs"
+          "crates/virtio-accel-mock/src/lib.rs",
+          "tests/portable_end_to_end.rs"
         ],
         "issues": [
-          "#20",
-          "#21",
           "#25"
         ],
-        "rationale": "Core ownership types and lifecycle tests exist; command-engine enforcement, complete backend policy, and retained-byte accounting remain tracked."
+        "rationale": "Provider and command-engine lifecycle semantics are executable; the threat model and aggregate retained-byte policy remain tracked."
       }
     },
     {
@@ -590,15 +578,15 @@
         "status": "mixed",
         "evidence": [
           "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
           "crates/virtio-accel-device/src/object_table.rs",
-          "crates/virtio-accel-mock/src/lib.rs"
+          "crates/virtio-accel-mock/src/lib.rs",
+          "tests/portable_end_to_end.rs"
         ],
         "issues": [
-          "#20",
-          "#21",
           "#25"
         ],
-        "rationale": "Core ownership types and lifecycle tests exist; command-engine enforcement, complete backend policy, and retained-byte accounting remain tracked."
+        "rationale": "Provider and command-engine lifecycle semantics are executable; the threat model and aggregate retained-byte policy remain tracked."
       }
     },
     {
@@ -612,15 +600,15 @@
         "status": "mixed",
         "evidence": [
           "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
           "crates/virtio-accel-device/src/object_table.rs",
-          "crates/virtio-accel-mock/src/lib.rs"
+          "crates/virtio-accel-mock/src/lib.rs",
+          "tests/portable_end_to_end.rs"
         ],
         "issues": [
-          "#20",
-          "#21",
           "#25"
         ],
-        "rationale": "Core ownership types and lifecycle tests exist; command-engine enforcement, complete backend policy, and retained-byte accounting remain tracked."
+        "rationale": "Provider and command-engine lifecycle semantics are executable; the threat model and aggregate retained-byte policy remain tracked."
       }
     },
     {
@@ -634,15 +622,15 @@
         "status": "mixed",
         "evidence": [
           "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
           "crates/virtio-accel-device/src/object_table.rs",
-          "crates/virtio-accel-mock/src/lib.rs"
+          "crates/virtio-accel-mock/src/lib.rs",
+          "tests/portable_end_to_end.rs"
         ],
         "issues": [
-          "#20",
-          "#21",
           "#25"
         ],
-        "rationale": "Core ownership types and lifecycle tests exist; command-engine enforcement, complete backend policy, and retained-byte accounting remain tracked."
+        "rationale": "Provider and command-engine lifecycle semantics are executable; the threat model and aggregate retained-byte policy remain tracked."
       }
     },
     {
@@ -653,18 +641,17 @@
       "keyword": "MUST",
       "statement": "The transport **MUST** stop fetching command chains and publishing completions before portable",
       "coverage": {
-        "status": "mixed",
+        "status": "executable",
         "evidence": [
           "crates/virtio-accel-transport/src/queue.rs",
           "crates/virtio-accel-split-queue/src/queue.rs",
           "crates/virtio-accel-device/src/engine.rs",
           "crates/virtio-accel-device/tests/command_processor.rs",
-          "docs/virtqueue.md"
+          "docs/virtqueue.md",
+          "tests/portable_end_to_end.rs"
         ],
-        "issues": [
-          "#20"
-        ],
-        "rationale": "The split model stops fetch and publication while atomically invalidating old byte ports; full transport-to-engine reset remains tracked."
+        "issues": [],
+        "rationale": "The full path stops fetch and publication, atomically invalidates old byte ports, tears down backend state, and reclaims guest ownership."
       }
     },
     {
@@ -753,10 +740,9 @@
           "crates/virtio-accel-proto/src/lib.rs"
         ],
         "issues": [
-          "#20",
           "#32"
         ],
-        "rationale": "Namespaces and reserved values are executable; runtime negotiation and future evolution remain tracked."
+        "rationale": "Namespaces, reserved values, runtime capability selection, and negotiation are executable; future evolution remains tracked."
       }
     },
     {
@@ -773,10 +759,9 @@
           "crates/virtio-accel-proto/src/lib.rs"
         ],
         "issues": [
-          "#20",
           "#32"
         ],
-        "rationale": "Namespaces and reserved values are executable; runtime negotiation and future evolution remain tracked."
+        "rationale": "Namespaces, reserved values, runtime capability selection, and negotiation are executable; future evolution remains tracked."
       }
     },
     {
@@ -793,10 +778,9 @@
           "crates/virtio-accel-proto/src/lib.rs"
         ],
         "issues": [
-          "#20",
           "#32"
         ],
-        "rationale": "Namespaces and reserved values are executable; runtime negotiation and future evolution remain tracked."
+        "rationale": "Namespaces, reserved values, runtime capability selection, and negotiation are executable; future evolution remains tracked."
       }
     },
     {
@@ -813,10 +797,9 @@
           "crates/virtio-accel-proto/src/lib.rs"
         ],
         "issues": [
-          "#20",
           "#32"
         ],
-        "rationale": "Namespaces and reserved values are executable; runtime negotiation and future evolution remain tracked."
+        "rationale": "Namespaces, reserved values, runtime capability selection, and negotiation are executable; future evolution remains tracked."
       }
     },
     {
@@ -833,10 +816,9 @@
           "crates/virtio-accel-proto/src/lib.rs"
         ],
         "issues": [
-          "#20",
           "#32"
         ],
-        "rationale": "Namespaces and reserved values are executable; runtime negotiation and future evolution remain tracked."
+        "rationale": "Namespaces, reserved values, runtime capability selection, and negotiation are executable; future evolution remains tracked."
       }
     },
     {
@@ -853,10 +835,9 @@
           "crates/virtio-accel-proto/src/lib.rs"
         ],
         "issues": [
-          "#20",
           "#32"
         ],
-        "rationale": "Namespaces and reserved values are executable; runtime negotiation and future evolution remain tracked."
+        "rationale": "Namespaces, reserved values, runtime capability selection, and negotiation are executable; future evolution remains tracked."
       }
     },
     {
@@ -873,10 +854,9 @@
           "crates/virtio-accel-proto/src/lib.rs"
         ],
         "issues": [
-          "#20",
           "#32"
         ],
-        "rationale": "Namespaces and reserved values are executable; runtime negotiation and future evolution remain tracked."
+        "rationale": "Namespaces, reserved values, runtime capability selection, and negotiation are executable; future evolution remains tracked."
       }
     },
     {
@@ -887,22 +867,149 @@
       "keyword": "MUST",
       "statement": "The device **MUST** reject an allocation for an unsupported memory domain before invoking the",
       "coverage": {
-        "status": "mixed",
+        "status": "executable",
         "evidence": [
-          "conformance/rust-clean-room/tests/vectors.rs",
-          "crates/virtio-accel-proto/src/lib.rs"
+          "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/src/decoder.rs",
+          "crates/virtio-accel-device/src/engine.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
+          "crates/virtio-accel-guest/src/client.rs",
+          "crates/virtio-accel-mock/src/lib.rs"
         ],
-        "issues": [
-          "#20",
-          "#32"
-        ],
-        "rationale": "Namespaces and reserved values are executable; runtime negotiation and future evolution remain tracked."
+        "issues": [],
+        "rationale": "Construction-time metadata checks and operation preflight tests enforce stable limits, usable memory domains, reserved flags, and capability-to-method consistency."
       }
     },
     {
-      "id": "REQ-SPEC-310DA03F3289",
+      "id": "REQ-SPEC-BC626A25687E",
+      "source": "docs/specification.md",
+      "line": 316,
+      "section": "5. Baseline capabilities and feature policy",
+      "keyword": "MUST",
+      "statement": "A baseline backend **MUST** advertise at least one assigned memory-domain capability. Every",
+      "coverage": {
+        "status": "executable",
+        "evidence": [
+          "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/src/decoder.rs",
+          "crates/virtio-accel-device/src/engine.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
+          "crates/virtio-accel-guest/src/client.rs",
+          "crates/virtio-accel-mock/src/lib.rs"
+        ],
+        "issues": [],
+        "rationale": "Construction-time metadata checks and operation preflight tests enforce stable limits, usable memory domains, reserved flags, and capability-to-method consistency."
+      }
+    },
+    {
+      "id": "REQ-SPEC-293DC68B231B",
       "source": "docs/specification.md",
       "line": 317,
+      "section": "5. Baseline capabilities and feature policy",
+      "keyword": "MUST",
+      "statement": "resource-count, binding-count, and byte limit in `DeviceInfo` **MUST** be nonzero. Identity,",
+      "coverage": {
+        "status": "executable",
+        "evidence": [
+          "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/src/decoder.rs",
+          "crates/virtio-accel-device/src/engine.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
+          "crates/virtio-accel-guest/src/client.rs",
+          "crates/virtio-accel-mock/src/lib.rs"
+        ],
+        "issues": [],
+        "rationale": "Construction-time metadata checks and operation preflight tests enforce stable limits, usable memory domains, reserved flags, and capability-to-method consistency."
+      }
+    },
+    {
+      "id": "REQ-SPEC-58C9CD029E4E",
+      "source": "docs/specification.md",
+      "line": 318,
+      "section": "5. Baseline capabilities and feature policy",
+      "keyword": "MUST",
+      "statement": "capabilities, and limits **MUST** remain stable for the lifetime of one backend instance so the",
+      "coverage": {
+        "status": "executable",
+        "evidence": [
+          "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/src/decoder.rs",
+          "crates/virtio-accel-device/src/engine.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
+          "crates/virtio-accel-guest/src/client.rs",
+          "crates/virtio-accel-mock/src/lib.rs"
+        ],
+        "issues": [],
+        "rationale": "Construction-time metadata checks and operation preflight tests enforce stable limits, usable memory domains, reserved flags, and capability-to-method consistency."
+      }
+    },
+    {
+      "id": "REQ-SPEC-ABEC6507C56E",
+      "source": "docs/specification.md",
+      "line": 321,
+      "section": "5. Baseline capabilities and feature policy",
+      "keyword": "MUST",
+      "statement": "If `EVENT_CANCELLATION` is absent, the command engine **MUST** reject cancellation before backend",
+      "coverage": {
+        "status": "executable",
+        "evidence": [
+          "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/src/decoder.rs",
+          "crates/virtio-accel-device/src/engine.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
+          "crates/virtio-accel-guest/src/client.rs",
+          "crates/virtio-accel-mock/src/lib.rs"
+        ],
+        "issues": [],
+        "rationale": "Construction-time metadata checks and operation preflight tests enforce stable limits, usable memory domains, reserved flags, and capability-to-method consistency."
+      }
+    },
+    {
+      "id": "REQ-SPEC-3BDDC7B37721",
+      "source": "docs/specification.md",
+      "line": 322,
+      "section": "5. Baseline capabilities and feature policy",
+      "keyword": "MUST",
+      "statement": "invocation. If it is present, the backend **MUST** implement cancellation and **MUST NOT** return",
+      "coverage": {
+        "status": "executable",
+        "evidence": [
+          "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/src/decoder.rs",
+          "crates/virtio-accel-device/src/engine.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
+          "crates/virtio-accel-guest/src/client.rs",
+          "crates/virtio-accel-mock/src/lib.rs"
+        ],
+        "issues": [],
+        "rationale": "Construction-time metadata checks and operation preflight tests enforce stable limits, usable memory domains, reserved flags, and capability-to-method consistency."
+      }
+    },
+    {
+      "id": "REQ-SPEC-B9DC00E86791",
+      "source": "docs/specification.md",
+      "line": 322,
+      "section": "5. Baseline capabilities and feature policy",
+      "keyword": "MUST NOT",
+      "statement": "invocation. If it is present, the backend **MUST** implement cancellation and **MUST NOT** return",
+      "coverage": {
+        "status": "executable",
+        "evidence": [
+          "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/src/decoder.rs",
+          "crates/virtio-accel-device/src/engine.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
+          "crates/virtio-accel-guest/src/client.rs",
+          "crates/virtio-accel-mock/src/lib.rs"
+        ],
+        "issues": [],
+        "rationale": "Construction-time metadata checks and operation preflight tests enforce stable limits, usable memory domains, reserved flags, and capability-to-method consistency."
+      }
+    },
+    {
+      "id": "REQ-SPEC-E6868E4CF5B2",
+      "source": "docs/specification.md",
+      "line": 326,
       "section": "5. Baseline capabilities and feature policy",
       "keyword": "MUST",
       "statement": "new synchronization, or changed lifetime rules, the device **MUST** also negotiate an appropriate",
@@ -913,36 +1020,36 @@
           "crates/virtio-accel-proto/src/lib.rs"
         ],
         "issues": [
-          "#20",
           "#32"
         ],
-        "rationale": "Namespaces and reserved values are executable; runtime negotiation and future evolution remain tracked."
+        "rationale": "Namespaces, reserved values, runtime capability selection, and negotiation are executable; future evolution remains tracked."
       }
     },
     {
-      "id": "REQ-SPEC-88D1E0A07A40",
+      "id": "REQ-SPEC-1192C3C18A01",
       "source": "docs/specification.md",
-      "line": 322,
+      "line": 331,
       "section": "5. Baseline capabilities and feature policy",
-      "keyword": "MUST NOT",
-      "statement": "implementation **MUST NOT** translate an underspecified capability into additional wire behavior.",
+      "keyword": "MUST",
+      "statement": "**MUST** reject nonempty values before backend invocation; a direct caller of the backend trait",
       "coverage": {
-        "status": "mixed",
+        "status": "executable",
         "evidence": [
-          "conformance/rust-clean-room/tests/vectors.rs",
-          "crates/virtio-accel-proto/src/lib.rs"
+          "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/src/decoder.rs",
+          "crates/virtio-accel-device/src/engine.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
+          "crates/virtio-accel-guest/src/client.rs",
+          "crates/virtio-accel-mock/src/lib.rs"
         ],
-        "issues": [
-          "#20",
-          "#32"
-        ],
-        "rationale": "Namespaces and reserved values are executable; runtime negotiation and future evolution remain tracked."
+        "issues": [],
+        "rationale": "Construction-time metadata checks and operation preflight tests enforce stable limits, usable memory domains, reserved flags, and capability-to-method consistency."
       }
     },
     {
-      "id": "REQ-SPEC-2B52FA3DDCAD",
+      "id": "REQ-SPEC-C438C1EA95F3",
       "source": "docs/specification.md",
-      "line": 327,
+      "line": 338,
       "section": "5. Baseline capabilities and feature policy",
       "keyword": "MUST",
       "statement": "reserved and **MUST** be zero.",
@@ -953,16 +1060,15 @@
           "crates/virtio-accel-proto/src/lib.rs"
         ],
         "issues": [
-          "#20",
           "#32"
         ],
-        "rationale": "Namespaces and reserved values are executable; runtime negotiation and future evolution remain tracked."
+        "rationale": "Namespaces, reserved values, runtime capability selection, and negotiation are executable; future evolution remains tracked."
       }
     },
     {
-      "id": "REQ-SPEC-53CBDDF2F9E6",
+      "id": "REQ-SPEC-034AAAED8CCB",
       "source": "docs/specification.md",
-      "line": 330,
+      "line": 341,
       "section": "5. Baseline capabilities and feature policy",
       "keyword": "MUST",
       "statement": "**MUST** be rejected before backend invocation. Reserved fields **MUST** be zero.",
@@ -973,16 +1079,15 @@
           "crates/virtio-accel-proto/src/lib.rs"
         ],
         "issues": [
-          "#20",
           "#32"
         ],
-        "rationale": "Namespaces and reserved values are executable; runtime negotiation and future evolution remain tracked."
+        "rationale": "Namespaces, reserved values, runtime capability selection, and negotiation are executable; future evolution remains tracked."
       }
     },
     {
-      "id": "REQ-SPEC-5B0DC6A13B5B",
+      "id": "REQ-SPEC-002AEF3E3100",
       "source": "docs/specification.md",
-      "line": 330,
+      "line": 341,
       "section": "5. Baseline capabilities and feature policy",
       "keyword": "MUST",
       "statement": "**MUST** be rejected before backend invocation. Reserved fields **MUST** be zero.",
@@ -993,16 +1098,15 @@
           "crates/virtio-accel-proto/src/lib.rs"
         ],
         "issues": [
-          "#20",
           "#32"
         ],
-        "rationale": "Namespaces and reserved values are executable; runtime negotiation and future evolution remain tracked."
+        "rationale": "Namespaces, reserved values, runtime capability selection, and negotiation are executable; future evolution remains tracked."
       }
     },
     {
-      "id": "REQ-SPEC-C15BB0E55C0A",
+      "id": "REQ-SPEC-C4038EE45051",
       "source": "docs/specification.md",
-      "line": 337,
+      "line": 348,
       "section": "6. Versioning and compatibility",
       "keyword": "MUST",
       "statement": "Candidate implementations **MUST** expose major `1` and minor `0` in device-specific configuration",
@@ -1021,9 +1125,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-200066C129F2",
+      "id": "REQ-SPEC-6B4375F7AFED",
       "source": "docs/specification.md",
-      "line": 338,
+      "line": 349,
       "section": "6. Versioning and compatibility",
       "keyword": "MUST NOT",
       "statement": "and **MUST NOT** claim candidate protocol 1.0 conformance unless they satisfy the normative wire,",
@@ -1042,9 +1146,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-14CBA0A183EB",
+      "id": "REQ-SPEC-CE15155BCD7C",
       "source": "docs/specification.md",
-      "line": 342,
+      "line": 353,
       "section": "6. Versioning and compatibility",
       "keyword": "MUST",
       "statement": "#33. Before that audit, an intentional candidate revision **MUST** follow the coordinated procedure",
@@ -1063,9 +1167,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-5ECE338A6907",
+      "id": "REQ-SPEC-7E361A949E8A",
       "source": "docs/specification.md",
-      "line": 343,
+      "line": 354,
       "section": "6. Versioning and compatibility",
       "keyword": "MUST NOT",
       "statement": "in [wire-abi.md](wire-abi.md) and **MUST NOT** be described as a frozen or stable release.",
@@ -1084,9 +1188,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-95AD226E6215",
+      "id": "REQ-SPEC-7959D696D2AB",
       "source": "docs/specification.md",
-      "line": 349,
+      "line": 360,
       "section": "6. Versioning and compatibility",
       "keyword": "MUST",
       "statement": "- a driver **MUST** reject a device with an unsupported major version;",
@@ -1105,9 +1209,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-B767A7B1C839",
+      "id": "REQ-SPEC-8417B9694757",
       "source": "docs/specification.md",
-      "line": 351,
+      "line": 362,
       "section": "6. Versioning and compatibility",
       "keyword": "MUST NOT",
       "statement": "- a driver **MUST NOT** use behavior newer than the device minor version it observed; and",
@@ -1126,9 +1230,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-AE218946BDCC",
+      "id": "REQ-SPEC-A47B979280E4",
       "source": "docs/specification.md",
-      "line": 360,
+      "line": 371,
       "section": "6. Versioning and compatibility",
       "keyword": "MUST NOT",
       "statement": "Therefore a minor version alone **MUST NOT** append fields to an existing response that an older",
@@ -1147,9 +1251,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-016999BA61E1",
+      "id": "REQ-SPEC-F2E9A4914D27",
       "source": "docs/specification.md",
-      "line": 364,
+      "line": 375,
       "section": "6. Versioning and compatibility",
       "keyword": "SHOULD",
       "statement": "negotiated feature explicitly selects a different layout. Extensions **SHOULD** use a new opcode or",
@@ -1168,9 +1272,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-1C37D20890C7",
+      "id": "REQ-SPEC-B102AEC467EA",
       "source": "docs/specification.md",
-      "line": 367,
+      "line": 378,
       "section": "6. Versioning and compatibility",
       "keyword": "MUST",
       "statement": "Without such a feature, a receiver **MUST** require the exact payload length for the opcode and",
@@ -1189,9 +1293,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-7EA21D16DE58",
+      "id": "REQ-SPEC-3F6D3B977243",
       "source": "docs/specification.md",
-      "line": 368,
+      "line": 379,
       "section": "6. Versioning and compatibility",
       "keyword": "MUST",
       "statement": "**MUST** reject trailing bytes. It **MUST NOT** silently reinterpret or ignore an unknown tail.",
@@ -1210,9 +1314,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-E3E8676ED37E",
+      "id": "REQ-SPEC-130EBE2E9C2E",
       "source": "docs/specification.md",
-      "line": 368,
+      "line": 379,
       "section": "6. Versioning and compatibility",
       "keyword": "MUST NOT",
       "statement": "**MUST** reject trailing bytes. It **MUST NOT** silently reinterpret or ignore an unknown tail.",
@@ -1231,9 +1335,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-A2CB96B8A1C3",
+      "id": "REQ-SPEC-5F6759A95E05",
       "source": "docs/specification.md",
-      "line": 375,
+      "line": 386,
       "section": "6. Versioning and compatibility",
       "keyword": "MUST NOT",
       "statement": "- An unknown response status is an opaque failure. A driver **MUST NOT** treat it as success or",
@@ -1252,231 +1356,289 @@
       }
     },
     {
-      "id": "REQ-SPEC-D3C51FC19E65",
+      "id": "REQ-SPEC-8EAED13479BA",
       "source": "docs/specification.md",
-      "line": 382,
+      "line": 393,
       "section": "7. Ownership and destruction",
       "keyword": "MUST",
       "statement": "The device owns the mapping from opaque object IDs to backend handles. The mapping **MUST** reject:",
       "coverage": {
-        "status": "mixed",
+        "status": "executable",
         "evidence": [
           "crates/virtio-accel-core/src/lib.rs",
           "crates/virtio-accel-device/src/object_table.rs",
-          "crates/virtio-accel-mock/src/lib.rs"
+          "crates/virtio-accel-device/tests/command_processor.rs",
+          "tests/portable_end_to_end.rs"
         ],
-        "issues": [
-          "#20",
-          "#21"
-        ],
-        "rationale": "Handle and generational-ID invariants are tested; end-to-end release recovery remains tracked."
+        "issues": [],
+        "rationale": "Handle ownership, generational IDs, rejected and indeterminate release, reset recovery, and transfer-failure publication are executable."
       }
     },
     {
-      "id": "REQ-SPEC-1A8E3B4C24C2",
+      "id": "REQ-SPEC-E8CBB7086059",
       "source": "docs/specification.md",
-      "line": 390,
+      "line": 401,
       "section": "7. Ownership and destruction",
       "keyword": "MUST NOT",
       "statement": "Object-ID encoding is implementation-private. Drivers **MUST NOT** infer slot, kind, generation, or",
       "coverage": {
-        "status": "mixed",
+        "status": "executable",
         "evidence": [
           "crates/virtio-accel-core/src/lib.rs",
           "crates/virtio-accel-device/src/object_table.rs",
-          "crates/virtio-accel-mock/src/lib.rs"
+          "crates/virtio-accel-device/tests/command_processor.rs",
+          "tests/portable_end_to_end.rs"
         ],
-        "issues": [
-          "#20",
-          "#21"
-        ],
-        "rationale": "Handle and generational-ID invariants are tested; end-to-end release recovery remains tracked."
+        "issues": [],
+        "rationale": "Handle ownership, generational IDs, rejected and indeterminate release, reset recovery, and transfer-failure publication are executable."
       }
     },
     {
-      "id": "REQ-SPEC-AB23FAC11CFD",
+      "id": "REQ-SPEC-11FB6A43D16D",
       "source": "docs/specification.md",
-      "line": 395,
+      "line": 406,
       "section": "7. Ownership and destruction",
       "keyword": "MUST",
       "statement": "- a rejected release returns the still-live handle and the device **MUST** restore it for retry;",
       "coverage": {
-        "status": "mixed",
+        "status": "executable",
         "evidence": [
           "crates/virtio-accel-core/src/lib.rs",
           "crates/virtio-accel-device/src/object_table.rs",
-          "crates/virtio-accel-mock/src/lib.rs"
+          "crates/virtio-accel-device/tests/command_processor.rs",
+          "tests/portable_end_to_end.rs"
         ],
-        "issues": [
-          "#20",
-          "#21"
-        ],
-        "rationale": "Handle and generational-ID invariants are tested; end-to-end release recovery remains tracked."
+        "issues": [],
+        "rationale": "Handle ownership, generational IDs, rejected and indeterminate release, reset recovery, and transfer-failure publication are executable."
       }
     },
     {
-      "id": "REQ-SPEC-C2F6D1492668",
+      "id": "REQ-SPEC-C5511AD39A09",
       "source": "docs/specification.md",
-      "line": 397,
+      "line": 408,
       "section": "7. Ownership and destruction",
       "keyword": "MUST NOT",
       "statement": "- an indeterminate release invalidates the guest ID and requires recovery. The device **MUST NOT**",
       "coverage": {
-        "status": "mixed",
+        "status": "executable",
         "evidence": [
           "crates/virtio-accel-core/src/lib.rs",
           "crates/virtio-accel-device/src/object_table.rs",
-          "crates/virtio-accel-mock/src/lib.rs"
+          "crates/virtio-accel-device/tests/command_processor.rs",
+          "tests/portable_end_to_end.rs"
         ],
-        "issues": [
-          "#20",
-          "#21"
-        ],
-        "rationale": "Handle and generational-ID invariants are tested; end-to-end release recovery remains tracked."
+        "issues": [],
+        "rationale": "Handle ownership, generational IDs, rejected and indeterminate release, reset recovery, and transfer-failure publication are executable."
       }
     },
     {
-      "id": "REQ-SPEC-00E07DBCC21D",
+      "id": "REQ-SPEC-2C20B9BB974C",
       "source": "docs/specification.md",
-      "line": 400,
+      "line": 411,
       "section": "7. Ownership and destruction",
       "keyword": "MUST NOT",
       "statement": "`Drop` may provide defensive cleanup inside an implementation but **MUST NOT** be used as",
       "coverage": {
-        "status": "mixed",
+        "status": "executable",
         "evidence": [
           "crates/virtio-accel-core/src/lib.rs",
           "crates/virtio-accel-device/src/object_table.rs",
-          "crates/virtio-accel-mock/src/lib.rs"
+          "crates/virtio-accel-device/tests/command_processor.rs",
+          "tests/portable_end_to_end.rs"
         ],
-        "issues": [
-          "#20",
-          "#21"
-        ],
-        "rationale": "Handle and generational-ID invariants are tested; end-to-end release recovery remains tracked."
+        "issues": [],
+        "rationale": "Handle ownership, generational IDs, rejected and indeterminate release, reset recovery, and transfer-failure publication are executable."
       }
     },
     {
-      "id": "REQ-SPEC-4FCCE03626EA",
+      "id": "REQ-SPEC-E520D676CE05",
       "source": "docs/specification.md",
-      "line": 406,
+      "line": 414,
+      "section": "7. Ownership and destruction",
+      "keyword": "MUST NOT",
+      "statement": "A creation method that returns an ordinary error **MUST NOT** retain a newly created resource. A",
+      "coverage": {
+        "status": "executable",
+        "evidence": [
+          "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/src/object_table.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
+          "tests/portable_end_to_end.rs"
+        ],
+        "issues": [],
+        "rationale": "Handle ownership, generational IDs, rejected and indeterminate release, reset recovery, and transfer-failure publication are executable."
+      }
+    },
+    {
+      "id": "REQ-SPEC-2AE3767049C0",
+      "source": "docs/specification.md",
+      "line": 418,
+      "section": "7. Ownership and destruction",
+      "keyword": "MUST NOT",
+      "statement": "the buffer; the command engine **MUST NOT** publish that destination as a successful payload.",
+      "coverage": {
+        "status": "executable",
+        "evidence": [
+          "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/src/object_table.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
+          "tests/portable_end_to_end.rs"
+        ],
+        "issues": [],
+        "rationale": "Handle ownership, generational IDs, rejected and indeterminate release, reset recovery, and transfer-failure publication are executable."
+      }
+    },
+    {
+      "id": "REQ-SPEC-83A7B584B764",
+      "source": "docs/specification.md",
+      "line": 423,
       "section": "8. Time and progress",
       "keyword": "MUST NOT",
       "statement": "infinite. Absolute guest timestamps **MUST NOT** be compared with a host clock because their",
       "coverage": {
-        "status": "mixed",
+        "status": "executable",
         "evidence": [
-          "crates/virtio-accel-core/src/lib.rs"
+          "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
+          "tests/portable_end_to_end.rs"
         ],
-        "issues": [
-          "#20",
-          "#21"
-        ],
-        "rationale": "Relative timeout semantics are tested; bounded polling and admission behavior require the command engine."
+        "issues": [],
+        "rationale": "Relative timeouts, bounded polling and cancellation, admission ownership, and end-to-end progress are executable."
       }
     },
     {
-      "id": "REQ-SPEC-32BEB66EDC72",
+      "id": "REQ-SPEC-E8A31804CE1C",
       "source": "docs/specification.md",
-      "line": 409,
+      "line": 426,
       "section": "8. Time and progress",
       "keyword": "MUST",
       "statement": "Polling an event **MUST** be nonblocking and bounded. The portable contract creates no background",
       "coverage": {
-        "status": "mixed",
+        "status": "executable",
         "evidence": [
-          "crates/virtio-accel-core/src/lib.rs"
+          "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
+          "tests/portable_end_to_end.rs"
         ],
-        "issues": [
-          "#20",
-          "#21"
-        ],
-        "rationale": "Relative timeout semantics are tested; bounded polling and admission behavior require the command engine."
+        "issues": [],
+        "rationale": "Relative timeouts, bounded polling and cancellation, admission ownership, and end-to-end progress are executable."
       }
     },
     {
-      "id": "REQ-SPEC-87204B0486BE",
+      "id": "REQ-SPEC-FBC2CA09456D",
       "source": "docs/specification.md",
-      "line": 413,
+      "line": 430,
+      "section": "8. Time and progress",
+      "keyword": "MUST NOT",
+      "statement": "synchronous provider work. Submission performs validation and admission only and **MUST NOT** wait",
+      "coverage": {
+        "status": "executable",
+        "evidence": [
+          "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
+          "tests/portable_end_to_end.rs"
+        ],
+        "issues": [],
+        "rationale": "Relative timeouts, bounded polling and cancellation, admission ownership, and end-to-end progress are executable."
+      }
+    },
+    {
+      "id": "REQ-SPEC-728D2CC1555F",
+      "source": "docs/specification.md",
+      "line": 431,
+      "section": "8. Time and progress",
+      "keyword": "MUST",
+      "statement": "for execution to become terminal. Cancellation **MUST** also be nonblocking and bounded. No portable",
+      "coverage": {
+        "status": "executable",
+        "evidence": [
+          "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
+          "tests/portable_end_to_end.rs"
+        ],
+        "issues": [],
+        "rationale": "Relative timeouts, bounded polling and cancellation, admission ownership, and end-to-end progress are executable."
+      }
+    },
+    {
+      "id": "REQ-SPEC-056523814181",
+      "source": "docs/specification.md",
+      "line": 437,
       "section": "8. Time and progress",
       "keyword": "MUST",
       "statement": "cannot prove rejection is indeterminate and **MUST** retain an event.",
       "coverage": {
-        "status": "mixed",
+        "status": "executable",
         "evidence": [
-          "crates/virtio-accel-core/src/lib.rs"
+          "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
+          "tests/portable_end_to_end.rs"
         ],
-        "issues": [
-          "#20",
-          "#21"
-        ],
-        "rationale": "Relative timeout semantics are tested; bounded polling and admission behavior require the command engine."
+        "issues": [],
+        "rationale": "Relative timeouts, bounded polling and cancellation, admission ownership, and end-to-end progress are executable."
       }
     },
     {
-      "id": "REQ-SPEC-FF88F37F2002",
+      "id": "REQ-SPEC-96510D494634",
       "source": "docs/specification.md",
-      "line": 422,
+      "line": 446,
       "section": "9. Errors",
       "keyword": "MUST",
       "statement": "A device **MUST** map errors deterministically and **MUST NOT** expose uninitialized response bytes.",
       "coverage": {
-        "status": "mixed",
+        "status": "executable",
         "evidence": [
           "conformance/rust-clean-room/tests/vectors.rs",
-          "crates/virtio-accel-core/src/lib.rs"
+          "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
+          "tests/portable_end_to_end.rs"
         ],
-        "issues": [
-          "#20",
-          "#21"
-        ],
-        "rationale": "Wire error shapes and ownership-aware failures are executable; backend-to-device recovery is tracked."
+        "issues": [],
+        "rationale": "Wire error shapes, ownership-aware failures, deterministic provider mapping, and backend-to-device recovery are executable."
       }
     },
     {
-      "id": "REQ-SPEC-9BF9C2113FC0",
+      "id": "REQ-SPEC-0C9E311E20CF",
       "source": "docs/specification.md",
-      "line": 422,
+      "line": 446,
       "section": "9. Errors",
       "keyword": "MUST NOT",
       "statement": "A device **MUST** map errors deterministically and **MUST NOT** expose uninitialized response bytes.",
       "coverage": {
-        "status": "mixed",
+        "status": "executable",
         "evidence": [
           "conformance/rust-clean-room/tests/vectors.rs",
-          "crates/virtio-accel-core/src/lib.rs"
+          "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
+          "tests/portable_end_to_end.rs"
         ],
-        "issues": [
-          "#20",
-          "#21"
-        ],
-        "rationale": "Wire error shapes and ownership-aware failures are executable; backend-to-device recovery is tracked."
+        "issues": [],
+        "rationale": "Wire error shapes, ownership-aware failures, deterministic provider mapping, and backend-to-device recovery are executable."
       }
     },
     {
-      "id": "REQ-SPEC-5B13C15F8588",
+      "id": "REQ-SPEC-234F92227481",
       "source": "docs/specification.md",
-      "line": 426,
+      "line": 450,
       "section": "9. Errors",
       "keyword": "MUST NOT",
       "statement": "An error response **MUST NOT** imply that a backend operation was rejected when acceptance was",
       "coverage": {
-        "status": "mixed",
+        "status": "executable",
         "evidence": [
           "conformance/rust-clean-room/tests/vectors.rs",
-          "crates/virtio-accel-core/src/lib.rs"
+          "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
+          "tests/portable_end_to_end.rs"
         ],
-        "issues": [
-          "#20",
-          "#21"
-        ],
-        "rationale": "Wire error shapes and ownership-aware failures are executable; backend-to-device recovery is tracked."
+        "issues": [],
+        "rationale": "Wire error shapes, ownership-aware failures, deterministic provider mapping, and backend-to-device recovery are executable."
       }
     },
     {
-      "id": "REQ-SPEC-992422D1DC7C",
+      "id": "REQ-SPEC-0CE0B3A3324E",
       "source": "docs/specification.md",
-      "line": 431,
+      "line": 455,
       "section": "10. Portability requirements",
       "keyword": "MUST NOT",
       "statement": "Portable crates **MUST NOT** select an operating system, VMM, kernel, vendor API, or global runtime.",
@@ -1492,9 +1654,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-3123035A074A",
+      "id": "REQ-SPEC-E51EF4A89805",
       "source": "docs/specification.md",
-      "line": 439,
+      "line": 463,
       "section": "10. Portability requirements",
       "keyword": "MUST NOT",
       "statement": "Platform adapters depend inward on the portable layers. A portable layer **MUST NOT** conditionally",
@@ -1510,9 +1672,9 @@
       }
     },
     {
-      "id": "REQ-SPEC-7D81F01D02EB",
+      "id": "REQ-SPEC-4A9C77D20762",
       "source": "docs/specification.md",
-      "line": 455,
+      "line": 477,
       "section": "11. Tracked completion work",
       "keyword": "MAY",
       "statement": "No implementation **MAY** advertise a reserved optional feature merely because a Rust constant",
@@ -1522,7 +1684,6 @@
           "ci/check-normative-requirements.py"
         ],
         "issues": [
-          "#21",
           "#25",
           "#32",
           "#33"
@@ -1886,13 +2047,14 @@
         "status": "mixed",
         "evidence": [
           "conformance/rust-clean-room/tests/vectors.rs",
-          "crates/virtio-accel-proto/tests/semantic_interop.rs"
+          "crates/virtio-accel-proto/tests/semantic_interop.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
+          "tests/portable_end_to_end.rs"
         ],
         "issues": [
-          "#20",
           "#25"
         ],
-        "rationale": "Every payload layout and scalar invariant is cross-decoded; live-object and advertised-quota checks are tracked."
+        "rationale": "Every payload layout and scalar invariant is cross-decoded, and live-object and advertised-quota checks are executable; adversarial aggregate limits remain tracked."
       }
     },
     {
@@ -1906,13 +2068,14 @@
         "status": "mixed",
         "evidence": [
           "conformance/rust-clean-room/tests/vectors.rs",
-          "crates/virtio-accel-proto/tests/semantic_interop.rs"
+          "crates/virtio-accel-proto/tests/semantic_interop.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
+          "tests/portable_end_to_end.rs"
         ],
         "issues": [
-          "#20",
           "#25"
         ],
-        "rationale": "Every payload layout and scalar invariant is cross-decoded; live-object and advertised-quota checks are tracked."
+        "rationale": "Every payload layout and scalar invariant is cross-decoded, and live-object and advertised-quota checks are executable; adversarial aggregate limits remain tracked."
       }
     },
     {
@@ -1926,13 +2089,14 @@
         "status": "mixed",
         "evidence": [
           "conformance/rust-clean-room/tests/vectors.rs",
-          "crates/virtio-accel-proto/tests/semantic_interop.rs"
+          "crates/virtio-accel-proto/tests/semantic_interop.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
+          "tests/portable_end_to_end.rs"
         ],
         "issues": [
-          "#20",
           "#25"
         ],
-        "rationale": "Every payload layout and scalar invariant is cross-decoded; live-object and advertised-quota checks are tracked."
+        "rationale": "Every payload layout and scalar invariant is cross-decoded, and live-object and advertised-quota checks are executable; adversarial aggregate limits remain tracked."
       }
     },
     {
@@ -1946,13 +2110,14 @@
         "status": "mixed",
         "evidence": [
           "conformance/rust-clean-room/tests/vectors.rs",
-          "crates/virtio-accel-proto/tests/semantic_interop.rs"
+          "crates/virtio-accel-proto/tests/semantic_interop.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
+          "tests/portable_end_to_end.rs"
         ],
         "issues": [
-          "#20",
           "#25"
         ],
-        "rationale": "Every payload layout and scalar invariant is cross-decoded; live-object and advertised-quota checks are tracked."
+        "rationale": "Every payload layout and scalar invariant is cross-decoded, and live-object and advertised-quota checks are executable; adversarial aggregate limits remain tracked."
       }
     },
     {
@@ -1966,13 +2131,14 @@
         "status": "mixed",
         "evidence": [
           "conformance/rust-clean-room/tests/vectors.rs",
-          "crates/virtio-accel-proto/tests/semantic_interop.rs"
+          "crates/virtio-accel-proto/tests/semantic_interop.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
+          "tests/portable_end_to_end.rs"
         ],
         "issues": [
-          "#20",
           "#25"
         ],
-        "rationale": "Every payload layout and scalar invariant is cross-decoded; live-object and advertised-quota checks are tracked."
+        "rationale": "Every payload layout and scalar invariant is cross-decoded, and live-object and advertised-quota checks are executable; adversarial aggregate limits remain tracked."
       }
     },
     {
@@ -1986,13 +2152,14 @@
         "status": "mixed",
         "evidence": [
           "conformance/rust-clean-room/tests/vectors.rs",
-          "crates/virtio-accel-proto/tests/semantic_interop.rs"
+          "crates/virtio-accel-proto/tests/semantic_interop.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
+          "tests/portable_end_to_end.rs"
         ],
         "issues": [
-          "#20",
           "#25"
         ],
-        "rationale": "Every payload layout and scalar invariant is cross-decoded; live-object and advertised-quota checks are tracked."
+        "rationale": "Every payload layout and scalar invariant is cross-decoded, and live-object and advertised-quota checks are executable; adversarial aggregate limits remain tracked."
       }
     },
     {
@@ -2006,13 +2173,14 @@
         "status": "mixed",
         "evidence": [
           "conformance/rust-clean-room/tests/vectors.rs",
-          "crates/virtio-accel-proto/tests/semantic_interop.rs"
+          "crates/virtio-accel-proto/tests/semantic_interop.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
+          "tests/portable_end_to_end.rs"
         ],
         "issues": [
-          "#20",
           "#25"
         ],
-        "rationale": "Every payload layout and scalar invariant is cross-decoded; live-object and advertised-quota checks are tracked."
+        "rationale": "Every payload layout and scalar invariant is cross-decoded, and live-object and advertised-quota checks are executable; adversarial aggregate limits remain tracked."
       }
     },
     {
@@ -2026,13 +2194,14 @@
         "status": "mixed",
         "evidence": [
           "conformance/rust-clean-room/tests/vectors.rs",
-          "crates/virtio-accel-proto/tests/semantic_interop.rs"
+          "crates/virtio-accel-proto/tests/semantic_interop.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
+          "tests/portable_end_to_end.rs"
         ],
         "issues": [
-          "#20",
           "#25"
         ],
-        "rationale": "Every payload layout and scalar invariant is cross-decoded; live-object and advertised-quota checks are tracked."
+        "rationale": "Every payload layout and scalar invariant is cross-decoded, and live-object and advertised-quota checks are executable; adversarial aggregate limits remain tracked."
       }
     },
     {
@@ -2046,13 +2215,14 @@
         "status": "mixed",
         "evidence": [
           "conformance/rust-clean-room/tests/vectors.rs",
-          "crates/virtio-accel-proto/tests/semantic_interop.rs"
+          "crates/virtio-accel-proto/tests/semantic_interop.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
+          "tests/portable_end_to_end.rs"
         ],
         "issues": [
-          "#20",
           "#25"
         ],
-        "rationale": "Every payload layout and scalar invariant is cross-decoded; live-object and advertised-quota checks are tracked."
+        "rationale": "Every payload layout and scalar invariant is cross-decoded, and live-object and advertised-quota checks are executable; adversarial aggregate limits remain tracked."
       }
     },
     {
@@ -2066,13 +2236,14 @@
         "status": "mixed",
         "evidence": [
           "conformance/rust-clean-room/tests/vectors.rs",
-          "crates/virtio-accel-proto/tests/semantic_interop.rs"
+          "crates/virtio-accel-proto/tests/semantic_interop.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
+          "tests/portable_end_to_end.rs"
         ],
         "issues": [
-          "#20",
           "#25"
         ],
-        "rationale": "Every payload layout and scalar invariant is cross-decoded; live-object and advertised-quota checks are tracked."
+        "rationale": "Every payload layout and scalar invariant is cross-decoded, and live-object and advertised-quota checks are executable; adversarial aggregate limits remain tracked."
       }
     },
     {
@@ -2086,13 +2257,14 @@
         "status": "mixed",
         "evidence": [
           "conformance/rust-clean-room/tests/vectors.rs",
-          "crates/virtio-accel-proto/tests/semantic_interop.rs"
+          "crates/virtio-accel-proto/tests/semantic_interop.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
+          "tests/portable_end_to_end.rs"
         ],
         "issues": [
-          "#20",
           "#25"
         ],
-        "rationale": "Every payload layout and scalar invariant is cross-decoded; live-object and advertised-quota checks are tracked."
+        "rationale": "Every payload layout and scalar invariant is cross-decoded, and live-object and advertised-quota checks are executable; adversarial aggregate limits remain tracked."
       }
     },
     {
@@ -2106,13 +2278,14 @@
         "status": "mixed",
         "evidence": [
           "conformance/rust-clean-room/tests/vectors.rs",
-          "crates/virtio-accel-proto/tests/semantic_interop.rs"
+          "crates/virtio-accel-proto/tests/semantic_interop.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
+          "tests/portable_end_to_end.rs"
         ],
         "issues": [
-          "#20",
           "#25"
         ],
-        "rationale": "Every payload layout and scalar invariant is cross-decoded; live-object and advertised-quota checks are tracked."
+        "rationale": "Every payload layout and scalar invariant is cross-decoded, and live-object and advertised-quota checks are executable; adversarial aggregate limits remain tracked."
       }
     },
     {
@@ -2126,13 +2299,14 @@
         "status": "mixed",
         "evidence": [
           "conformance/rust-clean-room/tests/vectors.rs",
-          "crates/virtio-accel-proto/tests/semantic_interop.rs"
+          "crates/virtio-accel-proto/tests/semantic_interop.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
+          "tests/portable_end_to_end.rs"
         ],
         "issues": [
-          "#20",
           "#25"
         ],
-        "rationale": "Every payload layout and scalar invariant is cross-decoded; live-object and advertised-quota checks are tracked."
+        "rationale": "Every payload layout and scalar invariant is cross-decoded, and live-object and advertised-quota checks are executable; adversarial aggregate limits remain tracked."
       }
     },
     {
@@ -2143,15 +2317,16 @@
       "keyword": "MUST",
       "statement": "Before backend invocation, the device **MUST** validate the complete readable frame and enough",
       "coverage": {
-        "status": "mixed",
+        "status": "executable",
         "evidence": [
           "conformance/v1.0/vectors.json",
-          "crates/virtio-accel-split-queue/src/queue.rs"
+          "crates/virtio-accel-device/src/response.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
+          "crates/virtio-accel-split-queue/src/queue.rs",
+          "tests/portable_end_to_end.rs"
         ],
-        "issues": [
-          "#20"
-        ],
-        "rationale": "Queue-level used accounting and preflight failures are executable; post-mutation command response atomicity requires full-path execution."
+        "issues": [],
+        "rationale": "Preflight, post-mutation response atomicity, exact used accounting, and short-completion rejection are executable through the full path."
       }
     },
     {
@@ -2162,15 +2337,16 @@
       "keyword": "MUST",
       "statement": "writable capacity for every possible response shape of that command. It **MUST** initialize every",
       "coverage": {
-        "status": "mixed",
+        "status": "executable",
         "evidence": [
           "conformance/v1.0/vectors.json",
-          "crates/virtio-accel-split-queue/src/queue.rs"
+          "crates/virtio-accel-device/src/response.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
+          "crates/virtio-accel-split-queue/src/queue.rs",
+          "tests/portable_end_to_end.rs"
         ],
-        "issues": [
-          "#20"
-        ],
-        "rationale": "Queue-level used accounting and preflight failures are executable; post-mutation command response atomicity requires full-path execution."
+        "issues": [],
+        "rationale": "Preflight, post-mutation response atomicity, exact used accounting, and short-completion rejection are executable through the full path."
       }
     },
     {
@@ -2181,15 +2357,16 @@
       "keyword": "MUST",
       "statement": "occurs after semantic mutation, or a release becomes indeterminate, the device **MUST** enter",
       "coverage": {
-        "status": "mixed",
+        "status": "executable",
         "evidence": [
           "conformance/v1.0/vectors.json",
-          "crates/virtio-accel-split-queue/src/queue.rs"
+          "crates/virtio-accel-device/src/response.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
+          "crates/virtio-accel-split-queue/src/queue.rs",
+          "tests/portable_end_to_end.rs"
         ],
-        "issues": [
-          "#20"
-        ],
-        "rationale": "Queue-level used accounting and preflight failures are executable; post-mutation command response atomicity requires full-path execution."
+        "issues": [],
+        "rationale": "Preflight, post-mutation response atomicity, exact used accounting, and short-completion rejection are executable through the full path."
       }
     },
     {
@@ -2200,15 +2377,16 @@
       "keyword": "MUST NOT",
       "statement": "recovery and expose the Virtio `DEVICE_NEEDS_RESET` condition. It **MUST NOT** report an ordinary",
       "coverage": {
-        "status": "mixed",
+        "status": "executable",
         "evidence": [
           "conformance/v1.0/vectors.json",
-          "crates/virtio-accel-split-queue/src/queue.rs"
+          "crates/virtio-accel-device/src/response.rs",
+          "crates/virtio-accel-device/tests/command_processor.rs",
+          "crates/virtio-accel-split-queue/src/queue.rs",
+          "tests/portable_end_to_end.rs"
         ],
-        "issues": [
-          "#20"
-        ],
-        "rationale": "Queue-level used accounting and preflight failures are executable; post-mutation command response atomicity requires full-path execution."
+        "issues": [],
+        "rationale": "Preflight, post-mutation response atomicity, exact used accounting, and short-completion rejection are executable through the full path."
       }
     },
     {
@@ -2312,18 +2490,17 @@
       "keyword": "MUST",
       "statement": "is request-header byte zero. The readable total **MUST** equal:",
       "coverage": {
-        "status": "mixed",
+        "status": "executable",
         "evidence": [
           "conformance/rust-clean-room/tests/vectors.rs",
           "crates/virtio-accel-device/src/frame.rs",
           "crates/virtio-accel-split-queue/src/chain.rs",
           "crates/virtio-accel-split-queue/src/queue.rs",
-          "crates/virtio-accel-transport/src/regions.rs"
+          "crates/virtio-accel-transport/src/regions.rs",
+          "tests/portable_end_to_end.rs"
         ],
-        "issues": [
-          "#20"
-        ],
-        "rationale": "Descriptor-backed segmented presentation and frame exactness are executable; one-command full-path behavior remains tracked."
+        "issues": [],
+        "rationale": "Descriptor-backed segmented presentation, frame exactness, and complete command behavior are executable through the full path."
       }
     },
     {
@@ -2334,16 +2511,15 @@
       "keyword": "MUST",
       "statement": "The device **MUST** commit a response atomically from the protocol\u2019s point of view:",
       "coverage": {
-        "status": "tracked",
+        "status": "executable",
         "evidence": [
           "conformance/rust-clean-room/tests/vectors.rs",
           "crates/virtio-accel-split-queue/src/chain.rs",
-          "crates/virtio-accel-split-queue/src/queue.rs"
+          "crates/virtio-accel-split-queue/src/queue.rs",
+          "tests/portable_end_to_end.rs"
         ],
-        "issues": [
-          "#20"
-        ],
-        "rationale": "Scatter writes and used-length accounting are executable; post-mutation command failure requires full-path execution."
+        "issues": [],
+        "rationale": "Scatter writes, used-length accounting, and post-mutation command failure are executable through the full path."
       }
     },
     {
@@ -2354,16 +2530,15 @@
       "keyword": "MUST",
       "statement": "Response bytes may span writable descriptors. A device **MUST** write them as if to one concatenated",
       "coverage": {
-        "status": "tracked",
+        "status": "executable",
         "evidence": [
           "conformance/rust-clean-room/tests/vectors.rs",
           "crates/virtio-accel-split-queue/src/chain.rs",
-          "crates/virtio-accel-split-queue/src/queue.rs"
+          "crates/virtio-accel-split-queue/src/queue.rs",
+          "tests/portable_end_to_end.rs"
         ],
-        "issues": [
-          "#20"
-        ],
-        "rationale": "Scatter writes and used-length accounting are executable; post-mutation command failure requires full-path execution."
+        "issues": [],
+        "rationale": "Scatter writes, used-length accounting, and post-mutation command failure are executable through the full path."
       }
     },
     {
@@ -2374,16 +2549,15 @@
       "keyword": "MUST",
       "statement": "If mutation or uncertain backend acceptance has occurred, the device **MUST** set",
       "coverage": {
-        "status": "tracked",
+        "status": "executable",
         "evidence": [
           "conformance/rust-clean-room/tests/vectors.rs",
           "crates/virtio-accel-split-queue/src/chain.rs",
-          "crates/virtio-accel-split-queue/src/queue.rs"
+          "crates/virtio-accel-split-queue/src/queue.rs",
+          "tests/portable_end_to_end.rs"
         ],
-        "issues": [
-          "#20"
-        ],
-        "rationale": "Scatter writes and used-length accounting are executable; post-mutation command failure requires full-path execution."
+        "issues": [],
+        "rationale": "Scatter writes, used-length accounting, and post-mutation command failure are executable through the full path."
       }
     },
     {
@@ -2394,15 +2568,14 @@
       "keyword": "MUST",
       "statement": "The baseline command queue permits out-of-order command completion. The device **MUST** consume",
       "coverage": {
-        "status": "mixed",
+        "status": "executable",
         "evidence": [
           "crates/virtio-accel-split-queue/src/queue.rs",
-          "docs/virtqueue.md"
+          "docs/virtqueue.md",
+          "tests/portable_end_to_end.rs"
         ],
-        "issues": [
-          "#20"
-        ],
-        "rationale": "Available-order consumption and out-of-order used publication are executable; command/event distinction awaits the full path."
+        "issues": [],
+        "rationale": "Available-order consumption, out-of-order completion, and command/event distinction are executable through the full path."
       }
     },
     {
@@ -2413,15 +2586,14 @@
       "keyword": "MUST NOT",
       "statement": "Request-ID uniqueness lasts until the corresponding chain is returned used. A driver **MUST NOT**",
       "coverage": {
-        "status": "mixed",
+        "status": "executable",
         "evidence": [
           "crates/virtio-accel-split-queue/src/queue.rs",
-          "docs/virtqueue.md"
+          "docs/virtqueue.md",
+          "tests/portable_end_to_end.rs"
         ],
-        "issues": [
-          "#20"
-        ],
-        "rationale": "Available-order consumption and out-of-order used publication are executable; command/event distinction awaits the full path."
+        "issues": [],
+        "rationale": "Available-order consumption, out-of-order completion, and command/event distinction are executable through the full path."
       }
     },
     {
@@ -2432,15 +2604,14 @@
       "keyword": "MUST NOT",
       "statement": "Implementations may serialize command execution, but they **MUST NOT** promise in-order completion",
       "coverage": {
-        "status": "mixed",
+        "status": "executable",
         "evidence": [
           "crates/virtio-accel-split-queue/src/queue.rs",
-          "docs/virtqueue.md"
+          "docs/virtqueue.md",
+          "tests/portable_end_to_end.rs"
         ],
-        "issues": [
-          "#20"
-        ],
-        "rationale": "Available-order consumption and out-of-order used publication are executable; command/event distinction awaits the full path."
+        "issues": [],
+        "rationale": "Available-order consumption, out-of-order completion, and command/event distinction are executable through the full path."
       }
     },
     {
@@ -2451,17 +2622,16 @@
       "keyword": "MUST",
       "statement": "- A driver with no free descriptor head or insufficient writable buffers **MUST** retain the command",
       "coverage": {
-        "status": "mixed",
+        "status": "executable",
         "evidence": [
+          "crates/virtio-accel-guest/src/client.rs",
           "crates/virtio-accel-split-queue/src/queue.rs",
           "crates/virtio-accel-transport/src/queue.rs",
-          "docs/virtqueue.md"
+          "docs/virtqueue.md",
+          "tests/portable_end_to_end.rs"
         ],
-        "issues": [
-          "#19",
-          "#20"
-        ],
-        "rationale": "Publication ownership and retryable backpressure types are executable; guest behavior and full-path tests remain tracked."
+        "issues": [],
+        "rationale": "Publication ownership, guest retryable backpressure, and full-path completion are executable."
       }
     },
     {
@@ -2472,17 +2642,16 @@
       "keyword": "MUST NOT",
       "statement": "- It **MUST NOT** publish a partial command or reuse descriptors still owned by the device.",
       "coverage": {
-        "status": "mixed",
+        "status": "executable",
         "evidence": [
+          "crates/virtio-accel-guest/src/client.rs",
           "crates/virtio-accel-split-queue/src/queue.rs",
           "crates/virtio-accel-transport/src/queue.rs",
-          "docs/virtqueue.md"
+          "docs/virtqueue.md",
+          "tests/portable_end_to_end.rs"
         ],
-        "issues": [
-          "#19",
-          "#20"
-        ],
-        "rationale": "Publication ownership and retryable backpressure types are executable; guest behavior and full-path tests remain tracked."
+        "issues": [],
+        "rationale": "Publication ownership, guest retryable backpressure, and full-path completion are executable."
       }
     },
     {
@@ -2493,16 +2662,15 @@
       "keyword": "MUST NOT",
       "statement": "limiting **MUST NOT** change object ownership or fabricate successful responses.",
       "coverage": {
-        "status": "mixed",
+        "status": "executable",
         "evidence": [
           "conformance/rust-clean-room/tests/vectors.rs",
           "crates/virtio-accel-split-queue/src/chain.rs",
-          "crates/virtio-accel-split-queue/src/queue.rs"
+          "crates/virtio-accel-split-queue/src/queue.rs",
+          "tests/portable_end_to_end.rs"
         ],
-        "issues": [
-          "#20"
-        ],
-        "rationale": "Malformed frames and descriptor chains are isolated separately; full command-chain continuation remains tracked."
+        "issues": [],
+        "rationale": "Malformed frames and descriptor chains are isolated while later command chains continue through the full path."
       }
     },
     {
@@ -2513,18 +2681,17 @@
       "keyword": "MUST NOT",
       "statement": "the base Virtio reset rule. It **MUST NOT** expect response bytes or used entries for those chains.",
       "coverage": {
-        "status": "mixed",
+        "status": "executable",
         "evidence": [
+          "crates/virtio-accel-guest/src/client.rs",
           "crates/virtio-accel-transport/src/queue.rs",
           "crates/virtio-accel-split-queue/src/queue.rs",
           "crates/virtio-accel-device/src/engine.rs",
-          "docs/virtqueue.md"
+          "docs/virtqueue.md",
+          "tests/portable_end_to_end.rs"
         ],
-        "issues": [
-          "#19",
-          "#20"
-        ],
-        "rationale": "Split-ring and engine reset are executable separately; guest reclamation and full-path reset remain tracked."
+        "issues": [],
+        "rationale": "Split-ring invalidation, guest reclamation, engine teardown, and full-path reset are executable."
       }
     },
     {
@@ -2535,15 +2702,16 @@
       "keyword": "SHOULD",
       "statement": "After observing `DEVICE_NEEDS_RESET`, the driver **SHOULD** stop submitting commands and perform",
       "coverage": {
-        "status": "tracked",
+        "status": "mixed",
         "evidence": [
-          "crates/virtio-accel-core/src/lib.rs"
+          "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/src/engine.rs",
+          "tests/portable_end_to_end.rs"
         ],
         "issues": [
-          "#20",
           "#25"
         ],
-        "rationale": "Ownership-aware failure types exist; DEVICE_NEEDS_RESET transitions require the command engine and threat limits."
+        "rationale": "Ownership-aware failures and DEVICE_NEEDS_RESET transitions are executable; the adversarial resource policy remains tracked."
       }
     },
     {
@@ -2554,15 +2722,16 @@
       "keyword": "MUST NOT",
       "statement": "but it **MUST NOT** accept new semantic work.",
       "coverage": {
-        "status": "tracked",
+        "status": "mixed",
         "evidence": [
-          "crates/virtio-accel-core/src/lib.rs"
+          "crates/virtio-accel-core/src/lib.rs",
+          "crates/virtio-accel-device/src/engine.rs",
+          "tests/portable_end_to_end.rs"
         ],
         "issues": [
-          "#20",
           "#25"
         ],
-        "rationale": "Ownership-aware failure types exist; DEVICE_NEEDS_RESET transitions require the command engine and threat limits."
+        "rationale": "Ownership-aware failures and DEVICE_NEEDS_RESET transitions are executable; the adversarial resource policy remains tracked."
       }
     }
   ]

--- a/crates/virtio-accel-core/src/lib.rs
+++ b/crates/virtio-accel-core/src/lib.rs
@@ -68,6 +68,7 @@ bitflags! {
         const HOST_VISIBLE_MEMORY = 1 << 0;
         /// Supports [`MemoryDomain::Device`] allocations.
         const DEVICE_LOCAL_MEMORY = 1 << 1;
+        /// [`Accelerator::cancel_event`] is implemented for pending events.
         const EVENT_CANCELLATION = 1 << 2;
         /// Reserved for post-v1 external-allocation import/export semantics.
         const EXTERNAL_MEMORY = 1 << 3;
@@ -75,6 +76,13 @@ bitflags! {
         const SECURE_CONTEXTS = 1 << 4;
         /// Supports provider-owned [`MemoryDomain::Shared`] allocations.
         const SHARED_MEMORY = 1 << 5;
+
+        /// Capabilities that make at least one provider-owned memory domain usable.
+        const MEMORY_DOMAINS = Self::HOST_VISIBLE_MEMORY.bits()
+            | Self::DEVICE_LOCAL_MEMORY.bits()
+            | Self::SHARED_MEMORY.bits();
+        /// Assigned bits whose semantics remain reserved by this version of the contract.
+        const RESERVED = Self::EXTERNAL_MEMORY.bits() | Self::SECURE_CONTEXTS.bits();
     }
 }
 
@@ -116,9 +124,21 @@ pub struct DeviceInfo {
     pub limits: DeviceLimits,
 }
 
+/// Invalid provider metadata discovered before any resource operation is invoked.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DeviceInfoError {
+    /// A capability whose semantics are still reserved was advertised.
+    ReservedCapabilities,
+    /// No provider-owned memory domain can be allocated.
+    MissingMemoryDomain,
+    /// A mandatory resource or byte limit is zero.
+    ZeroLimit,
+}
+
 bitflags! {
     #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
     pub struct ContextFlags: u32 {
+        /// Reserved until secure-context isolation and transport semantics are specified.
         const SECURE = 1 << 0;
     }
 }
@@ -324,6 +344,43 @@ impl BufferInfo {
 }
 
 impl DeviceInfo {
+    /// Validate immutable provider metadata once, before constructing live object state.
+    ///
+    /// Unknown capability bits remain representable for forward-compatible diagnostics. Assigned
+    /// reserved bits are rejected because this version cannot enforce their ownership and
+    /// synchronization rules.
+    pub const fn validate(self) -> Result<(), DeviceInfoError> {
+        if self.capabilities.intersects(Capabilities::RESERVED) {
+            return Err(DeviceInfoError::ReservedCapabilities);
+        }
+        if !self.capabilities.intersects(Capabilities::MEMORY_DOMAINS) {
+            return Err(DeviceInfoError::MissingMemoryDomain);
+        }
+        if self.limits.max_contexts == 0
+            || self.limits.max_buffers_per_context == 0
+            || self.limits.max_programs_per_context == 0
+            || self.limits.max_queues_per_context == 0
+            || self.limits.max_events_per_context == 0
+            || self.limits.max_bindings_per_submission == 0
+            || self.limits.max_buffer_bytes == 0
+            || self.limits.max_artifact_bytes == 0
+        {
+            return Err(DeviceInfoError::ZeroLimit);
+        }
+        Ok(())
+    }
+
+    /// Validate context intent before backend invocation.
+    ///
+    /// This contract currently reserves every nonempty context flag set.
+    pub fn validate_context_desc(self, desc: ContextDesc) -> Result<(), BackendError> {
+        if desc.flags.is_empty() {
+            Ok(())
+        } else {
+            Err(BackendError::Unsupported)
+        }
+    }
+
     /// Validate allocation size and memory-domain support before backend invocation.
     pub fn validate_buffer_desc(self, desc: BufferDesc) -> Result<(), BackendError> {
         if desc.bytes() > self.limits.max_buffer_bytes {
@@ -346,6 +403,26 @@ impl DeviceInfo {
             return Err(BackendError::Incompatible);
         }
         Ok(())
+    }
+
+    /// Validate execution-queue intent before backend invocation.
+    ///
+    /// This contract currently reserves every nonempty execution-queue flag set.
+    pub fn validate_queue_desc(self, desc: QueueDesc) -> Result<(), BackendError> {
+        if desc.flags.is_empty() {
+            Ok(())
+        } else {
+            Err(BackendError::Unsupported)
+        }
+    }
+
+    /// Validate event-cancellation support before backend invocation.
+    pub fn validate_event_cancellation(self) -> Result<(), BackendError> {
+        if self.capabilities.contains(Capabilities::EVENT_CANCELLATION) {
+            Ok(())
+        } else {
+            Err(BackendError::Unsupported)
+        }
     }
 }
 
@@ -653,6 +730,7 @@ bitflags! {
     /// protocol uses the term *command virtqueue* for the transport queue carrying requests.
     #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
     pub struct QueueFlags: u32 {
+        /// Reserved until ordering behavior and capability negotiation are specified.
         const IN_ORDER = 1 << 0;
     }
 }
@@ -750,41 +828,102 @@ impl<R> ReleaseFailure<R> {
     }
 }
 
-/// Native accelerator lifecycle. Handles remain provider-owned and statically dispatched.
+/// Native accelerator lifecycle over provider-owned handle types.
 ///
-/// Destructive methods consume handles. A transport adapter must reject parent destruction while
-/// child objects or in-flight events still exist; it must not use `Drop` timing as protocol state.
+/// The reference command engine is generic over this trait, so its calls are statically dispatched
+/// and native handles need no boxing. The trait imposes no `Send` or `Sync` bounds: a provider may
+/// preserve thread-affine handles, while a provider that opts into those auto traits must make the
+/// corresponding shared calls safe. Callers must not overlap a mutable borrow, a consumed handle,
+/// or destruction with another use of the same resource.
 ///
-/// The only baseline operations that explicitly transfer buffer contents are [`Self::write_buffer`]
-/// and [`Self::read_buffer`]. Allocation, submission, polling, and release must not hide full-range
-/// staging copies. In particular, `submit` binds the provider allocation directly or rejects it as
-/// [`BackendError::Incompatible`].
+/// Borrowed arguments are valid only for the duration of a call and must not be retained as Rust
+/// references. Destructive methods consume handles. A caller must reject parent destruction while
+/// child objects or in-flight events still exist; it must not use `Drop` timing as lifecycle state.
 ///
-/// [`Self::Queue`] is an accelerator execution queue. It must not be confused with the command
-/// virtqueue used by a transport adapter to deliver protocol requests.
+/// The only operations that explicitly transfer buffer contents are [`Self::write_buffer`] and
+/// [`Self::read_buffer`]. Allocation, submission, polling, and release must not hide full-range
+/// staging copies. In particular, `submit` binds the exact provider allocation directly or rejects
+/// it as [`BackendError::Incompatible`].
+///
+/// Dynamic loading, a stable binary interface, and erased cross-boundary handle ownership are not
+/// defined here. An integration that needs dynamic dispatch must fix one concrete handle family in
+/// an adapter without weakening this trait's borrowing, acceptance, or release contracts.
 pub trait Accelerator {
+    /// Owned context handle. It may be a native value and need not be boxed, cloneable, or thread
+    /// safe.
     type Context;
+    /// Owned handle for the exact allocation described by its accompanying [`BufferInfo`].
     type Buffer;
+    /// Owned resident-program handle with no borrow of its source artifact.
     type Program;
+    /// Owned accelerator execution-queue handle.
     type Queue;
+    /// Owned submission and completion token with no borrow of the submitted binding slice.
     type Event;
 
+    /// Return immutable identity, capability, and limit metadata.
+    ///
+    /// - **Ownership/lifetime:** no ownership changes; a successful value must remain stable for
+    ///   the lifetime of this backend instance.
+    /// - **Progress/concurrency:** discovery may perform bounded synchronous provider work but must
+    ///   not wait for resource progress. Concurrent calls are permitted only when the concrete
+    ///   backend is `Sync`.
+    /// - **Failure/retry:** an error creates no resource and may be retried; callers validate and
+    ///   cache the first successful result before invoking resource methods.
+    /// - **Allocation/copies:** the call must not allocate resource backing or copy bulk content.
     fn device_info(&self) -> Result<DeviceInfo, BackendError>;
+
+    /// Create one context from prevalidated intent.
+    ///
+    /// - **Ownership/lifetime:** `desc` is consumed by value and not retained by reference; success
+    ///   returns one owned context. All current nonempty context flags are unsupported.
+    /// - **Progress/concurrency:** provider setup may synchronously block, but must not wait for
+    ///   unrelated resource progress. Independent creation may overlap only when concrete types
+    ///   permit it.
+    /// - **Failure/retry:** `Err` guarantees that no context resource was retained and the request
+    ///   may be retried.
+    /// - **Allocation/copies:** context bookkeeping may be allocated; no buffer content is copied.
     fn create_context(&self, desc: ContextDesc) -> Result<Self::Context, BackendError>;
+
+    /// Destroy an empty context.
+    ///
+    /// - **Ownership/lifetime:** the handle is consumed and must have no live child resources.
+    /// - **Progress/concurrency:** release may synchronously block, but must not wait for children
+    ///   or in-flight work; no use of this context may overlap the call.
+    /// - **Failure/retry:** [`ReleaseFailure::Rejected`] returns the live handle for retry;
+    ///   [`ReleaseFailure::Indeterminate`] invalidates it and forbids retry.
+    /// - **Allocation/copies:** the call releases provider bookkeeping and copies no content.
     fn destroy_context(&self, context: Self::Context) -> Result<(), ReleaseFailure<Self::Context>>;
 
+    /// Allocate one exact provider-owned buffer backing.
+    ///
+    /// - **Ownership/lifetime:** `context` is borrowed only for this call. Success returns an owned
+    ///   handle plus metadata for the actual backing; neither may borrow `context`.
+    /// - **Progress/concurrency:** allocation may synchronously block. Independent contexts may be
+    ///   used concurrently only when the concrete backend and handles permit it.
+    /// - **Failure/retry:** `Err` guarantees that no buffer backing was retained and may be retried.
+    /// - **Allocation/copies:** this is the buffer-allocation boundary. Program-visible requests
+    ///   allocate directly bindable backing here or fail; they must not reserve a submission-time
+    ///   bounce allocation or copy buffer content.
     fn allocate_buffer(
         &self,
         context: &Self::Context,
         desc: BufferDesc,
     ) -> Result<AllocatedBuffer<Self::Buffer>, BackendError>;
+
     /// Perform one explicit host-to-buffer transfer.
     ///
-    /// The command engine calls this only for buffers with [`BufferUsage::TRANSFER_DESTINATION`].
-    /// The provider must not retain `data`. A segmented source should be read directly into final
-    /// backing rather than coalesced. Host-visible allocations should copy directly into their
-    /// final backing; device-local allocations may use bounded temporary staging during this
-    /// explicit transfer.
+    /// - **Ownership/lifetime:** `buffer` is exclusively borrowed and `data` is borrowed only for
+    ///   this call. The provider must not retain either reference.
+    /// - **Progress/concurrency:** the call may synchronously block until the explicit transfer is
+    ///   complete. The exclusive buffer borrow prevents overlapping access without forcing
+    ///   interior synchronization; unrelated buffers may progress when concrete types permit it.
+    /// - **Failure/retry:** on `Err`, the requested range may be partially modified but the handle
+    ///   remains live. A later successful full-range write replaces it; device loss is not
+    ///   retryable on the same backend instance.
+    /// - **Allocation/copies:** this is an explicit content-copy boundary. Segmented input should
+    ///   flow into final backing without frame-sized coalescing. Device-local backing may use
+    ///   bounded temporary staging during this call.
     fn write_buffer(
         &self,
         buffer: &mut Self::Buffer,
@@ -793,32 +932,102 @@ pub trait Accelerator {
     ) -> Result<(), BackendError>;
     /// Perform one explicit buffer-to-host transfer.
     ///
-    /// The command engine calls this only for buffers with [`BufferUsage::TRANSFER_SOURCE`]. The
-    /// provider must not retain `data` and should write directly across segmented destinations.
-    /// Returning `Ok(())` guarantees that every byte in `data` was initialized; the command engine
-    /// may publish the complete destination without first clearing it.
+    /// - **Ownership/lifetime:** `buffer` is shared-borrowed and `data` is exclusively borrowed only
+    ///   for this call. The provider must not retain either reference.
+    /// - **Progress/concurrency:** the call may synchronously block until the explicit transfer is
+    ///   complete. Shared reads may overlap only when the concrete buffer is `Sync` and the
+    ///   provider supports that access.
+    /// - **Failure/retry:** `Err` leaves the destination potentially partially initialized; the
+    ///   caller must not publish it. The buffer is unchanged and a complete read may be retried
+    ///   unless the backend is lost. `Ok(())` guarantees every destination byte was initialized.
+    /// - **Allocation/copies:** this is an explicit content-copy boundary. The provider should
+    ///   write directly across segmented destinations; device-local backing may use bounded
+    ///   temporary staging during this call.
     fn read_buffer(
         &self,
         buffer: &Self::Buffer,
         offset: u64,
         data: &mut dyn ByteSink,
     ) -> Result<(), BackendError>;
+
+    /// Release an unreferenced buffer and its exact backing allocation.
+    ///
+    /// - **Ownership/lifetime:** the handle is consumed and must not be bound to an in-flight event.
+    /// - **Progress/concurrency:** release may synchronously block but must not wait for references
+    ///   to disappear; no access to this buffer may overlap the call.
+    /// - **Failure/retry:** rejected release returns the live handle for retry; indeterminate
+    ///   release invalidates it and requires recovery.
+    /// - **Allocation/copies:** backing is deallocated without copying its contents or allocating a
+    ///   replacement.
     fn free_buffer(&self, buffer: Self::Buffer) -> Result<(), ReleaseFailure<Self::Buffer>>;
 
+    /// Create a resident program from an opaque, possibly segmented artifact.
+    ///
+    /// - **Ownership/lifetime:** `context`, `artifact.payload`, and the envelope are borrowed only
+    ///   for this call. Success returns an owned program with no source borrow.
+    /// - **Progress/concurrency:** program creation may synchronously block. Independent lifecycle
+    ///   work may overlap only when the concrete backend and context permit it.
+    /// - **Failure/retry:** `Err` guarantees that no program resource was retained and may be
+    ///   retried with a still-live context and artifact.
+    /// - **Allocation/copies:** resident program storage may be allocated. Segmented bytes should
+    ///   stream into final resident storage rather than require one artifact-sized coalescing copy.
     fn load_program(
         &self,
         context: &Self::Context,
         artifact: ArtifactRef<'_>,
     ) -> Result<Self::Program, BackendError>;
+
+    /// Release an unreferenced resident program.
+    ///
+    /// - **Ownership/lifetime:** the program is consumed and must not be referenced by an event.
+    /// - **Progress/concurrency:** release may synchronously block but must not wait for in-flight
+    ///   references; no use of this program may overlap the call.
+    /// - **Failure/retry:** rejected release returns the live handle for retry; indeterminate
+    ///   release invalidates it and requires recovery.
+    /// - **Allocation/copies:** resident storage is released without copying buffer contents or
+    ///   allocating replacement state.
     fn unload_program(&self, program: Self::Program) -> Result<(), ReleaseFailure<Self::Program>>;
 
+    /// Create one accelerator execution queue.
+    ///
+    /// - **Ownership/lifetime:** `context` is borrowed only for this call and success returns an
+    ///   owned queue. All current nonempty queue flags are unsupported.
+    /// - **Progress/concurrency:** queue setup may synchronously block. Independent creation may
+    ///   overlap only when concrete types permit it.
+    /// - **Failure/retry:** `Err` guarantees that no queue resource was retained and may be retried.
+    /// - **Allocation/copies:** queue bookkeeping may be allocated; no program or buffer content is
+    ///   copied.
     fn create_queue(
         &self,
         context: &Self::Context,
         desc: QueueDesc,
     ) -> Result<Self::Queue, BackendError>;
+
+    /// Release an unreferenced execution queue.
+    ///
+    /// - **Ownership/lifetime:** the queue is consumed and must not be referenced by an event.
+    /// - **Progress/concurrency:** release may synchronously block but must not wait for submitted
+    ///   work; no use of this queue may overlap the call.
+    /// - **Failure/retry:** rejected release returns the live handle for retry; indeterminate
+    ///   release invalidates it and requires recovery.
+    /// - **Allocation/copies:** queue state is released without copying buffer content or allocating
+    ///   replacement state.
     fn destroy_queue(&self, queue: Self::Queue) -> Result<(), ReleaseFailure<Self::Queue>>;
 
+    /// Attempt to admit one program execution and return its event.
+    ///
+    /// - **Ownership/lifetime:** queue, program, buffers, and the binding slice are borrowed only
+    ///   during admission and must not be retained as Rust references. The caller keeps every
+    ///   referenced handle alive until the returned event is terminal and destroyed.
+    /// - **Progress/concurrency:** synchronous work is limited to validation and admission; the call
+    ///   must not wait for execution to finish. Concurrent submission requires concrete `Sync`
+    ///   handles and provider support; the trait requires no lock or atomic operation by itself.
+    /// - **Failure/retry:** [`SubmitFailure::Rejected`] guarantees no acceptance and permits retry.
+    ///   Success or [`SubmitFailure::Indeterminate`] transfers invocation ownership to the event and
+    ///   must not be retried as though rejected.
+    /// - **Allocation/copies:** the borrowed slice requires no per-binding box or owned mirror.
+    ///   Providers may use amortized event storage, but must directly bind each exact allocation and
+    ///   reject incompatibility instead of allocating or copying through hidden bounce buffers.
     fn submit(
         &self,
         queue: &Self::Queue,
@@ -826,18 +1035,41 @@ pub trait Accelerator {
         bindings: &[BindingRef<'_, Self::Buffer>],
         timeout: Timeout,
     ) -> Result<Self::Event, SubmitFailure<Self::Event>>;
+
     /// Observe event state without blocking or driving an executor.
     ///
-    /// Once a terminal state is observed, every later successful poll returns the same state.
+    /// - **Ownership/lifetime:** the event is borrowed only for this call and remains live.
+    /// - **Progress/concurrency:** polling is bounded, nonblocking, and safe to race with provider
+    ///   completion when the concrete event is `Sync`.
+    /// - **Failure/retry:** errors do not make an event terminal; polling may be retried unless the
+    ///   backend is lost. Once observed, a terminal state is stable across every later success.
+    /// - **Allocation/copies:** polling allocates no per-call state and copies no bulk content.
     fn poll_event(&self, event: &Self::Event) -> Result<EventState, BackendError>;
+
     /// Attempt to make a pending event terminal as [`EventState::Cancelled`].
     ///
-    /// If completion wins the race, the backend returns [`BackendError::Busy`] and polling reveals
-    /// the selected terminal result. Returning `Ok(())` means cancellation won and every later
-    /// successful poll returns `Cancelled`.
+    /// - **Ownership/lifetime:** the event is borrowed only for this call and remains live.
+    /// - **Progress/concurrency:** cancellation is bounded and nonblocking. It may race with
+    ///   completion; the provider chooses exactly one terminal result without requiring a lock in
+    ///   the handle contract.
+    /// - **Failure/retry:** `Ok(())` means cancellation won. [`BackendError::Busy`] means completion
+    ///   won and the caller should poll. The default `Unsupported` implementation is conformant only
+    ///   when [`Capabilities::EVENT_CANCELLATION`] is absent.
+    /// - **Allocation/copies:** cancellation allocates no per-call state and copies no bulk content.
     fn cancel_event(&self, _event: &Self::Event) -> Result<(), BackendError> {
         Err(BackendError::Unsupported)
     }
+
+    /// Release one terminal event and its provider invocation state.
+    ///
+    /// - **Ownership/lifetime:** the event is consumed. Every referenced queue, program, and buffer
+    ///   must remain live until this release succeeds or becomes indeterminate.
+    /// - **Progress/concurrency:** release may synchronously block but must not wait for a pending
+    ///   event to finish; no poll or cancellation may overlap this call.
+    /// - **Failure/retry:** rejected release returns the live event for retry; indeterminate release
+    ///   invalidates it and requires recovery.
+    /// - **Allocation/copies:** invocation state is released without copying buffer content or
+    ///   allocating replacement state.
     fn destroy_event(&self, event: Self::Event) -> Result<(), ReleaseFailure<Self::Event>>;
 }
 
@@ -877,6 +1109,28 @@ mod tests {
                 .ok_or(ByteAccessError::OutOfBounds)?;
             self.0[start..end].copy_from_slice(source);
             Ok(())
+        }
+    }
+
+    fn valid_device_info() -> DeviceInfo {
+        DeviceInfo {
+            identity: DeviceIdentity {
+                uuid: [0; 16],
+                class: AcceleratorClass::OTHER,
+                vendor_id: 0,
+                device_id: 0,
+            },
+            capabilities: Capabilities::HOST_VISIBLE_MEMORY,
+            limits: DeviceLimits {
+                max_contexts: 1,
+                max_buffers_per_context: 1,
+                max_programs_per_context: 1,
+                max_queues_per_context: 1,
+                max_events_per_context: 1,
+                max_bindings_per_submission: 1,
+                max_buffer_bytes: 1,
+                max_artifact_bytes: 1,
+            },
         }
     }
 
@@ -977,6 +1231,60 @@ mod tests {
         assert!(capabilities.supports_memory_domain(MemoryDomain::Host));
         assert!(capabilities.supports_memory_domain(MemoryDomain::Shared));
         assert!(!capabilities.supports_memory_domain(MemoryDomain::Device));
+    }
+
+    #[test]
+    fn device_information_rejects_unusable_provider_contracts() {
+        let valid = valid_device_info();
+        assert_eq!(valid.validate(), Ok(()));
+
+        let mut reserved = valid;
+        reserved.capabilities |= Capabilities::EXTERNAL_MEMORY;
+        assert_eq!(
+            reserved.validate(),
+            Err(DeviceInfoError::ReservedCapabilities)
+        );
+
+        let mut no_memory = valid;
+        no_memory.capabilities = Capabilities::EVENT_CANCELLATION;
+        assert_eq!(
+            no_memory.validate(),
+            Err(DeviceInfoError::MissingMemoryDomain)
+        );
+
+        let mut zero_limit = valid;
+        zero_limit.limits.max_bindings_per_submission = 0;
+        assert_eq!(zero_limit.validate(), Err(DeviceInfoError::ZeroLimit));
+
+        let mut unknown = valid;
+        unknown.capabilities |= Capabilities::from_bits_retain(1 << 63);
+        assert_eq!(unknown.validate(), Ok(()));
+    }
+
+    #[test]
+    fn reserved_operations_are_rejected_before_provider_invocation() {
+        let mut info = valid_device_info();
+        assert_eq!(info.validate_context_desc(ContextDesc::default()), Ok(()));
+        assert_eq!(info.validate_queue_desc(QueueDesc::default()), Ok(()));
+        assert_eq!(
+            info.validate_context_desc(ContextDesc {
+                flags: ContextFlags::SECURE,
+            }),
+            Err(BackendError::Unsupported)
+        );
+        assert_eq!(
+            info.validate_queue_desc(QueueDesc {
+                flags: QueueFlags::IN_ORDER,
+            }),
+            Err(BackendError::Unsupported)
+        );
+        assert_eq!(
+            info.validate_event_cancellation(),
+            Err(BackendError::Unsupported)
+        );
+
+        info.capabilities |= Capabilities::EVENT_CANCELLATION;
+        assert_eq!(info.validate_event_cancellation(), Ok(()));
     }
 
     #[test]

--- a/crates/virtio-accel-device/src/engine.rs
+++ b/crates/virtio-accel-device/src/engine.rs
@@ -9,7 +9,8 @@ use alloc::vec::Vec;
 
 use virtio_accel_core::{
     Accelerator, ArtifactRef, BackendError, BindingRef, BufferRange, BufferUsage, ByteSink,
-    ByteSource, Capabilities, DeviceInfo, EventState, ReleaseFailure, SubmitFailure, Timeout,
+    ByteSource, Capabilities, DeviceInfo, DeviceInfoError, EventState, ReleaseFailure,
+    SubmitFailure, Timeout,
 };
 use virtio_accel_proto::{
     KnownEventState, Le16, Le32, Le64, ObjectPayload, StatusCode, SubmitResponse, WireConfig,
@@ -62,6 +63,7 @@ pub enum ResetError {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CommandProcessorInitError {
     Backend(BackendError),
+    DeviceInfo(DeviceInfoError),
     Decoder(DecoderLimitsError),
     State(DeviceStateConfigError),
 }
@@ -128,6 +130,8 @@ impl<A: Accelerator> CommandProcessor<A> {
         let info = accelerator
             .device_info()
             .map_err(CommandProcessorInitError::Backend)?;
+        info.validate()
+            .map_err(CommandProcessorInitError::DeviceInfo)?;
         let limits =
             DecoderLimits::new(config, info).map_err(CommandProcessorInitError::Decoder)?;
         let state =
@@ -286,6 +290,9 @@ impl<A: Accelerator> CommandProcessor<A> {
                 )
             }
             DecodedRequestBody::CreateContext(desc) => {
+                if let Err(error) = self.info.validate_context_desc(desc) {
+                    return self.respond_backend_error(response, request_id, error, false);
+                }
                 let accelerator = &self.accelerator;
                 match self
                     .state
@@ -356,6 +363,9 @@ impl<A: Accelerator> CommandProcessor<A> {
                 self.unload_program(response, request_id, program_id)
             }
             DecodedRequestBody::CreateQueue { context_id, desc } => {
+                if let Err(error) = self.info.validate_queue_desc(desc) {
+                    return self.respond_backend_error(response, request_id, error, false);
+                }
                 let accelerator = &self.accelerator;
                 match self.state.create_queue_with(context_id, |context| {
                     accelerator.create_queue(context, desc)
@@ -805,11 +815,7 @@ impl<A: Accelerator> CommandProcessor<A> {
         request_id: u64,
         event_id: ObjectId,
     ) -> Result<CommandOutcome, CommandProcessError> {
-        if !self
-            .info
-            .capabilities
-            .contains(Capabilities::EVENT_CANCELLATION)
-        {
+        if self.info.validate_event_cancellation().is_err() {
             return self.respond_empty(response, StatusCode::UNSUPPORTED, request_id, false);
         }
         let event = match self.state.event_record(event_id) {

--- a/crates/virtio-accel-device/tests/command_processor.rs
+++ b/crates/virtio-accel-device/tests/command_processor.rs
@@ -5,8 +5,8 @@ use std::vec::Vec;
 
 use virtio_accel_core::{
     Accelerator, AccessMode, AllocatedBuffer, ArtifactRef, BackendError, BindingRef, BufferDesc,
-    BufferUsage, ByteSink, ByteSource, Capabilities, ContextDesc, DeviceInfo, EventState,
-    MemoryDomain, QueueDesc, ReleaseFailure, SubmitFailure, Timeout,
+    BufferUsage, ByteSink, ByteSource, Capabilities, ContextDesc, DeviceInfo, DeviceInfoError,
+    EventState, MemoryDomain, QueueDesc, ReleaseFailure, SubmitFailure, Timeout,
 };
 use virtio_accel_device::{
     ChainRegion, CommandOutcome, CommandProcessError, CommandProcessor, CommandProcessorInitError,
@@ -552,6 +552,43 @@ fn invalid_config_is_rejected_before_backend_discovery() {
         ))
     ));
     assert_eq!(device_info_calls.get(), 0);
+}
+
+#[test]
+fn invalid_provider_metadata_is_rejected_before_object_state_exists() {
+    for (capabilities, expected) in [
+        (
+            Capabilities::HOST_VISIBLE_MEMORY | Capabilities::EXTERNAL_MEMORY,
+            DeviceInfoError::ReservedCapabilities,
+        ),
+        (
+            Capabilities::EVENT_CANCELLATION,
+            DeviceInfoError::MissingMemoryDomain,
+        ),
+    ] {
+        let backend = RecordingBackend::default();
+        let mut info = backend.device_info().unwrap();
+        backend.device_info_calls.set(0);
+        info.capabilities = capabilities;
+        backend.info_override.set(Some(info));
+        let device_info_calls = Rc::clone(&backend.device_info_calls);
+
+        assert!(matches!(
+            CommandProcessor::new(backend, &config(), ObjectNamespace::new(1).unwrap()),
+            Err(CommandProcessorInitError::DeviceInfo(error)) if error == expected
+        ));
+        assert_eq!(device_info_calls.get(), 1);
+    }
+
+    let backend = RecordingBackend::default();
+    let mut info = backend.device_info().unwrap();
+    backend.device_info_calls.set(0);
+    info.limits.max_events_per_context = 0;
+    backend.info_override.set(Some(info));
+    assert_eq!(
+        CommandProcessor::new(backend, &config(), ObjectNamespace::new(1).unwrap()).unwrap_err(),
+        CommandProcessorInitError::DeviceInfo(DeviceInfoError::ZeroLimit)
+    );
 }
 
 #[test]

--- a/crates/virtio-accel-guest/src/client.rs
+++ b/crates/virtio-accel-guest/src/client.rs
@@ -1245,7 +1245,7 @@ mod tests {
     };
 
     use super::*;
-    use crate::types::{MemoryDomain, SubmissionOutcome};
+    use crate::types::{DeviceInfoError, MemoryDomain, SubmissionOutcome};
 
     type TestClient = GuestClient<SplitQueue>;
 
@@ -1478,6 +1478,24 @@ mod tests {
             }
             _ => panic!("unknown status was not preserved"),
         }
+        assert!(client.device_info().is_none());
+    }
+
+    #[test]
+    fn discovery_rejects_a_device_without_a_baseline_memory_domain() {
+        let mut client = test_client(16, 8, 4);
+        let pending = client.get_device_info(chain(16, 92)).unwrap();
+        let mut info = device_info();
+        info.capabilities = Le64::new(1 << 2);
+        complete_next(&mut client, StatusCode::OK, info.as_bytes());
+
+        assert!(matches!(
+            client.poll(pending),
+            RequestPoll::Ready(Completion::InvalidResponse {
+                error: ResponseError::DeviceInfo(DeviceInfoError::MissingMemoryDomain),
+                ..
+            })
+        ));
         assert!(client.device_info().is_none());
     }
 

--- a/crates/virtio-accel-guest/src/types.rs
+++ b/crates/virtio-accel-guest/src/types.rs
@@ -12,6 +12,8 @@ const CAPABILITY_RESERVED_SECURE_CONTEXTS: u64 = 1 << 4;
 const CAPABILITY_SHARED_MEMORY: u64 = 1 << 5;
 const RESERVED_CAPABILITIES: u64 =
     CAPABILITY_RESERVED_EXTERNAL_MEMORY | CAPABILITY_RESERVED_SECURE_CONTEXTS;
+const MEMORY_DOMAIN_CAPABILITIES: u64 =
+    CAPABILITY_HOST_VISIBLE_MEMORY | CAPABILITY_DEVICE_LOCAL_MEMORY | CAPABILITY_SHARED_MEMORY;
 
 bitflags! {
     /// Protocol 1.0 buffer usage bits.
@@ -324,6 +326,9 @@ impl DeviceInfo {
         if capabilities & RESERVED_CAPABILITIES != 0 {
             return Err(DeviceInfoError::ReservedCapabilities);
         }
+        if capabilities & MEMORY_DOMAIN_CAPABILITIES == 0 {
+            return Err(DeviceInfoError::MissingMemoryDomain);
+        }
         let limits = [
             wire.max_contexts.get(),
             wire.max_buffers_per_context.get(),
@@ -387,6 +392,8 @@ pub enum DeviceInfoError {
     Reserved,
     /// A reserved semantic capability was advertised.
     ReservedCapabilities,
+    /// No protocol 1.0 provider-owned memory domain is usable.
+    MissingMemoryDomain,
     /// A mandatory advertised limit is zero.
     ZeroLimit,
     /// Binding limit is outside protocol bounds.

--- a/crates/virtio-accel-mock/src/lib.rs
+++ b/crates/virtio-accel-mock/src/lib.rs
@@ -145,7 +145,8 @@ impl Accelerator for MockAccelerator {
         Ok(self.info)
     }
 
-    fn create_context(&self, _desc: ContextDesc) -> Result<Self::Context, BackendError> {
+    fn create_context(&self, desc: ContextDesc) -> Result<Self::Context, BackendError> {
+        self.info.validate_context_desc(desc)?;
         Ok(MockContext {
             id: self.next_id()?,
         })
@@ -276,8 +277,9 @@ impl Accelerator for MockAccelerator {
     fn create_queue(
         &self,
         context: &Self::Context,
-        _desc: QueueDesc,
+        desc: QueueDesc,
     ) -> Result<Self::Queue, BackendError> {
+        self.info.validate_queue_desc(desc)?;
         Ok(MockQueue {
             context_id: context.id,
         })
@@ -355,7 +357,9 @@ impl Accelerator for MockAccelerator {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use virtio_accel_core::{AccessMode, BindingRef, BufferRange, BufferUsage};
+    use virtio_accel_core::{
+        AccessMode, BindingRef, BufferRange, BufferUsage, ContextFlags, QueueFlags,
+    };
 
     #[derive(Debug)]
     struct SplitSource<'a> {
@@ -508,6 +512,29 @@ mod tests {
         );
 
         backend.free_buffer(buffer).unwrap();
+        backend.destroy_context(context).unwrap();
+    }
+
+    #[test]
+    fn reserved_creation_flags_are_rejected_without_resources() {
+        let backend = MockAccelerator::default();
+        assert!(matches!(
+            backend.create_context(ContextDesc {
+                flags: ContextFlags::SECURE,
+            }),
+            Err(BackendError::Unsupported)
+        ));
+
+        let context = backend.create_context(ContextDesc::default()).unwrap();
+        assert!(matches!(
+            backend.create_queue(
+                &context,
+                QueueDesc {
+                    flags: QueueFlags::IN_ORDER,
+                },
+            ),
+            Err(BackendError::Unsupported)
+        ));
         backend.destroy_context(context).unwrap();
     }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -169,6 +169,24 @@ regions. Object lookup is constant time and bounded by advertised limits. The qu
 allocation or copy to the steady-state path; mapping implementations can present borrowed segmented
 byte ports directly to the command processor.
 
+`Accelerator` deliberately places no `Send` or `Sync` bound on the backend or its associated handle
+types. The reference command engine specializes over one concrete backend and owns it behind one
+mutable admission boundary. A provider can therefore preserve thread-affine native handles without
+boxing, atomics, or locks. Providers that opt into cross-thread auto traits own the synchronization
+needed by their actual shared state; the portable object graph does not speculate by adding it to
+every handle.
+
+The source-level trait may be erased only after an adapter fixes all associated handle types. Stable
+binary plugin loading, cross-module allocation ownership, and an erased handle ABI are deliberately
+outside v1. A future plugin adapter can add those policies without changing static providers or
+weakening the submit and release contracts.
+
+Backend metadata is fetched and validated once before object tables are constructed. Assigned
+reserved capabilities, a missing usable memory domain, and zero advertised limits fail construction.
+Unknown capability bits remain available for diagnostics but do not select operations. The command
+engine then uses the cached capabilities and limits to reject unsupported work before provider
+invocation.
+
 `WRITE_BUFFER` and `READ_BUFFER` are the baseline's explicit content-copy boundaries. Device-local
 memory may require bounded staging during those operations. Allocation, submission, polling, and
 release do not receive permission to copy a bound buffer merely because a native import or binding
@@ -230,7 +248,8 @@ transport-neutral region metadata re-exported by `virtio-accel-device`. Its base
 5. Produces a response without knowing about rust-vmm or a host operating system.
 
 Submission/event retention, deterministic reset, the bounded split-virtqueue model, and the no-std
-reference guest complete both portable queue endpoints. The next boundary is the full
-guest-to-command-engine lifecycle in issue #20. A thin rust-vmm adapter supplying
-`virtio-device`, `virtio-queue`, and `vm-memory` integration remains a later platform layer, as do
-Linux vhost-user and an in-kernel guest driver.
+reference guest now complete both portable queue endpoints and their full serialized lifecycle. The
+next backend boundary is issue #22's portable reference artifact and deterministic execution model,
+which will exercise real buffer output without standardizing production artifact contents. A thin
+rust-vmm adapter supplying `virtio-device`, `virtio-queue`, and `vm-memory` integration remains a
+later platform layer, as do Linux vhost-user and an in-kernel guest driver.

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -301,7 +301,7 @@ Protocol 1.0 assigns these semantic capability bits:
 |---:|---|---|
 | 0 | `HOST_VISIBLE_MEMORY` | `MemoryDomain::Host` allocation is supported |
 | 1 | `DEVICE_LOCAL_MEMORY` | `MemoryDomain::Device` allocation is supported |
-| 2 | `EVENT_CANCELLATION` | Pending events may support `CANCEL_EVENT` |
+| 2 | `EVENT_CANCELLATION` | `CANCEL_EVENT` is implemented for pending events |
 | 5 | `SHARED_MEMORY` | Provider-owned `MemoryDomain::Shared` allocation is supported |
 
 Semantic bits 3 (`EXTERNAL_MEMORY`) and 4 (`SECURE_CONTEXTS`) are reserved until their transport,
@@ -313,13 +313,24 @@ backend. Advertising a memory-domain capability commits the backend to the corre
 properties and direct-binding rules from section 4.4; capability reporting is not permission to
 substitute a staged implementation.
 
+A baseline backend **MUST** advertise at least one assigned memory-domain capability. Every
+resource-count, binding-count, and byte limit in `DeviceInfo` **MUST** be nonzero. Identity,
+capabilities, and limits **MUST** remain stable for the lifetime of one backend instance so the
+command engine can validate and cache them once before constructing object state.
+
+If `EVENT_CANCELLATION` is absent, the command engine **MUST** reject cancellation before backend
+invocation. If it is present, the backend **MUST** implement cancellation and **MUST NOT** return
+`UNSUPPORTED` for a valid pending event.
+
 If enabling a backend capability would require different descriptor direction, additional queues,
 new synchronization, or changed lifetime rules, the device **MUST** also negotiate an appropriate
 transport feature.
 
-The exact secure-context and execution-queue-flag semantics remain tracked by issue #21. Protocol
-1.0 accepts only the wire values explicitly listed in [wire-abi.md](wire-abi.md); the reference
-implementation **MUST NOT** translate an underspecified capability into additional wire behavior.
+`ContextFlags::SECURE` and `QueueFlags::IN_ORDER` reserve semantic API positions only. Protocol 1.0
+defines neither behavior and accepts only empty context and execution-queue flags. The command engine
+**MUST** reject nonempty values before backend invocation; a direct caller of the backend trait
+receives `UNSUPPORTED` without a retained resource. Enabling either reservation in a later version
+requires explicit ownership, ordering, synchronization, and negotiation rules.
 
 ### 5.4 Request and object flags
 
@@ -400,6 +411,12 @@ Destructive backend calls consume handles and have an explicit release boundary:
 `Drop` may provide defensive cleanup inside an implementation but **MUST NOT** be used as
 guest-visible protocol state.
 
+A creation method that returns an ordinary error **MUST NOT** retain a newly created resource. A
+failed explicit write may have modified part of its requested buffer range; that complete range is
+then unspecified, the buffer remains live, and a later successful full-range write reestablishes its
+contents. A failed explicit read may have partially initialized its destination but does not modify
+the buffer; the command engine **MUST NOT** publish that destination as a successful payload.
+
 ## 8. Time and progress
 
 Wire timeouts are relative nanosecond durations measured from backend admission. Zero means
@@ -408,6 +425,13 @@ monotonic epochs are unrelated.
 
 Polling an event **MUST** be nonblocking and bounded. The portable contract creates no background
 thread and selects no async executor.
+
+Discovery, context, allocation, transfer, program, execution-queue, and release methods may perform
+synchronous provider work. Submission performs validation and admission only and **MUST NOT** wait
+for execution to become terminal. Cancellation **MUST** also be nonblocking and bounded. No portable
+method requires a provider handle to contain a lock or atomic value; cross-thread calls are
+available only when the concrete backend and handle types opt into the corresponding Rust auto
+traits.
 
 A timeout before admission is rejected. A timeout or communication failure after admission that
 cannot prove rejection is indeterminate and **MUST** retain an event.
@@ -445,9 +469,7 @@ This document, [wire-abi.md](wire-abi.md), and [virtqueue.md](virtqueue.md) defi
 driver/device protocol candidate. The following implementation, provider, and verification details
 remain explicitly tracked rather than silently decided here:
 
-- issue #21 completes the backend capability, memory-domain, execution-queue, blocking,
-  concurrency, and release semantics before the wire contract freezes;
-- issue #25 turns the trust assumptions into enforceable resource and threat-model limits; and
+- issue #25 turns the trust assumptions into enforceable resource and threat-model limits;
 - issue #32 defines post-1.0 semver and wire-evolution policy; and
 - issue #33 performs the final protocol and API audit, including independent clean-room review,
   before freezing protocol 1.0.
@@ -468,6 +490,7 @@ model or is identified as an implementation helper.
 | `DeviceIdentity` | Device instance identity |
 | `DeviceLimits` | Context, buffer, program, execution-queue, event, binding, and byte limits enforced before backend invocation |
 | `DeviceInfo` | Device identity, semantic capabilities, and limits |
+| `DeviceInfoError` | Construction-time rejection of reserved capabilities, absent baseline memory domains, or zero limits |
 | `ContextFlags`, `ContextDesc` | Context creation intent; protocol 1.0 accepts only empty context flags |
 | `MemoryDomain` | Strict provider-owned buffer placement requirement |
 | `BufferUsage`, `BufferDesc`, `BufferRange` | Buffer allocation intent and checked byte range |

--- a/docs/virtqueue.md
+++ b/docs/virtqueue.md
@@ -258,8 +258,8 @@ implementations consume the case identifiers above so the same behavioral scenar
 by the in-memory split ring and future platform transports. The dependency-free
 `virtio-accel-transport` crate provides the executable region, ownership, reset-epoch, backpressure,
 and notification port contracts. `virtio-accel-split-queue` exercises the ring-level portions of
-`VQ-001`, `VQ-003` through `VQ-006`, `VQ-013`, `VQ-014`, and `VQ-016` through `VQ-018`. Guest
-compatibility behavior remains tracked by #19 and full-path semantic assertions by #20.
+`VQ-001`, `VQ-003` through `VQ-006`, `VQ-013`, `VQ-014`, and `VQ-016` through `VQ-018`. The reference
+guest and end-to-end scenarios exercise the complete `VQ-001` through `VQ-020` lifecycle.
 
 ## Appendix A: portable Rust queue-port mapping
 


### PR DESCRIPTION
Closes #21

## Summary

- define the complete ownership, lifetime, blocking, concurrency, retry, allocation, and copy contract for every `Accelerator` method
- validate immutable provider capabilities and limits once before object-state construction, including reserved capability and missing memory-domain rejection on both device and guest paths
- reserve secure-context and ordered-queue semantics explicitly, enforce capability-to-method consistency, and keep native associated handles statically dispatched without mandatory boxing or synchronization
- specify truthful post-mutation transfer behavior and refresh the normative conformance ledger for the completed #19/#20 lifecycle evidence

## Performance impact

The steady-state provider ABI is unchanged: submission still receives borrowed native handles and one borrowed binding slice. The new validation runs only during backend construction or lifecycle preflight and adds no locks, atomics, allocation, or content copies to submission, polling, or release.

## Verification

- `cargo fmt --all -- --check`
- `python3 ci/check-normative-requirements.py --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-targets --all-features`
- `cargo test --workspace --doc --all-features`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps`
- `cargo check --workspace --release --all-features`
- `cargo hack check --workspace --feature-powerset --no-dev-deps`
- `bash ci/check-portable-dependencies.sh`
- Rust 1.85 workspace check and tests
- no-default-feature checks for AArch64 bare metal, RISC-V bare metal, and Wasm; all-feature workspace check on Wasm