### PR TITLE
Fuzz the reference guest client against hostile device completions

### DIFF
--- a/ci/seed-fuzz-corpus.py
+++ b/ci/seed-fuzz-corpus.py
@@ -15,12 +15,21 @@ PROTOCOL_CONTROLS = bytes([0x00, 0x40, 1, 2, 4, 8, 16, 32])
 DESCRIPTOR_MARKER = 0xA5
 DESCRIPTOR_RESPONSE_BYTES_MINUS_ONE = 127
 
+# Guest-client action opcodes; see the dispatch table in fuzz/src/guest.rs.
+GUEST_DEVICE_POP = 11
+GUEST_DEVICE_COMPLETE = 12
+GUEST_PUMP = 13
+GUEST_POLL = 14
+GUEST_RESET = 15
+GUEST_POOL_LIMIT = 512
+
 
 def main() -> None:
     corpus = json.loads(VECTORS.read_text())
     reset_target("protocol_decode")
     reset_target("descriptor_end_to_end")
     reset_target("stateful_commands")
+    reset_target("guest_client")
 
     write_seed("protocol_decode", "empty", b"")
     write_seed("protocol_decode", "short_header", PROTOCOL_CONTROLS + b"\x00\x01\x02")
@@ -39,6 +48,11 @@ def main() -> None:
 
     write_seed("stateful_commands", "lifecycle", stateful_lifecycle_seed())
     write_seed("stateful_commands", "stale_after_reset", stateful_stale_after_reset_seed())
+
+    responses = response_pool(corpus)
+    write_seed("guest_client", "conforming_lifecycle", guest_lifecycle_seed(responses))
+    write_seed("guest_client", "hostile_completion", guest_hostile_seed(responses))
+    write_seed("guest_client", "reset_with_inflight", guest_reset_seed(responses))
 
 
 def reset_target(target: str) -> None:
@@ -120,6 +134,63 @@ def stateful_lifecycle_seed() -> bytes:
             action(15),
         ]
     )
+
+
+def response_pool(corpus: dict) -> bytes:
+    """Concatenate reviewed response frames for the guest client's payload pool."""
+    frames = [
+        bytes.fromhex(frame["hex"]) for frame in corpus["frames"] if frame["kind"] != "request"
+    ]
+    return b"".join(frames)[:GUEST_POOL_LIMIT]
+
+
+def guest_action(opcode: int, selector: int = 0, argument: int = 0, entropy: int = 0) -> bytes:
+    return bytes([opcode & 0xFF, selector & 0xFF]) + argument.to_bytes(
+        2, "little"
+    ) + entropy.to_bytes(4, "little")
+
+
+def guest_seed(pool: bytes, actions: bytes) -> bytes:
+    return len(pool).to_bytes(2, "little") + pool + actions
+
+
+def guest_lifecycle_seed(pool: bytes) -> bytes:
+    """Discover, then build a context, buffer, program, queue, and event conformingly."""
+    actions = b""
+    for start in (0, 1, 2, 3, 4, 5, 6):
+        for step in (start, GUEST_DEVICE_POP, GUEST_DEVICE_COMPLETE, GUEST_POLL):
+            actions += guest_action(step)
+    return guest_seed(pool, actions)
+
+
+def guest_hostile_seed(pool: bytes) -> bytes:
+    """Answer a discovery request with reviewed response bytes under a corrupted header."""
+    actions = b"".join(
+        [
+            guest_action(0),
+            guest_action(GUEST_DEVICE_POP),
+            guest_action(GUEST_DEVICE_COMPLETE, selector=0x90, argument=0x0060),
+            guest_action(GUEST_POLL),
+            guest_action(GUEST_RESET),
+        ]
+    )
+    return guest_seed(pool, actions)
+
+
+def guest_reset_seed(pool: bytes) -> bytes:
+    """Reset while requests are published, popped, and completed but not yet polled."""
+    actions = b"".join(
+        [
+            guest_action(0),
+            guest_action(0),
+            guest_action(GUEST_DEVICE_POP),
+            guest_action(GUEST_DEVICE_COMPLETE),
+            guest_action(GUEST_PUMP),
+            guest_action(GUEST_RESET),
+            guest_action(GUEST_POLL),
+        ]
+    )
+    return guest_seed(pool, actions)
 
 
 def stateful_stale_after_reset_seed() -> bytes:

--- a/docs/portability.md
+++ b/docs/portability.md
@@ -97,6 +97,7 @@ python3 ci/seed-fuzz-corpus.py
 cargo fuzz run protocol_decode fuzz/corpus/protocol_decode fuzz/regressions/protocol_decode -- -runs=256 -max_total_time=20 -timeout=5 -rss_limit_mb=2048 -max_len=65536
 cargo fuzz run descriptor_end_to_end fuzz/corpus/descriptor_end_to_end fuzz/regressions/descriptor_end_to_end -- -runs=256 -max_total_time=20 -timeout=5 -rss_limit_mb=2048 -max_len=65536
 cargo fuzz run stateful_commands fuzz/corpus/stateful_commands fuzz/regressions/stateful_commands -- -runs=256 -max_total_time=20 -timeout=5 -rss_limit_mb=2048 -max_len=65536
+cargo fuzz run guest_client fuzz/corpus/guest_client fuzz/regressions/guest_client -- -runs=256 -max_total_time=20 -timeout=5 -rss_limit_mb=2048 -max_len=65536
 ```
 
 Target checks require the corresponding Rust standard libraries:

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -76,7 +76,12 @@ All named tests are located in the corresponding crate's `src` unit tests,
 or [`tests/portable_end_to_end.rs`](../tests/portable_end_to_end.rs). Coverage-guided malformed
 input checks live under [`fuzz/`](../fuzz/): protocol decode is compared with the clean-room codec,
 descriptor segmentation is driven through the split-queue model, and bounded stateful sequences
-check resource accounting after every action. The deterministic state-model suite runs a bounded
+check resource accounting after every action. A fourth target drives the reference guest client
+against a non-conforming device. That direction is reference-implementation robustness rather than
+a portable-layer security boundary, because a malicious backend or host process is excluded below;
+it exists so the driver-side obligations in this protocol — opaque unknown statuses, recovery on
+unknown event states, bounded in-flight tracking, and epoch-scoped handle staleness — hold against
+inputs no example test enumerates. The deterministic state-model suite runs a bounded
 seed set in normal CI, asserts stale-ID retirement, context isolation, reference release, quota, and
 retained-byte invariants after every action, and prints minimized replayable schedules for failures.
 An ignored deep test provides manual or nightly-style exploration with `VIRTIO_ACCEL_STATE_MODEL_SEED`.

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -152,9 +152,20 @@ dependencies = [
  "virtio-accel-cleanroom",
  "virtio-accel-core",
  "virtio-accel-device",
+ "virtio-accel-guest",
  "virtio-accel-mock",
  "virtio-accel-proto",
  "virtio-accel-split-queue",
+ "virtio-accel-transport",
+ "zerocopy",
+]
+
+[[package]]
+name = "virtio-accel-guest"
+version = "0.1.0"
+dependencies = [
+ "bitflags",
+ "virtio-accel-proto",
  "virtio-accel-transport",
  "zerocopy",
 ]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -20,6 +20,7 @@ libfuzzer-sys = { version = "0.4", optional = true }
 virtio-accel-cleanroom = { path = "../conformance/rust-clean-room" }
 virtio-accel-core = { path = "../crates/virtio-accel-core" }
 virtio-accel-device = { path = "../crates/virtio-accel-device" }
+virtio-accel-guest = { path = "../crates/virtio-accel-guest" }
 virtio-accel-mock = { path = "../crates/virtio-accel-mock" }
 virtio-accel-proto = { path = "../crates/virtio-accel-proto" }
 virtio-accel-split-queue = { path = "../crates/virtio-accel-split-queue" }
@@ -45,6 +46,14 @@ required-features = ["fuzzing"]
 [[bin]]
 name = "stateful_commands"
 path = "fuzz_targets/stateful_commands.rs"
+test = false
+doc = false
+bench = false
+required-features = ["fuzzing"]
+
+[[bin]]
+name = "guest_client"
+path = "fuzz_targets/guest_client.rs"
 test = false
 doc = false
 bench = false

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -11,9 +11,18 @@ code is regular Rust and can be tested without libFuzzer; the `fuzzing` feature 
 | `protocol_decode` | Feeds arbitrary bounded byte frames through contiguous and segmented decode paths and checks accepted frames against the clean-room codec. |
 | `descriptor_end_to_end` | Builds raw or canonical split-virtqueue descriptor chains, runs valid chains through the command processor, and verifies used-length, truncation, and response-tail behavior. |
 | `stateful_commands` | Generates bounded create/use/destroy/reset command sequences and checks resource counts, retained bytes, stale IDs, and backend health after every action. |
+| `guest_client` | Drives the reference guest client against an arbitrary, non-conforming device and checks in-flight bounds, epoch staleness, and caller-chain ownership after every action. |
 
 All targets cap input length before allocation. A resource-limit rejection, malformed descriptor,
 or protocol error is not a crash unless it violates a processor, queue, or codec invariant.
+
+## Guest client input layout
+
+`guest_client` reads a little-endian `u16` response-byte pool length, that many pool bytes, and then
+a stream of eight-byte actions. Seeds fill the pool with reviewed response frames from
+`conformance/v1.0/vectors.json` so a mutated header or used length is applied to otherwise
+canonical bytes. The device side is driven by the harness itself rather than the split-queue model,
+so it can publish responses no conforming transport would produce.
 
 ## Local Commands
 
@@ -24,6 +33,7 @@ cargo fuzz list
 cargo fuzz run protocol_decode fuzz/corpus/protocol_decode -- -runs=256 -max_total_time=20 -timeout=5 -rss_limit_mb=2048 -max_len=65536
 cargo fuzz run descriptor_end_to_end fuzz/corpus/descriptor_end_to_end -- -runs=256 -max_total_time=20 -timeout=5 -rss_limit_mb=2048 -max_len=65536
 cargo fuzz run stateful_commands fuzz/corpus/stateful_commands -- -runs=256 -max_total_time=20 -timeout=5 -rss_limit_mb=2048 -max_len=65536
+cargo fuzz run guest_client fuzz/corpus/guest_client -- -runs=256 -max_total_time=20 -timeout=5 -rss_limit_mb=2048 -max_len=65536
 ```
 
 Minimize a failing input with `cargo fuzz tmin <target> <artifact>`, then commit the minimized file

--- a/fuzz/fuzz_targets/guest_client.rs
+++ b/fuzz/fuzz_targets/guest_client.rs
@@ -1,0 +1,5 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| virtio_accel_fuzz::fuzz_guest_client(data));

--- a/fuzz/src/guest.rs
+++ b/fuzz/src/guest.rs
@@ -1,0 +1,1194 @@
+use core::cell::RefCell;
+use core::mem::size_of;
+use core::num::{NonZeroU32, NonZeroU64};
+use std::collections::{BTreeSet, VecDeque};
+use std::rc::Rc;
+
+use virtio_accel_guest::{
+    AccessMode, AllocateBuffer, Binding, Buffer, BufferDesc, BufferRange, BufferUsage, CancelEvent,
+    ClientHealth, Completion, Context, CreateContext, CreateExecutionQueue, DestroyContext,
+    DestroyEvent, DestroyExecutionQueue, Event, ExecutionQueue, FreeBuffer, GetDeviceInfo,
+    GuestClient, GuestConfig, LoadProgram, MemoryDomain, Operation, Pending, PollEvent, Program,
+    ProgramDesc, PumpResult, ReadBuffer, RequestPoll, StartResult, SubmissionOutcome, Submit,
+    UnloadProgram, WriteBuffer,
+};
+use virtio_accel_proto::{
+    AllocateBufferRequest, BASELINE_COMMAND_QUEUES, CreateContextRequest, CreateQueueRequest,
+    KnownEventState, KnownOpcode, Le16, Le32, Le64, LoadProgramRequest, ObjectPayload,
+    PROTOCOL_MAJOR, PROTOCOL_MINOR, RequestHeader, ResponseHeader, StatusCode, SubmitRequest,
+    SubmitResponse, TransferBufferRequest, WireBinding, WireConfig, WireDeviceInfo, WireEventState,
+    read_exact,
+};
+use virtio_accel_transport::{
+    ByteAccessError, ChainId, DriverChainBuffer, DriverQueue, NotificationHint,
+    NotificationRecheck, PublishError, PublishErrorKind, PublishedChain, QueueControl, QueueEpoch,
+    QueueError, QueuePort, QueueSize, QueueState, ReclaimedChain, UsedChain, UsedLength,
+};
+use zerocopy::IntoBytes;
+
+use crate::Input;
+
+const MAX_SEQUENCE_BYTES: usize = 1_024;
+const ACTION_BYTES: usize = 8;
+const ACTION_COUNT: u8 = 17;
+
+const QUEUE_SIZE: u16 = 16;
+const MAX_INFLIGHT: u16 = 8;
+const MAX_CHAIN_DESCRIPTORS: u16 = 4;
+const MAX_REQUEST_BYTES: u32 = 512;
+const MAX_RESPONSE_BYTES: u32 = 512;
+const RING_CAPACITY: usize = 6;
+
+const MAX_BUFFER_BYTES: u64 = 256;
+const MAX_ARTIFACT_BYTES: u64 = 256;
+const BUFFER_BYTES: u64 = 64;
+const ARTIFACT_BYTES: usize = 8;
+const READ_BYTES: u64 = 8;
+const WRITE_BYTES: usize = 8;
+
+const REQUEST_HEADER_BYTES: usize = size_of::<RequestHeader>();
+const RESPONSE_HEADER_BYTES: usize = size_of::<ResponseHeader>();
+
+/// Status values a non-conforming device may publish, including an unassigned one.
+const STATUS_CHOICES: [StatusCode; 8] = [
+    StatusCode::OK,
+    StatusCode::INVALID_ARGUMENT,
+    StatusCode::BUSY,
+    StatusCode::RESOURCE_LIMIT,
+    StatusCode::DEVICE_LOST,
+    StatusCode::STALE_OBJECT,
+    StatusCode::INTERNAL_ERROR,
+    StatusCode(0x4242),
+];
+
+/// Caller-owned request/response storage with no transport validation of its own.
+///
+/// The harness owns both sides so a hostile device can publish arbitrary response bytes without
+/// a split-ring model silently normalizing them first.
+#[derive(Debug)]
+pub(crate) struct FuzzChain {
+    tag: u64,
+    readable: Vec<u8>,
+    writable: Vec<u8>,
+}
+
+impl FuzzChain {
+    fn new(tag: u64, readable_bytes: usize, writable_bytes: usize) -> Self {
+        Self {
+            tag,
+            readable: vec![0; readable_bytes],
+            writable: vec![0; writable_bytes],
+        }
+    }
+}
+
+impl DriverChainBuffer for FuzzChain {
+    type Error = ByteAccessError;
+
+    fn device_readable_len(&self) -> u64 {
+        self.readable.len() as u64
+    }
+
+    fn device_writable_len(&self) -> u64 {
+        self.writable.len() as u64
+    }
+
+    fn write_device_readable(&mut self, offset: u64, source: &[u8]) -> Result<(), Self::Error> {
+        let range = span(self.readable.len(), offset, source.len())?;
+        self.readable[range].copy_from_slice(source);
+        Ok(())
+    }
+
+    fn read_device_writable(&self, offset: u64, target: &mut [u8]) -> Result<(), Self::Error> {
+        let range = span(self.writable.len(), offset, target.len())?;
+        target.copy_from_slice(&self.writable[range]);
+        Ok(())
+    }
+}
+
+fn span(len: usize, offset: u64, bytes: usize) -> Result<core::ops::Range<usize>, ByteAccessError> {
+    let start = usize::try_from(offset).map_err(|_| ByteAccessError::OutOfBounds)?;
+    let end = start
+        .checked_add(bytes)
+        .ok_or(ByteAccessError::OutOfBounds)?;
+    if end > len {
+        return Err(ByteAccessError::OutOfBounds);
+    }
+    Ok(start..end)
+}
+
+/// Queue storage shared between the client-owned driver port and the harness device port.
+struct Ring {
+    state: QueueState,
+    published: VecDeque<(ChainId, FuzzChain)>,
+    used: VecDeque<UsedChain<FuzzChain>>,
+    next_token: u64,
+    notifications: bool,
+    inject_pop_error: bool,
+}
+
+impl Ring {
+    fn new() -> Self {
+        let max_size = QueueSize::new(QUEUE_SIZE).expect("queue size is a valid power of two");
+        Self {
+            state: QueueState::unconfigured(max_size, QueueEpoch::INITIAL),
+            published: VecDeque::new(),
+            used: VecDeque::new(),
+            next_token: 1,
+            notifications: true,
+            inject_pop_error: false,
+        }
+    }
+}
+
+/// Driver-side queue port backed by harness-controlled storage.
+struct FuzzQueue {
+    ring: Rc<RefCell<Ring>>,
+}
+
+impl QueuePort for FuzzQueue {
+    fn state(&self) -> QueueState {
+        self.ring.borrow().state
+    }
+}
+
+impl DriverQueue for FuzzQueue {
+    type Chain = FuzzChain;
+    type Reclaimed = Vec<ReclaimedChain<FuzzChain>>;
+    type Error = ByteAccessError;
+
+    fn publish(
+        &mut self,
+        chain: Self::Chain,
+    ) -> Result<PublishedChain, PublishError<Self::Chain, Self::Error>> {
+        let mut ring = self.ring.borrow_mut();
+        if !ring.state.ready() {
+            return Err(PublishError::new(chain, PublishErrorKind::NotReady));
+        }
+        if ring.published.len() >= RING_CAPACITY {
+            return Err(PublishError::new(chain, PublishErrorKind::QueueFull));
+        }
+        let id = ChainId::new(ring.state.epoch(), ring.next_token);
+        ring.next_token = ring.next_token.wrapping_add(1);
+        let notification = if ring.notifications {
+            NotificationHint::Notify
+        } else {
+            NotificationHint::Suppressed
+        };
+        ring.published.push_back((id, chain));
+        Ok(PublishedChain::new(id, notification))
+    }
+
+    fn pop_used(&mut self) -> Result<Option<UsedChain<Self::Chain>>, QueueError<Self::Error>> {
+        let mut ring = self.ring.borrow_mut();
+        if ring.inject_pop_error {
+            ring.inject_pop_error = false;
+            return Err(QueueError::Transport(ByteAccessError::OutOfBounds));
+        }
+        Ok(ring.used.pop_front())
+    }
+
+    fn disable_used_notifications(&mut self) -> Result<(), QueueError<Self::Error>> {
+        self.ring.borrow_mut().notifications = false;
+        Ok(())
+    }
+
+    fn enable_used_notifications(
+        &mut self,
+    ) -> Result<NotificationRecheck, QueueError<Self::Error>> {
+        let mut ring = self.ring.borrow_mut();
+        ring.notifications = true;
+        Ok(if ring.used.is_empty() {
+            NotificationRecheck::Idle
+        } else {
+            NotificationRecheck::WorkPending
+        })
+    }
+
+    fn reset(
+        &mut self,
+        next_epoch: QueueEpoch,
+    ) -> Result<Self::Reclaimed, QueueError<Self::Error>> {
+        let mut ring = self.ring.borrow_mut();
+        let current = ring.state.epoch();
+        if next_epoch.get() <= current.get() {
+            return Err(QueueError::ResetRace {
+                operation: next_epoch,
+                current,
+            });
+        }
+        let mut reclaimed = Vec::new();
+        for (id, chain) in ring.published.drain(..) {
+            reclaimed.push(ReclaimedChain::new(id, chain));
+        }
+        for used in ring.used.drain(..) {
+            let (id, _, chain) = used.into_parts();
+            reclaimed.push(ReclaimedChain::new(id, chain));
+        }
+        ring.state = QueueState::unconfigured(ring.state.max_size(), next_epoch);
+        ring.notifications = true;
+        Ok(reclaimed)
+    }
+}
+
+impl QueueControl for FuzzQueue {
+    type Error = ByteAccessError;
+
+    fn configure(&mut self, size: QueueSize) -> Result<(), QueueError<Self::Error>> {
+        let mut ring = self.ring.borrow_mut();
+        let state = QueueState::new(ring.state.max_size(), Some(size), false, ring.state.epoch())
+            .map_err(QueueError::InvalidConfiguration)?;
+        ring.state = state;
+        Ok(())
+    }
+
+    fn set_ready(&mut self, ready: bool) -> Result<(), QueueError<Self::Error>> {
+        let mut ring = self.ring.borrow_mut();
+        let state = QueueState::new(
+            ring.state.max_size(),
+            ring.state.size(),
+            ready,
+            ring.state.epoch(),
+        )
+        .map_err(QueueError::InvalidConfiguration)?;
+        ring.state = state;
+        Ok(())
+    }
+}
+
+type Client = GuestClient<FuzzQueue>;
+
+/// One in-flight typed request, retained so every response decoder stays reachable.
+enum AnyPending {
+    GetDeviceInfo(Pending<GetDeviceInfo>),
+    CreateContext(Pending<CreateContext>),
+    DestroyContext(Pending<DestroyContext>),
+    AllocateBuffer(Pending<AllocateBuffer>),
+    FreeBuffer(Pending<FreeBuffer>),
+    WriteBuffer(Pending<WriteBuffer>),
+    ReadBuffer(Pending<ReadBuffer>),
+    LoadProgram(Pending<LoadProgram>),
+    UnloadProgram(Pending<UnloadProgram>),
+    CreateExecutionQueue(Pending<CreateExecutionQueue>),
+    DestroyExecutionQueue(Pending<DestroyExecutionQueue>),
+    Submit(Pending<Submit>),
+    PollEvent(Pending<PollEvent>),
+    CancelEvent(Pending<CancelEvent>),
+    DestroyEvent(Pending<DestroyEvent>),
+}
+
+/// Coverage counters that keep the harness unit tests from passing vacuously.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct Progress {
+    handles: u32,
+    invalid_responses: u32,
+    device_errors: u32,
+    resets: u32,
+}
+
+/// Split a leading length-prefixed response-byte pool from the trailing action stream.
+///
+/// Seeds can therefore carry real canonical response frames while the fuzzer still mutates the
+/// command sequence independently.
+fn split_pool(data: &[u8]) -> (&[u8], &[u8]) {
+    let Some((header, rest)) = data.split_at_checked(2) else {
+        return (&[], data);
+    };
+    let requested = usize::from(u16::from_le_bytes([header[0], header[1]]));
+    rest.split_at(requested.min(rest.len()))
+}
+
+struct Harness {
+    client: Client,
+    progress: Progress,
+    pool: Vec<u8>,
+    ring: Rc<RefCell<Ring>>,
+    pendings: Vec<AnyPending>,
+    popped: Vec<(ChainId, FuzzChain)>,
+    outstanding: BTreeSet<u64>,
+    next_tag: u64,
+    next_object_id: u64,
+    contexts: Vec<Context>,
+    buffers: Vec<Buffer>,
+    programs: Vec<Program>,
+    queues: Vec<ExecutionQueue>,
+    events: Vec<Event>,
+}
+
+pub fn fuzz_guest_client(data: &[u8]) {
+    run(data);
+}
+
+fn run(data: &[u8]) -> Progress {
+    let data = &data[..data.len().min(MAX_SEQUENCE_BYTES)];
+    let (pool, data) = split_pool(data);
+    let mut harness = Harness::new();
+    harness.pool = pool.to_vec();
+
+    for action_bytes in data.chunks(ACTION_BYTES) {
+        let mut input = Input::new(action_bytes);
+        let action = input.byte() % ACTION_COUNT;
+        let selector = input.byte();
+        let argument = input.u16();
+        let entropy = input.u64();
+        harness.step(action, selector, argument, entropy);
+        harness.assert_invariants();
+    }
+
+    harness.drain()
+}
+
+impl Harness {
+    fn new() -> Self {
+        let ring = Rc::new(RefCell::new(Ring::new()));
+        let mut queue = FuzzQueue {
+            ring: Rc::clone(&ring),
+        };
+        let size = QueueSize::new(QUEUE_SIZE).expect("queue size is a valid power of two");
+        QueueControl::configure(&mut queue, size).expect("initial configuration succeeds");
+        QueueControl::set_ready(&mut queue, true).expect("initial readiness succeeds");
+        let client = GuestClient::new(queue, config()).expect("client construction succeeds");
+        Self {
+            client,
+            progress: Progress::default(),
+            pool: Vec::new(),
+            ring,
+            pendings: Vec::new(),
+            popped: Vec::new(),
+            outstanding: BTreeSet::new(),
+            next_tag: 1,
+            next_object_id: 1,
+            contexts: Vec::new(),
+            buffers: Vec::new(),
+            programs: Vec::new(),
+            queues: Vec::new(),
+            events: Vec::new(),
+        }
+    }
+
+    fn step(&mut self, action: u8, selector: u8, argument: u16, entropy: u64) {
+        match action {
+            0 => self.start_get_device_info(),
+            1 => self.start_create_context(),
+            2 => self.start_allocate_buffer(selector, argument),
+            3 => self.start_load_program(selector),
+            4 => self.start_create_execution_queue(selector),
+            5 => self.start_submit(selector, argument),
+            6 => self.start_event_command(selector, true),
+            7 => self.start_event_command(selector, false),
+            8 => self.start_read_buffer(selector),
+            9 => self.start_write_buffer(selector),
+            10 => self.start_release(selector),
+            11 => self.device_pop(),
+            12 => self.device_complete(selector, argument, entropy),
+            13 => self.pump(),
+            14 => self.poll_one(selector),
+            15 => self.reset(),
+            16 => self.notifications(selector),
+            _ => unreachable!("action is reduced modulo ACTION_COUNT"),
+        }
+    }
+
+    fn chain(&mut self, readable_bytes: usize, writable_bytes: usize) -> FuzzChain {
+        let tag = self.next_tag;
+        self.next_tag = self.next_tag.wrapping_add(1);
+        self.outstanding.insert(tag);
+        FuzzChain::new(tag, readable_bytes, writable_bytes)
+    }
+
+    fn recover(&mut self, chain: FuzzChain) {
+        assert!(
+            self.outstanding.remove(&chain.tag),
+            "chain {} was returned twice or was never issued",
+            chain.tag
+        );
+    }
+
+    fn record<O>(&mut self, result: StartResult<FuzzQueue, O>, wrap: fn(Pending<O>) -> AnyPending) {
+        match result {
+            Ok(pending) => {
+                // Only `start_frame` can admit work, and it rejects before publishing whenever
+                // health is degraded. Typed argument validation runs earlier and may reject an
+                // unhealthy client's request with its own diagnostic instead, so the meaningful
+                // invariant is that admission never happens, not which error is reported.
+                assert_eq!(
+                    self.client.health(),
+                    ClientHealth::Running,
+                    "an unhealthy client admitted new work"
+                );
+                self.pendings.push(wrap(pending));
+            }
+            Err(error) => {
+                let (chain, _operation, _kind) = error.into_parts();
+                self.recover(chain);
+            }
+        }
+    }
+
+    fn start_get_device_info(&mut self) {
+        let chain = self.chain(
+            REQUEST_HEADER_BYTES,
+            RESPONSE_HEADER_BYTES + size_of::<WireDeviceInfo>(),
+        );
+        let result = self.client.get_device_info(chain);
+        self.record(result, AnyPending::GetDeviceInfo);
+    }
+
+    fn start_create_context(&mut self) {
+        let chain = self.chain(
+            REQUEST_HEADER_BYTES + size_of::<CreateContextRequest>(),
+            object_response_bytes(),
+        );
+        let result = self.client.create_context(chain);
+        self.record(result, AnyPending::CreateContext);
+    }
+
+    fn start_allocate_buffer(&mut self, selector: u8, argument: u16) {
+        if self.contexts.is_empty() {
+            return;
+        }
+        let index = usize::from(selector) % self.contexts.len();
+        let bytes = u64::from(argument % BUFFER_BYTES as u16) + 1;
+        let Ok(desc) = BufferDesc::new(
+            bytes,
+            1 << (selector % 4),
+            domain(selector),
+            BufferUsage::all(),
+        ) else {
+            return;
+        };
+        let chain = self.chain(
+            REQUEST_HEADER_BYTES + size_of::<AllocateBufferRequest>(),
+            object_response_bytes(),
+        );
+        let context = &self.contexts[index];
+        let result = self.client.allocate_buffer(chain, context, desc);
+        self.record(result, AnyPending::AllocateBuffer);
+    }
+
+    fn start_load_program(&mut self, selector: u8) {
+        if self.contexts.is_empty() {
+            return;
+        }
+        let index = usize::from(selector) % self.contexts.len();
+        let desc = ProgramDesc::new(
+            NonZeroU32::new(1).expect("one is nonzero"),
+            [0; 12],
+            NonZeroU64::new(32).expect("thirty-two is nonzero"),
+        );
+        let chain = self.chain(
+            REQUEST_HEADER_BYTES + size_of::<LoadProgramRequest>() + ARTIFACT_BYTES,
+            object_response_bytes(),
+        );
+        let artifact = [selector; ARTIFACT_BYTES];
+        let context = &self.contexts[index];
+        let result = self
+            .client
+            .load_program(chain, context, desc, &artifact[..]);
+        self.record(result, AnyPending::LoadProgram);
+    }
+
+    fn start_create_execution_queue(&mut self, selector: u8) {
+        if self.contexts.is_empty() {
+            return;
+        }
+        let index = usize::from(selector) % self.contexts.len();
+        let chain = self.chain(
+            REQUEST_HEADER_BYTES + size_of::<CreateQueueRequest>(),
+            object_response_bytes(),
+        );
+        let context = &self.contexts[index];
+        let result = self.client.create_execution_queue(chain, context);
+        self.record(result, AnyPending::CreateExecutionQueue);
+    }
+
+    fn start_submit(&mut self, selector: u8, argument: u16) {
+        if self.queues.is_empty() || self.programs.is_empty() || self.buffers.is_empty() {
+            return;
+        }
+        let queue_index = usize::from(selector) % self.queues.len();
+        let program_index = usize::from(selector.rotate_left(2)) % self.programs.len();
+        let buffer_index = usize::from(selector.rotate_left(4)) % self.buffers.len();
+        let bytes = self.buffers[buffer_index].desc().bytes().min(BUFFER_BYTES);
+        let Ok(range) = BufferRange::new(0, bytes) else {
+            return;
+        };
+        let chain = self.chain(
+            REQUEST_HEADER_BYTES + size_of::<SubmitRequest>() + size_of::<WireBinding>(),
+            RESPONSE_HEADER_BYTES + size_of::<SubmitResponse>(),
+        );
+        let bindings = [Binding {
+            buffer: &self.buffers[buffer_index],
+            range,
+            slot: 0,
+            access: access(selector),
+        }];
+        let result = self.client.submit(
+            chain,
+            &self.queues[queue_index],
+            &self.programs[program_index],
+            &bindings,
+            u64::from(argument),
+        );
+        self.record(result, AnyPending::Submit);
+    }
+
+    fn start_event_command(&mut self, selector: u8, poll: bool) {
+        if self.events.is_empty() {
+            return;
+        }
+        let index = usize::from(selector) % self.events.len();
+        if poll {
+            let chain = self.chain(
+                object_request_bytes(),
+                RESPONSE_HEADER_BYTES + size_of::<WireEventState>(),
+            );
+            let event = &self.events[index];
+            let result = self.client.poll_event(chain, event);
+            self.record(result, AnyPending::PollEvent);
+        } else {
+            let chain = self.chain(object_request_bytes(), RESPONSE_HEADER_BYTES);
+            let event = &self.events[index];
+            let result = self.client.cancel_event(chain, event);
+            self.record(result, AnyPending::CancelEvent);
+        }
+    }
+
+    fn start_read_buffer(&mut self, selector: u8) {
+        if self.buffers.is_empty() {
+            return;
+        }
+        let index = usize::from(selector) % self.buffers.len();
+        let buffer = &self.buffers[index];
+        let bytes = READ_BYTES.min(buffer.desc().bytes());
+        let Ok(range) = BufferRange::new(0, bytes) else {
+            return;
+        };
+        let chain = self.chain(
+            REQUEST_HEADER_BYTES + size_of::<TransferBufferRequest>(),
+            RESPONSE_HEADER_BYTES + bytes as usize,
+        );
+        let buffer = &self.buffers[index];
+        let result = self.client.read_buffer(chain, buffer, range);
+        self.record(result, AnyPending::ReadBuffer);
+    }
+
+    fn start_write_buffer(&mut self, selector: u8) {
+        if self.buffers.is_empty() {
+            return;
+        }
+        let index = usize::from(selector) % self.buffers.len();
+        let payload = [selector; WRITE_BYTES];
+        let chain = self.chain(
+            REQUEST_HEADER_BYTES + size_of::<TransferBufferRequest>() + WRITE_BYTES,
+            RESPONSE_HEADER_BYTES,
+        );
+        let buffer = &self.buffers[index];
+        let result = self.client.write_buffer(chain, buffer, 0, &payload[..]);
+        self.record(result, AnyPending::WriteBuffer);
+    }
+
+    fn start_release(&mut self, selector: u8) {
+        let chain = self.chain(object_request_bytes(), RESPONSE_HEADER_BYTES);
+        match selector % 5 {
+            0 if !self.events.is_empty() => {
+                let event = self
+                    .events
+                    .swap_remove(usize::from(selector) % self.events.len());
+                let result = self.client.destroy_event(chain, event);
+                self.record(result, AnyPending::DestroyEvent);
+            }
+            1 if !self.queues.is_empty() => {
+                let queue = self
+                    .queues
+                    .swap_remove(usize::from(selector) % self.queues.len());
+                let result = self.client.destroy_execution_queue(chain, queue);
+                self.record(result, AnyPending::DestroyExecutionQueue);
+            }
+            2 if !self.programs.is_empty() => {
+                let program = self
+                    .programs
+                    .swap_remove(usize::from(selector) % self.programs.len());
+                let result = self.client.unload_program(chain, program);
+                self.record(result, AnyPending::UnloadProgram);
+            }
+            3 if !self.buffers.is_empty() => {
+                let buffer = self
+                    .buffers
+                    .swap_remove(usize::from(selector) % self.buffers.len());
+                let result = self.client.free_buffer(chain, buffer);
+                self.record(result, AnyPending::FreeBuffer);
+            }
+            4 if !self.contexts.is_empty() => {
+                let context = self
+                    .contexts
+                    .swap_remove(usize::from(selector) % self.contexts.len());
+                let result = self.client.destroy_context(chain, context);
+                self.record(result, AnyPending::DestroyContext);
+            }
+            _ => self.recover(chain),
+        }
+    }
+
+    fn device_pop(&mut self) {
+        let entry = self.ring.borrow_mut().published.pop_front();
+        if let Some(entry) = entry {
+            self.popped.push(entry);
+        }
+    }
+
+    /// Publish one completion as an arbitrary, possibly non-conforming device.
+    fn device_complete(&mut self, selector: u8, argument: u16, entropy: u64) {
+        if self.popped.is_empty() {
+            return;
+        }
+        let index = usize::from(selector) % self.popped.len();
+        let (id, mut chain) = self.popped.swap_remove(index);
+
+        let mut header_bytes = [0_u8; REQUEST_HEADER_BYTES];
+        let request_id = if chain.readable.len() >= REQUEST_HEADER_BYTES {
+            header_bytes.copy_from_slice(&chain.readable[..REQUEST_HEADER_BYTES]);
+            read_exact::<RequestHeader>(&header_bytes)
+                .map(|header| header.request_id.get())
+                .unwrap_or(0)
+        } else {
+            0
+        };
+        let opcode = read_exact::<RequestHeader>(&header_bytes)
+            .map(|header| header.opcode.get())
+            .unwrap_or(0);
+
+        let well_formed = selector & 0x80 == 0;
+        let payload = if well_formed {
+            self.canonical_payload(opcode)
+        } else {
+            self.pooled_payload(entropy, argument)
+        };
+
+        let (status, flags, declared_bytes, response_id) = if well_formed {
+            (StatusCode::OK, 0, payload.len() as u32, request_id)
+        } else {
+            (
+                STATUS_CHOICES[usize::from(selector >> 4) % STATUS_CHOICES.len()],
+                if selector & 0x08 == 0 { 0 } else { argument },
+                u32::from(argument),
+                if selector & 0x10 == 0 {
+                    request_id
+                } else {
+                    request_id.wrapping_add(entropy | 1)
+                },
+            )
+        };
+
+        let mut header = ResponseHeader::new(status, declared_bytes, response_id);
+        header.flags = Le16::new(flags);
+        write_clamped(&mut chain.writable, 0, header.as_bytes());
+        write_clamped(&mut chain.writable, RESPONSE_HEADER_BYTES, &payload);
+
+        let used = if well_formed {
+            (RESPONSE_HEADER_BYTES + payload.len()) as u32
+        } else {
+            u32::from(argument) % (chain.writable.len() as u32 + 8)
+        };
+
+        self.ring
+            .borrow_mut()
+            .used
+            .push_back(UsedChain::new(id, UsedLength::new(used), chain));
+    }
+
+    /// Build the response payload a conforming device would return for `opcode`.
+    fn canonical_payload(&mut self, opcode: u16) -> Vec<u8> {
+        let Ok(opcode) = KnownOpcode::try_from(opcode) else {
+            return Vec::new();
+        };
+        match opcode {
+            KnownOpcode::GetDeviceInfo => Vec::from(device_info().as_bytes()),
+            KnownOpcode::CreateContext
+            | KnownOpcode::AllocateBuffer
+            | KnownOpcode::LoadProgram
+            | KnownOpcode::CreateQueue => {
+                let payload = ObjectPayload {
+                    object_id: Le64::new(self.allocate_object_id()),
+                };
+                Vec::from(payload.as_bytes())
+            }
+            KnownOpcode::Submit => {
+                let payload = SubmitResponse {
+                    event_id: Le64::new(self.allocate_object_id()),
+                };
+                Vec::from(payload.as_bytes())
+            }
+            KnownOpcode::PollEvent => {
+                let payload = WireEventState {
+                    state: Le16::new(KnownEventState::Complete as u16),
+                    error: Le16::new(0),
+                    reserved: Le32::new(0),
+                };
+                Vec::from(payload.as_bytes())
+            }
+            KnownOpcode::ReadBuffer => vec![0xa5; READ_BYTES as usize],
+            KnownOpcode::DestroyContext
+            | KnownOpcode::FreeBuffer
+            | KnownOpcode::WriteBuffer
+            | KnownOpcode::UnloadProgram
+            | KnownOpcode::DestroyQueue
+            | KnownOpcode::CancelEvent
+            | KnownOpcode::DestroyEvent => Vec::new(),
+        }
+    }
+
+    /// Take response bytes straight from the input pool so seeds can carry canonical frames.
+    fn pooled_payload(&self, offset: u64, length: u16) -> Vec<u8> {
+        if self.pool.is_empty() {
+            return Vec::new();
+        }
+        let start = usize::try_from(offset % self.pool.len() as u64).unwrap_or(0);
+        let available = self.pool.len() - start;
+        let bytes = usize::from(length) % (available + 1);
+        self.pool[start..start + bytes].to_vec()
+    }
+
+    fn note_handle(&mut self) {
+        self.progress.handles = self.progress.handles.saturating_add(1);
+    }
+
+    fn allocate_object_id(&mut self) -> u64 {
+        let id = self.next_object_id;
+        self.next_object_id = self.next_object_id.wrapping_add(1).max(1);
+        id
+    }
+
+    fn pump(&mut self) {
+        if let Ok(PumpResult::UnexpectedCompletion) = self.client.pump() {
+            assert_eq!(
+                self.client.health(),
+                ClientHealth::NeedsReset,
+                "an unexpected completion left the client healthy"
+            );
+        }
+    }
+
+    fn poll_one(&mut self, selector: u8) {
+        if self.pendings.is_empty() {
+            return;
+        }
+        let index = usize::from(selector) % self.pendings.len();
+        let epoch = self.client.queue_state().epoch();
+        match self.pendings.swap_remove(index) {
+            AnyPending::GetDeviceInfo(pending) => {
+                assert_stale_epoch(&pending, epoch);
+                match self.client.poll(pending) {
+                    RequestPoll::Ready(completion) => {
+                        self.finish(completion);
+                    }
+                    other => self.retain(other, AnyPending::GetDeviceInfo),
+                }
+            }
+            AnyPending::CreateContext(pending) => match self.client.poll(pending) {
+                RequestPoll::Ready(completion) => {
+                    if let Some(context) = self.finish(completion) {
+                        self.contexts.push(context);
+                        self.note_handle();
+                    }
+                }
+                other => self.retain(other, AnyPending::CreateContext),
+            },
+            AnyPending::AllocateBuffer(pending) => match self.client.poll(pending) {
+                RequestPoll::Ready(completion) => {
+                    if let Some(buffer) = self.finish(completion) {
+                        self.buffers.push(buffer);
+                        self.note_handle();
+                    }
+                }
+                other => self.retain(other, AnyPending::AllocateBuffer),
+            },
+            AnyPending::LoadProgram(pending) => match self.client.poll(pending) {
+                RequestPoll::Ready(completion) => {
+                    if let Some(program) = self.finish(completion) {
+                        self.programs.push(program);
+                        self.note_handle();
+                    }
+                }
+                other => self.retain(other, AnyPending::LoadProgram),
+            },
+            AnyPending::CreateExecutionQueue(pending) => match self.client.poll(pending) {
+                RequestPoll::Ready(completion) => {
+                    if let Some(queue) = self.finish(completion) {
+                        self.queues.push(queue);
+                        self.note_handle();
+                    }
+                }
+                other => self.retain(other, AnyPending::CreateExecutionQueue),
+            },
+            AnyPending::Submit(pending) => match self.client.poll(pending) {
+                RequestPoll::Ready(completion) => {
+                    if let Some(outcome) = self.finish(completion) {
+                        let event = match outcome {
+                            SubmissionOutcome::Accepted(event) => event,
+                            SubmissionOutcome::Indeterminate { event, .. } => event,
+                        };
+                        self.events.push(event);
+                        self.note_handle();
+                    }
+                }
+                other => self.retain(other, AnyPending::Submit),
+            },
+            AnyPending::PollEvent(pending) => match self.client.poll(pending) {
+                RequestPoll::Ready(completion) => {
+                    self.finish(completion);
+                }
+                other => self.retain(other, AnyPending::PollEvent),
+            },
+            AnyPending::DestroyContext(pending) => match self.client.poll(pending) {
+                RequestPoll::Ready(completion) => {
+                    self.finish(completion);
+                }
+                other => self.retain(other, AnyPending::DestroyContext),
+            },
+            AnyPending::FreeBuffer(pending) => match self.client.poll(pending) {
+                RequestPoll::Ready(completion) => {
+                    self.finish(completion);
+                }
+                other => self.retain(other, AnyPending::FreeBuffer),
+            },
+            AnyPending::WriteBuffer(pending) => match self.client.poll(pending) {
+                RequestPoll::Ready(completion) => {
+                    self.finish(completion);
+                }
+                other => self.retain(other, AnyPending::WriteBuffer),
+            },
+            AnyPending::ReadBuffer(pending) => match self.client.poll(pending) {
+                RequestPoll::Ready(completion) => {
+                    self.finish(completion);
+                }
+                other => self.retain(other, AnyPending::ReadBuffer),
+            },
+            AnyPending::UnloadProgram(pending) => match self.client.poll(pending) {
+                RequestPoll::Ready(completion) => {
+                    self.finish(completion);
+                }
+                other => self.retain(other, AnyPending::UnloadProgram),
+            },
+            AnyPending::DestroyExecutionQueue(pending) => match self.client.poll(pending) {
+                RequestPoll::Ready(completion) => {
+                    self.finish(completion);
+                }
+                other => self.retain(other, AnyPending::DestroyExecutionQueue),
+            },
+            AnyPending::CancelEvent(pending) => match self.client.poll(pending) {
+                RequestPoll::Ready(completion) => {
+                    self.finish(completion);
+                }
+                other => self.retain(other, AnyPending::CancelEvent),
+            },
+            AnyPending::DestroyEvent(pending) => match self.client.poll(pending) {
+                RequestPoll::Ready(completion) => {
+                    self.finish(completion);
+                }
+                other => self.retain(other, AnyPending::DestroyEvent),
+            },
+        }
+    }
+
+    /// Reclaim the caller chain from a terminal completion and expose the typed output.
+    fn finish<O: Operation>(
+        &mut self,
+        completion: Completion<O, FuzzChain, ByteAccessError>,
+    ) -> Option<O::Output> {
+        match completion {
+            Completion::Success { output, chain } => {
+                self.recover(chain);
+                Some(output)
+            }
+            Completion::DeviceError { chain, .. } => {
+                self.recover(chain);
+                self.progress.device_errors = self.progress.device_errors.saturating_add(1);
+                None
+            }
+            Completion::InvalidResponse { chain, .. } => {
+                self.recover(chain);
+                self.progress.invalid_responses = self.progress.invalid_responses.saturating_add(1);
+                assert_eq!(
+                    self.client.health(),
+                    ClientHealth::NeedsReset,
+                    "a malformed response left the client healthy"
+                );
+                None
+            }
+        }
+    }
+
+    fn retain<O: Operation>(
+        &mut self,
+        poll: RequestPoll<O, FuzzChain, ByteAccessError, ByteAccessError>,
+        wrap: fn(Pending<O>) -> AnyPending,
+    ) {
+        match poll {
+            RequestPoll::Pending(pending) | RequestPoll::NeedsReset(pending) => {
+                self.pendings.push(wrap(pending));
+            }
+            RequestPoll::QueueError { pending, .. } => self.pendings.push(wrap(pending)),
+            RequestPoll::Stale(_) => {}
+            RequestPoll::Ready(_) => unreachable!("terminal completions are handled by the caller"),
+        }
+    }
+
+    fn reset(&mut self) {
+        let Some(next) = self.client.queue_state().epoch().checked_next() else {
+            return;
+        };
+        let reclaimed = match self.client.reset(next) {
+            Ok(reclaimed) => reclaimed,
+            Err(_) => return,
+        };
+        for chain in reclaimed {
+            let (_, chain) = chain.into_parts();
+            self.recover(chain);
+        }
+        for (_, chain) in core::mem::take(&mut self.popped) {
+            self.recover(chain);
+        }
+        while let Some(used) = self.client.pop_recovered_completion() {
+            let (_, _, chain) = used.into_parts();
+            self.recover(chain);
+        }
+        if let Some(used) = self.client.take_unexpected_completion() {
+            let (_, _, chain) = used.into_parts();
+            self.recover(chain);
+        }
+
+        assert_eq!(
+            self.client.health(),
+            ClientHealth::Running,
+            "reset did not restore client health"
+        );
+        assert!(
+            self.client.device_info().is_none(),
+            "reset retained discovery from an invalidated epoch"
+        );
+        assert_eq!(self.client.queue_state().epoch(), next);
+        self.progress.resets = self.progress.resets.saturating_add(1);
+
+        self.contexts.clear();
+        self.buffers.clear();
+        self.programs.clear();
+        self.queues.clear();
+        self.events.clear();
+
+        let size = QueueSize::new(QUEUE_SIZE).expect("queue size is a valid power of two");
+        self.client
+            .reconfigure_queue(size)
+            .expect("reconfiguration after reset succeeds");
+
+        // Every pending token belongs to the invalidated epoch and must never resolve again.
+        for pending in core::mem::take(&mut self.pendings) {
+            assert_stale(&mut self.client, pending);
+        }
+    }
+
+    fn notifications(&mut self, selector: u8) {
+        if selector & 1 == 0 {
+            let _ = self.client.disable_used_notifications();
+        } else {
+            let _ = self.client.enable_used_notifications();
+        }
+    }
+
+    fn assert_invariants(&self) {
+        assert!(
+            self.pendings.len() <= usize::from(MAX_INFLIGHT),
+            "client admitted {} requests beyond the {MAX_INFLIGHT} in-flight bound",
+            self.pendings.len()
+        );
+        let epoch = self.client.queue_state().epoch();
+        assert!(
+            self.ring
+                .borrow()
+                .published
+                .iter()
+                .all(|(id, _)| id.epoch() == epoch),
+            "a published chain outlived its queue epoch"
+        );
+    }
+
+    /// Return every caller chain and prove none was retained by the client.
+    fn drain(mut self) -> Progress {
+        self.reset();
+        for (_, chain) in core::mem::take(&mut self.popped) {
+            self.recover(chain);
+        }
+        let leftover = core::mem::take(&mut self.ring.borrow_mut().published);
+        for (_, chain) in leftover {
+            self.recover(chain);
+        }
+        let leftover = core::mem::take(&mut self.ring.borrow_mut().used);
+        for used in leftover {
+            let (_, _, chain) = used.into_parts();
+            self.recover(chain);
+        }
+        assert!(
+            self.outstanding.is_empty(),
+            "client retained {} caller chains after full teardown",
+            self.outstanding.len()
+        );
+        self.progress
+    }
+}
+
+fn assert_stale(client: &mut Client, pending: AnyPending) {
+    macro_rules! stale {
+        ($pending:expr) => {
+            assert!(
+                matches!(client.poll($pending), RequestPoll::Stale(_)),
+                "an invalidated epoch resolved a pending request"
+            )
+        };
+    }
+    match pending {
+        AnyPending::GetDeviceInfo(pending) => stale!(pending),
+        AnyPending::CreateContext(pending) => stale!(pending),
+        AnyPending::DestroyContext(pending) => stale!(pending),
+        AnyPending::AllocateBuffer(pending) => stale!(pending),
+        AnyPending::FreeBuffer(pending) => stale!(pending),
+        AnyPending::WriteBuffer(pending) => stale!(pending),
+        AnyPending::ReadBuffer(pending) => stale!(pending),
+        AnyPending::LoadProgram(pending) => stale!(pending),
+        AnyPending::UnloadProgram(pending) => stale!(pending),
+        AnyPending::CreateExecutionQueue(pending) => stale!(pending),
+        AnyPending::DestroyExecutionQueue(pending) => stale!(pending),
+        AnyPending::Submit(pending) => stale!(pending),
+        AnyPending::PollEvent(pending) => stale!(pending),
+        AnyPending::CancelEvent(pending) => stale!(pending),
+        AnyPending::DestroyEvent(pending) => stale!(pending),
+    }
+}
+
+fn assert_stale_epoch<O>(pending: &Pending<O>, epoch: QueueEpoch) {
+    assert!(
+        pending.epoch().get() <= epoch.get(),
+        "a pending token claims a future queue epoch"
+    );
+}
+
+fn write_clamped(target: &mut [u8], offset: usize, source: &[u8]) {
+    let Some(window) = target.get_mut(offset..) else {
+        return;
+    };
+    let count = window.len().min(source.len());
+    window[..count].copy_from_slice(&source[..count]);
+}
+
+fn object_request_bytes() -> usize {
+    REQUEST_HEADER_BYTES + size_of::<ObjectPayload>()
+}
+
+fn object_response_bytes() -> usize {
+    RESPONSE_HEADER_BYTES + size_of::<ObjectPayload>()
+}
+
+fn domain(selector: u8) -> MemoryDomain {
+    match selector % 3 {
+        0 => MemoryDomain::Host,
+        1 => MemoryDomain::Device,
+        _ => MemoryDomain::Shared,
+    }
+}
+
+fn access(selector: u8) -> AccessMode {
+    match selector % 3 {
+        0 => AccessMode::Read,
+        1 => AccessMode::Write,
+        _ => AccessMode::ReadWrite,
+    }
+}
+
+fn config() -> GuestConfig {
+    let wire = WireConfig {
+        protocol_major: Le16::new(PROTOCOL_MAJOR),
+        protocol_minor: Le16::new(PROTOCOL_MINOR),
+        command_queue_count: Le16::new(BASELINE_COMMAND_QUEUES),
+        max_chain_descriptors: Le16::new(MAX_CHAIN_DESCRIPTORS),
+        max_request_bytes: Le32::new(MAX_REQUEST_BYTES),
+        max_response_bytes: Le32::new(MAX_RESPONSE_BYTES),
+    };
+    GuestConfig::new(wire, 0, MAX_INFLIGHT).expect("harness configuration is valid")
+}
+
+fn device_info() -> WireDeviceInfo {
+    WireDeviceInfo {
+        uuid: [0x5a; 16],
+        class: Le16::new(1),
+        reserved: Le16::new(0),
+        vendor_id: Le32::new(0x1234),
+        device_id: Le32::new(0x5678),
+        capabilities: Le64::new((1 << 0) | (1 << 1) | (1 << 2) | (1 << 5)),
+        max_contexts: Le32::new(8),
+        max_buffers_per_context: Le32::new(8),
+        max_programs_per_context: Le32::new(8),
+        max_queues_per_context: Le32::new(8),
+        max_events_per_context: Le32::new(8),
+        max_bindings_per_submission: Le32::new(8),
+        max_buffer_bytes: Le64::new(MAX_BUFFER_BYTES),
+        max_artifact_bytes: Le64::new(MAX_ARTIFACT_BYTES),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build an input with an explicit response-byte pool followed by zero-argument actions.
+    fn input(pool: &[u8], actions: &[u8]) -> Vec<u8> {
+        let mut bytes = Vec::from((pool.len() as u16).to_le_bytes());
+        bytes.extend_from_slice(pool);
+        for action in actions {
+            bytes.extend_from_slice(&[*action, 0, 0, 0, 0, 0, 0, 0]);
+        }
+        bytes
+    }
+
+    #[test]
+    fn well_formed_lifecycle_builds_the_whole_object_graph() {
+        // Discover, then create a context, buffer, program, queue, and event against a conforming
+        // device. Each object needs its own start/pop/complete/poll quartet.
+        let sequence = input(
+            &[],
+            &[
+                0, 11, 12, 14, 1, 11, 12, 14, 2, 11, 12, 14, 3, 11, 12, 14, 4, 11, 12, 14, 5, 11,
+                12, 14, 6, 11, 12, 14,
+            ],
+        );
+        let progress = run(&sequence);
+        assert_eq!(
+            progress.handles, 5,
+            "conforming lifecycle did not build the full object graph: {progress:?}"
+        );
+        assert_eq!(progress.invalid_responses, 0);
+    }
+
+    #[test]
+    fn hostile_completions_are_rejected_without_resolving_stale_epochs() {
+        let mut bytes = Vec::from(4_u16.to_le_bytes());
+        bytes.extend_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
+        bytes.extend_from_slice(&[0, 0, 0, 0, 0, 0, 0, 0]);
+        bytes.extend_from_slice(&[11, 0, 0, 0, 0, 0, 0, 0]);
+        // Selector bit 0x80 selects a non-conforming response; bit 0x10 corrupts the request ID.
+        bytes.extend_from_slice(&[12, 0x90, 0x60, 0x00, 0x33, 0x44, 0x55, 0x66]);
+        bytes.extend_from_slice(&[14, 0, 0, 0, 0, 0, 0, 0]);
+        bytes.extend_from_slice(&[15, 0, 0, 0, 0, 0, 0, 0]);
+        let progress = run(&bytes);
+        assert_eq!(
+            progress.invalid_responses, 1,
+            "a corrupted response was not classified as invalid: {progress:?}"
+        );
+        assert_eq!(progress.resets, 2, "final teardown always resets once more");
+    }
+
+    #[test]
+    fn empty_and_truncated_inputs_are_accepted() {
+        fuzz_guest_client(&[]);
+        fuzz_guest_client(&[13]);
+        fuzz_guest_client(&[12, 0x80, 0xff]);
+    }
+}

--- a/fuzz/src/guest.rs
+++ b/fuzz/src/guest.rs
@@ -330,7 +330,7 @@ fn run(data: &[u8]) -> Progress {
         let action = input.byte() % ACTION_COUNT;
         let selector = input.byte();
         let argument = input.u16();
-        let entropy = input.u64();
+        let entropy = u64::from(u32::from_le_bytes([input.byte(), input.byte(), input.byte(), input.byte()]));
         harness.step(action, selector, argument, entropy);
         harness.assert_invariants();
     }

--- a/fuzz/src/guest.rs
+++ b/fuzz/src/guest.rs
@@ -659,11 +659,15 @@ impl Harness {
             .unwrap_or(0);
 
         let well_formed = selector & 0x80 == 0;
-        let payload = if well_formed {
+        let mut payload = if well_formed {
             self.canonical_payload(opcode)
         } else {
             self.pooled_payload(entropy, argument)
         };
+        if well_formed {
+            let max_payload = chain.writable.len().saturating_sub(RESPONSE_HEADER_BYTES);
+            payload.truncate(max_payload);
+        }
 
         let (status, flags, declared_bytes, response_id) = if well_formed {
             (StatusCode::OK, 0, payload.len() as u32, request_id)

--- a/fuzz/src/guest.rs
+++ b/fuzz/src/guest.rs
@@ -330,7 +330,12 @@ fn run(data: &[u8]) -> Progress {
         let action = input.byte() % ACTION_COUNT;
         let selector = input.byte();
         let argument = input.u16();
-        let entropy = u64::from(u32::from_le_bytes([input.byte(), input.byte(), input.byte(), input.byte()]));
+        let entropy = u64::from(u32::from_le_bytes([
+            input.byte(),
+            input.byte(),
+            input.byte(),
+            input.byte(),
+        ]));
         harness.step(action, selector, argument, entropy);
         harness.assert_invariants();
     }

--- a/fuzz/src/guest.rs
+++ b/fuzz/src/guest.rs
@@ -988,6 +988,8 @@ impl Harness {
     }
 
     fn notifications(&mut self, selector: u8) {
+        // Bit 1 injects a one-shot transport error on the next pop_used().
+        self.ring.borrow_mut().inject_pop_error = selector & 2 != 0;
         if selector & 1 == 0 {
             let _ = self.client.disable_used_notifications();
         } else {

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -1,10 +1,12 @@
 #![forbid(unsafe_code)]
 
 mod descriptor;
+mod guest;
 mod protocol;
 mod stateful;
 
 pub use descriptor::fuzz_descriptor_end_to_end;
+pub use guest::fuzz_guest_client;
 pub use protocol::fuzz_protocol_decode;
 pub use stateful::fuzz_stateful_commands;
 


### PR DESCRIPTION
Closes #61.

## Summary

The three existing fuzz targets (`protocol_decode`, `descriptor_end_to_end`, `stateful_commands`)
all drive the device. `virtio-accel-guest` was the only workspace crate absent from
`fuzz/Cargo.toml`, so the reference client's response and completion handling had never seen
coverage-guided input.

This adds a fourth target, `guest_client`. It is reference-implementation robustness rather than a
new security boundary — the threat model keeps the guest adversarial and the host trusted — but the
reference client is what downstream driver authors start from, and protocol 1.0 places real
receiver-side obligations on it.

The harness owns both ends of a queue that performs no validation of its own, rather than reusing
the split-queue model, so it can publish completions no conforming transport would produce:

- malformed and truncated response headers, unknown statuses, and unknown event states
- mismatched request correlation, nonzero response flags, arbitrary used lengths
- duplicated, out-of-order, and spurious completions
- reset and epoch advancement interleaved with in-flight requests and stale operations
- publication backpressure and injected transport errors on the used ring

Hostile response payloads come from an input-controlled byte pool rather than synthesized entropy.
Seeds fill that pool with reviewed response frames from `conformance/v1.0/vectors.json`, so a
mutated header or used length is applied to otherwise canonical bytes.

## Invariants asserted

- An unhealthy client never admits new work.
- Pending tokens from an invalidated epoch never resolve; every one returns `Stale` after reset.
- Reset restores health, clears discovery, and advances the epoch.
- A malformed response always degrades health to `NeedsReset`.
- In-flight tracking never exceeds `GuestConfig::max_inflight`.
- Every caller chain is returned exactly once across completion, reset, recovered-completion, and
  unexpected-completion paths. The teardown pass fails if the client retained any chain.

Backpressure, resource limits, and protocol errors are ordinary outcomes and are not treated as
crashes.

## Notes for review

Two things worth a maintainer's opinion rather than silent choices:

- **Error precedence.** An early version asserted that an unhealthy client rejects with
  `StartErrorKind::NeedsReset`. Fuzzing disproved it in about five seconds: typed argument
  validation in methods like `write_buffer` runs before `start_frame`'s health check, so an
  unhealthy client with invalid arguments reports `InvalidArgument` instead. Nothing is admitted
  either way, so I read this as intentional precedence and relaxed the assertion to the property
  that matters — admission never happens. Happy to file it separately if you consider the ordering
  worth changing.
- **Parent epic.** Filed under #7 because it owns the CI fuzz-smoke deliverable and is still open.
  #6 covered fuzzing but scoped it to "wire and descriptor segmentation", so the driver side was
  never in its scope.

No crashes were found. `fuzz/regressions/guest_client/` is created empty so a future finding has a
home.

## Test plan

- [x] `cargo test --manifest-path fuzz/Cargo.toml --lib --no-default-features` — 7 passed. The two
      new harness tests are load-bearing: one asserts a conforming device drives the client through
      all five object kinds, the other asserts a corrupted response is classified invalid.
- [x] `cargo fuzz list` discovers `guest_client`, so the existing CI smoke job picks it up with no
      workflow change.
- [x] `python3 ci/seed-fuzz-corpus.py` generates three deterministic seeds from checked-in
      conformance artifacts.
- [x] `cargo fuzz run guest_client` at the documented CI budget (256 runs) — clean.
- [x] Extended run: 4,000,000 runs / 189s and 600,000 runs / 20s reaching 1255 edges — no crashes.
- [x] `cargo clippy` with `-D warnings` on both the workspace and the fuzz crate — clean.
- [x] `cargo fmt --check` on both — clean.
- [x] `cargo test --workspace --all-targets --all-features` — 144 passed, unchanged.
- [x] `cargo +1.85.0 check` on the workspace and the fuzz crate — MSRV holds.
- [x] `check-normative-requirements.py`, `check-release-policy.py`, `check-performance-budgets.py`,
      `check-portable-dependencies.sh` — all pass.
- [x] Harness keeps `#![forbid(unsafe_code)]` and adds no platform or vendor surface.

Made with [Cursor](https://cursor.com)