### PR TITLE
Add public API docs and runnable examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,12 @@ jobs:
       - name: Run documentation tests
         run: cargo test --workspace --doc --all-features
 
+      - name: Run backend conformance example
+        run: cargo run --example backend_conformance
+
+      - name: Run reference execution example
+        run: cargo run --example reference_execution
+
       - name: Check release profile
         run: cargo check --workspace --release --all-features
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,7 @@ name = "virtio-accel"
 version = "0.1.0"
 dependencies = [
  "serde_json",
+ "virtio-accel-conformance",
  "virtio-accel-core",
  "virtio-accel-device",
  "virtio-accel-guest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ serde_json = "1.0.149"
 zerocopy = { version = "0.8.54", default-features = false, features = ["derive"] }
 virtio-accel-core = { path = "crates/virtio-accel-core" }
 virtio-accel-cleanroom = { path = "conformance/rust-clean-room" }
+virtio-accel-conformance = { path = "crates/virtio-accel-conformance" }
 virtio-accel-device = { path = "crates/virtio-accel-device" }
 virtio-accel-guest = { path = "crates/virtio-accel-guest" }
 virtio-accel-mock = { path = "crates/virtio-accel-mock" }
@@ -50,4 +51,5 @@ virtio-accel-transport.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true
+virtio-accel-conformance.workspace = true
 virtio-accel-mock.workspace = true

--- a/README.md
+++ b/README.md
@@ -68,8 +68,9 @@ model, compatibility rules, and mandatory baseline. The exact byte layouts live 
 [docs/architecture.md](docs/architecture.md) for implementation invariants and
 [docs/threat-model.md](docs/threat-model.md) for trust boundaries and finite resource policy, and
 [docs/portability.md](docs/portability.md) for the enforced target matrix. The v1 performance and
-copy budgets are tracked in [docs/performance.md](docs/performance.md). Backend authors can run the
-standard semantic suite using the
+copy budgets are tracked in [docs/performance.md](docs/performance.md), and the public rustdoc
+policy is in [docs/public-api.md](docs/public-api.md). Backend authors can run the standard
+semantic suite using the
 [accelerator backend implementer guide](docs/backend-implementer-guide.md).
 
 The primary `zerocopy` ABI and the manual clean-room codec both decode and re-encode every canonical
@@ -82,6 +83,8 @@ without making the conformance codec a production dependency.
 cargo fmt --all -- --check
 cargo clippy --workspace --all-targets --all-features -- -D warnings
 cargo test --workspace --all-targets --all-features
+cargo run --example backend_conformance
+cargo run --example reference_execution
 ```
 
 The project remains pre-standardization work and claims no Virtio device ID. Protocol 1.0 numeric

--- a/docs/backend-implementer-guide.md
+++ b/docs/backend-implementer-guide.md
@@ -11,6 +11,9 @@ provider-owned inputs:
 2. One executable `TargetDescription` containing an artifact and one observable binding.
 3. A `ConformanceHooks` implementation that advances a pending event to successful completion.
 
+The same flow is available as a runnable crate-level example:
+`cargo run --example backend_conformance`.
+
 The completion hook is test control, not a new production requirement. A backend with an external
 scheduler can signal that scheduler; a deterministic backend can execute the retained invocation
 directly. The target operation must remain pending until the hook runs, transform the fixture's
@@ -174,6 +177,10 @@ Use `virtio_accel_mock::fault::FaultAccelerator` or an equivalent provider-local
 rejected and indeterminate outcomes at each native API boundary. The standard suite remains usable
 without a vendor fault API, while the command-engine and full-stack fault tests prove the portable
 recovery policy.
+
+For a complete successful lifecycle without the conformance harness, run
+`cargo run --example reference_execution`. It demonstrates the portable context, buffer, program,
+queue, submit, poll, transfer, and teardown sequence against the mock backend.
 
 ## Common traps
 

--- a/docs/portability.md
+++ b/docs/portability.md
@@ -11,7 +11,7 @@ Rust 2024 edition selected by the workspace. Every package inherits the same `ru
 | Job | Toolchain and targets | Contract enforced |
 |---|---|---|
 | `style-and-api` | Current stable on Ubuntu | Formatting, complete normative-requirement ledger, Clippy with warnings denied, and warning-free public docs |
-| `native-test` | Current stable on Ubuntu, macOS, and Windows | All workspace unit, integration, target, feature, and documentation tests plus release-profile checking |
+| `native-test` | Current stable on Ubuntu, macOS, and Windows | All workspace unit, integration, target, feature, and documentation tests, runnable examples, and release-profile checking |
 | `msrv` | Rust 1.85.0 on Ubuntu | Every workspace target and test continues to compile at the declared MSRV |
 | `portable-target` | Stable `aarch64-unknown-none`, `riscv64gc-unknown-none-elf`, and `wasm32-unknown-unknown` | `cleanroom`, `proto`, `transport`, and `core` remain `no_std`; guest, split-queue, device, and facade layers require at most `alloc`; Wasm also checks the std reference crates |
 | `feature-sets-and-dependencies` | Stable on Ubuntu | Every Cargo feature combination plus dependency and `std`/`alloc` leakage guards for the portable codecs, queue ports, and core |
@@ -74,6 +74,8 @@ RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps
 cargo test --workspace --all-targets --all-features
 cargo test -p virtio-accel-device --test state_model
 cargo test --workspace --doc --all-features
+cargo run --example backend_conformance
+cargo run --example reference_execution
 cargo +1.85.0 check --workspace --all-targets --all-features
 cargo hack check --workspace --feature-powerset --no-dev-deps
 bash ci/check-portable-dependencies.sh

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -1,0 +1,49 @@
+# Public API documentation
+
+The public Rust API is split into three documentation layers:
+
+1. Human-facing contracts in `virtio-accel-core`, `virtio-accel-guest`,
+   `virtio-accel-device`, `virtio-accel-transport`, and `virtio-accel-conformance`.
+2. Pointer-free wire mirrors in `virtio-accel-proto`.
+3. Independent conformance artifacts and the clean-room codec under `conformance/`.
+
+The first layer documents ownership, blocking behavior, allocation, copy boundaries, and recovery
+semantics in rustdoc. The normative protocol text remains in
+[`specification.md`](specification.md), [`wire-abi.md`](wire-abi.md), and
+[`virtqueue.md`](virtqueue.md); rustdoc links back to those documents rather than restating every
+wire rule in multiple places.
+
+## Raw wire and clean-room exceptions
+
+`virtio-accel-proto` deliberately exposes `repr(C)` structures whose public fields match the
+normative wire names exactly. Field-level rustdoc would mostly duplicate
+[`wire-abi.md`](wire-abi.md) and increase drift risk. The authoritative field semantics are the
+normative document, [`layout.json`](../conformance/v1.0/layout.json), and
+[`vectors.json`](../conformance/v1.0/vectors.json).
+
+`virtio-accel-cleanroom` is also intentionally raw. It is a dependency-free independent decoder for
+golden-vector validation, not the ergonomic production API. Its public names mirror protocol
+terms so another implementer can compare behavior without importing the primary wire crate.
+
+These are documented exceptions, not permission for platform adapters or future public crates to
+skip API docs. New ergonomic APIs should document ownership, lifetime, error, blocking, allocation,
+copy, and portability behavior at the item where consumers call it.
+
+## Runnable entry points
+
+Two examples are part of the default CI workflow:
+
+- `cargo run --example backend_conformance`
+- `cargo run --example reference_execution`
+
+`backend_conformance` shows how a backend author wires a provider to the reusable conformance
+suite. `reference_execution` runs a complete context/buffer/program/queue/submit/poll/read/release
+lifecycle against the portable mock backend.
+
+## Baseline, reserved, and post-v1 work
+
+Baseline v1 is the mandatory command, queue, object, reset, error, and conformance behavior in the
+normative documents. Reserved feature bits, opcodes, flags, and fields are not optional features;
+they are invalid until a later policy assigns semantics. Platform integrations such as KVM,
+vhost-user, VFIO, Windows, macOS, or vendor SDK adapters are post-v1 work and must not leak into
+portable default dependencies.

--- a/examples/backend_conformance.rs
+++ b/examples/backend_conformance.rs
@@ -1,0 +1,80 @@
+use virtio_accel::core::BackendError;
+use virtio_accel_conformance::{
+    BindingFixture, ConformanceHooks, ProgramFixture, ResourceCounts, SubmissionPathDiagnostics,
+    TargetDescription, run,
+};
+use virtio_accel_mock::fault::{FaultAccelerator, FaultEvent, FaultScript, ResourceState};
+use virtio_accel_mock::{MockAccelerator, MockEvent, reference};
+
+struct Hooks;
+
+impl ConformanceHooks<FaultAccelerator<MockAccelerator>> for Hooks {
+    fn complete_event(
+        &self,
+        backend: &FaultAccelerator<MockAccelerator>,
+        event: &FaultEvent<MockEvent>,
+    ) -> Result<(), BackendError> {
+        backend.inner().complete(event.inner())
+    }
+
+    fn resource_counts(
+        &self,
+        backend: &FaultAccelerator<MockAccelerator>,
+    ) -> Option<ResourceCounts> {
+        let snapshot = backend.control().snapshot();
+        let live = snapshot.resources_in(ResourceState::Live);
+        let unknown = snapshot.resources_in(ResourceState::Indeterminate);
+        Some(ResourceCounts {
+            contexts: u64::from(live.contexts + unknown.contexts),
+            buffers: u64::from(live.buffers + unknown.buffers),
+            programs: u64::from(live.programs + unknown.programs),
+            queues: u64::from(live.queues + unknown.queues),
+            events: u64::from(live.events + unknown.events),
+        })
+    }
+
+    fn submission_path_diagnostics(
+        &self,
+        backend: &FaultAccelerator<MockAccelerator>,
+    ) -> Option<SubmissionPathDiagnostics> {
+        Some(SubmissionPathDiagnostics {
+            direct_bindings: backend.inner().direct_binding_admissions(),
+            ..SubmissionPathDiagnostics::default()
+        })
+    }
+}
+
+fn target() -> TargetDescription {
+    let initial = vec![0x00, 0x11, 0x7f, 0x80, 0xa5, 0xff, 0x3c, 0xc3];
+    let expected = initial.iter().map(|byte| byte ^ 0x5a).collect::<Vec<_>>();
+    TargetDescription::new(
+        ProgramFixture::new(
+            reference::ARTIFACT_FORMAT,
+            reference::TARGET_IDENTITY,
+            reference::ReferenceArtifact::xor(7, 0x5a).as_bytes(),
+            reference::RESIDENT_BYTES,
+        )
+        .unwrap(),
+        BindingFixture::new(
+            7,
+            virtio_accel::core::AccessMode::ReadWrite,
+            virtio_accel::core::MemoryDomain::Shared,
+            16,
+            initial,
+            expected,
+        )
+        .unwrap(),
+    )
+}
+
+fn main() {
+    let report = run(
+        || FaultAccelerator::new(MockAccelerator::default(), FaultScript::default()),
+        &target(),
+        &Hooks,
+    );
+    report.assert_conformant();
+    for case in report.cases() {
+        println!("{}: {:?}", case.id, case.status);
+    }
+}

--- a/examples/reference_execution.rs
+++ b/examples/reference_execution.rs
@@ -1,0 +1,77 @@
+use virtio_accel::core::{
+    Accelerator, AccessMode, ArtifactRef, BackendError, BindingRef, BufferDesc, BufferRange,
+    BufferUsage, ContextDesc, EventState, MemoryDomain, QueueDesc, ReleaseFailure, Timeout,
+};
+use virtio_accel_mock::{MockAccelerator, reference};
+
+fn release_ok<T>(result: Result<(), ReleaseFailure<T>>) -> Result<(), BackendError> {
+    match result {
+        Ok(()) => Ok(()),
+        Err(ReleaseFailure::Rejected { error, .. } | ReleaseFailure::Indeterminate { error }) => {
+            Err(error)
+        }
+    }
+}
+
+fn main() -> Result<(), BackendError> {
+    let backend = MockAccelerator::default();
+    let context = backend.create_context(ContextDesc::default())?;
+
+    let desc = BufferDesc::new(
+        8,
+        8,
+        MemoryDomain::Shared,
+        BufferUsage::TRANSFER_SOURCE
+            | BufferUsage::TRANSFER_DESTINATION
+            | BufferUsage::PROGRAM_INPUT
+            | BufferUsage::PROGRAM_OUTPUT
+            | BufferUsage::MUTABLE_STATE,
+    )?;
+    let (mut buffer, _) = backend.allocate_buffer(&context, desc)?.into_parts();
+    backend.write_buffer(
+        &mut buffer,
+        0,
+        &[0x00, 0x11, 0x7f, 0x80, 0xa5, 0xff, 0x3c, 0xc3],
+    )?;
+
+    let artifact = reference::ReferenceArtifact::xor(7, 0x5a);
+    let program = backend.load_program(
+        &context,
+        ArtifactRef {
+            format: reference::ARTIFACT_FORMAT,
+            target: reference::TARGET_IDENTITY,
+            payload: artifact.as_bytes(),
+            resident_bytes: reference::RESIDENT_BYTES,
+        },
+    )?;
+    let queue = backend.create_queue(&context, QueueDesc::default())?;
+
+    let binding = [BindingRef {
+        slot: 7,
+        buffer: &buffer,
+        range: BufferRange::new(0, 8)?,
+        access: AccessMode::ReadWrite,
+    }];
+    let event = backend
+        .submit(&queue, &program, &binding, Timeout::Infinite)
+        .map_err(|failure| match failure {
+            virtio_accel::core::SubmitFailure::Rejected(error)
+            | virtio_accel::core::SubmitFailure::Indeterminate { error, .. } => error,
+        })?;
+
+    assert_eq!(backend.poll_event(&event)?, EventState::Pending);
+    backend.complete(&event)?;
+    assert_eq!(backend.poll_event(&event)?, EventState::Complete);
+
+    let mut output = [0_u8; 8];
+    backend.read_buffer(&buffer, 0, &mut output)?;
+    assert_eq!(output, [0x5a, 0x4b, 0x25, 0xda, 0xff, 0xa5, 0x66, 0x99]);
+    println!("completed output: {output:02x?}");
+
+    release_ok(backend.destroy_event(event))?;
+    release_ok(backend.destroy_queue(queue))?;
+    release_ok(backend.unload_program(program))?;
+    release_ok(backend.free_buffer(buffer))?;
+    release_ok(backend.destroy_context(context))?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add a public API documentation policy that separates ergonomic Rust APIs from raw wire and clean-room conformance surfaces
- add runnable backend conformance and reference execution examples
- run both examples in the native CI lane and link them from the README, portability docs, and backend implementer guide

Closes #31.

## Validation
- `cargo fmt --all -- --check`
- `python3 ci/check-normative-requirements.py --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps`
- `cargo test --workspace --all-targets --all-features`
- `cargo test --workspace --doc --all-features`
- `cargo run --example backend_conformance`
- `cargo run --example reference_execution`
- `cargo check --workspace --release --all-features`