### PR TITLE
Clarify that validate_bindings is not a complete host usage gate

### DIFF
--- a/crates/virtio-accel-core/src/lib.rs
+++ b/crates/virtio-accel-core/src/lib.rs
@@ -765,11 +765,15 @@ impl Timeout {
     }
 }
 
-/// One validated binding. The referenced buffer must remain alive until its event is reclaimed.
+/// One borrowed program binding. The referenced buffer must remain alive until its event is
+/// reclaimed.
 ///
 /// Program-visible buffers carry [`BufferProperties::DIRECT_BINDING`]. A backend must reject an
 /// incompatible buffer/program combination instead of copying the range into a hidden bounce
 /// allocation. Binding order is not semantic; command engines may present the slice in slot order.
+///
+/// Before [`Accelerator::submit`], hosts must reject an [`AccessMode`] incompatible with the
+/// buffer's declared [`BufferUsage`] (see [`Self::validate_for_submit`]).
 #[derive(Debug)]
 pub struct BindingRef<'a, B> {
     pub slot: u32,
@@ -778,6 +782,36 @@ pub struct BindingRef<'a, B> {
     pub access: AccessMode,
 }
 
+impl<'a, B> BindingRef<'a, B> {
+    /// Slot/count checks plus [`BufferDesc::allows_access`] for each binding.
+    ///
+    /// Hosts must call this before [`Accelerator::submit`]. `descs[i]` must be the
+    /// descriptor for the buffer behind `bindings[i].buffer` (equal length alone is
+    /// not enough). A usage mismatch returns [`BackendError::PermissionDenied`].
+    pub fn validate_for_submit(
+        bindings: &[Self],
+        descs: &[BufferDesc],
+        max_bindings: u32,
+    ) -> Result<(), BackendError> {
+        validate_bindings(bindings, max_bindings)?;
+        if bindings.len() != descs.len() {
+            return Err(BackendError::InvalidArgument);
+        }
+        for (binding, desc) in bindings.iter().zip(descs.iter()) {
+            if !desc.allows_access(binding.access) {
+                return Err(BackendError::PermissionDenied);
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Slot/count uniqueness helper for program bindings.
+///
+/// Structural only: nonempty, bounded by `max_bindings`, and unique slots. This is
+/// **incomplete** for pre-admission checks -- it does not enforce access/usage
+/// compatibility required before backend admission. Prefer
+/// [`BindingRef::validate_for_submit`] before [`Accelerator::submit`].
 pub fn validate_bindings<B>(
     bindings: &[BindingRef<'_, B>],
     max_bindings: u32,
@@ -1018,6 +1052,10 @@ pub trait Accelerator {
     fn destroy_queue(&self, queue: Self::Queue) -> Result<(), ReleaseFailure<Self::Queue>>;
 
     /// Attempt to admit one program execution and return its event.
+    ///
+    /// Hosts must reject an [`AccessMode`] incompatible with each buffer's [`BufferUsage`] before
+    /// calling this method (see [`BindingRef::validate_for_submit`]). Providers may repeat the check
+    /// as defense in depth, but host-side rejection is required by Wire ABI section 4.4.
     ///
     /// - **Ownership/lifetime:** queue, program, buffers, and the binding slice are borrowed only
     ///   during admission and must not be retained as Rust references. The caller keeps every
@@ -1323,6 +1361,38 @@ mod tests {
         assert_eq!(
             validate_bindings::<()>(&[], 1),
             Err(BackendError::ResourceLimit)
+        );
+    }
+
+    #[test]
+    fn binding_access_rejects_usage_mismatch_with_unique_slots() {
+        let buffer = ();
+        let range = BufferRange::new(0, 16).unwrap();
+        let bindings = [BindingRef {
+            slot: 0,
+            buffer: &buffer,
+            range,
+            access: AccessMode::Write,
+        }];
+        let input = BufferDesc::new(64, 16, MemoryDomain::Host, BufferUsage::PROGRAM_INPUT).unwrap();
+        assert!(!input.allows_access(AccessMode::Write));
+        // Slot-only checks still pass; the usage gate lives on validate_for_submit.
+        assert!(validate_bindings(&bindings, 1).is_ok());
+        assert_eq!(
+            BindingRef::validate_for_submit(&bindings, &[input], 1),
+            Err(BackendError::PermissionDenied)
+        );
+
+        let read_bindings = [BindingRef {
+            slot: 0,
+            buffer: &buffer,
+            range,
+            access: AccessMode::Read,
+        }];
+        assert!(BindingRef::validate_for_submit(&read_bindings, &[input], 1).is_ok());
+        assert_eq!(
+            BindingRef::validate_for_submit(&read_bindings, &[], 1),
+            Err(BackendError::InvalidArgument)
         );
     }
 

--- a/crates/virtio-accel-core/src/lib.rs
+++ b/crates/virtio-accel-core/src/lib.rs
@@ -1374,7 +1374,8 @@ mod tests {
             range,
             access: AccessMode::Write,
         }];
-        let input = BufferDesc::new(64, 16, MemoryDomain::Host, BufferUsage::PROGRAM_INPUT).unwrap();
+        let input =
+            BufferDesc::new(64, 16, MemoryDomain::Host, BufferUsage::PROGRAM_INPUT).unwrap();
         assert!(!input.allows_access(AccessMode::Write));
         // Slot-only checks still pass; the usage gate lives on validate_for_submit.
         assert!(validate_bindings(&bindings, 1).is_ok());

--- a/crates/virtio-accel-device/src/engine.rs
+++ b/crates/virtio-accel-device/src/engine.rs
@@ -8,8 +8,8 @@
 use alloc::vec::Vec;
 
 use virtio_accel_core::{
-    Accelerator, ArtifactRef, BackendError, BindingRef, BufferRange, BufferUsage, ByteSink,
-    ByteSource, Capabilities, DeviceInfo, DeviceInfoError, EventState, ReleaseFailure,
+    Accelerator, ArtifactRef, BackendError, BindingRef, BufferDesc, BufferRange, BufferUsage,
+    ByteSink, ByteSource, Capabilities, DeviceInfo, DeviceInfoError, EventState, ReleaseFailure,
     SubmitFailure, Timeout,
 };
 use virtio_accel_proto::{
@@ -452,13 +452,18 @@ impl<A: Accelerator> CommandProcessor<A> {
         buffer_ids.extend(bindings.iter().map(|binding| binding.buffer_id));
 
         let accelerator = &self.accelerator;
+        let max_bindings = self.info.limits.max_bindings_per_submission;
         let mut admission_status = StatusCode::OK;
         let mut admission_requires_discard = false;
         let result = self
             .state
             .create_event_with(queue_id, program_id, buffer_ids, |resources| {
                 let mut native_bindings = Vec::new();
+                let mut descs: Vec<BufferDesc> = Vec::new();
                 native_bindings
+                    .try_reserve_exact(bindings.len())
+                    .map_err(|_| SubmitCreateError::OutOfMemory)?;
+                descs
                     .try_reserve_exact(bindings.len())
                     .map_err(|_| SubmitCreateError::OutOfMemory)?;
                 for binding in &bindings {
@@ -469,9 +474,7 @@ impl<A: Accelerator> CommandProcessor<A> {
                     if binding.range.end() > desc.bytes() {
                         return Err(SubmitCreateError::Validation(StatusCode::OUT_OF_BOUNDS));
                     }
-                    if !desc.allows_access(binding.access) {
-                        return Err(SubmitCreateError::Validation(StatusCode::PERMISSION_DENIED));
-                    }
+                    descs.push(desc);
                     native_bindings.push(BindingRef {
                         slot: binding.slot,
                         buffer,
@@ -479,6 +482,9 @@ impl<A: Accelerator> CommandProcessor<A> {
                         access: binding.access,
                     });
                 }
+                BindingRef::validate_for_submit(&native_bindings, &descs, max_bindings).map_err(
+                    |error| SubmitCreateError::Validation(status_from_backend_error(error)),
+                )?;
                 match accelerator.submit(
                     resources.queue(),
                     resources.program(),

--- a/crates/virtio-accel-mock/src/lib.rs
+++ b/crates/virtio-accel-mock/src/lib.rs
@@ -16,7 +16,7 @@ use virtio_accel_core::{
     Accelerator, AcceleratorClass, AllocatedBuffer, ArtifactFormat, ArtifactRef, BackendError,
     BindingRef, BufferDesc, BufferInfo, BufferProperties, ByteSink, ByteSource, Capabilities,
     ContextDesc, DeviceIdentity, DeviceInfo, DeviceLimits, EventState, MemoryDomain, QueueDesc,
-    ReleaseFailure, SubmitFailure, TargetIdentity, Timeout, validate_bindings,
+    ReleaseFailure, SubmitFailure, TargetIdentity, Timeout,
 };
 
 use reference::Operation;
@@ -508,8 +508,10 @@ impl Accelerator for MockAccelerator {
         bindings: &[BindingRef<'_, Self::Buffer>],
         _timeout: Timeout,
     ) -> Result<Self::Event, SubmitFailure<Self::Event>> {
-        validate_bindings(bindings, self.info.limits.max_bindings_per_submission)
-            .map_err(SubmitFailure::Rejected)?;
+        // Provider-side defense-in-depth. Hosts must still call
+        // `BindingRef::validate_for_submit` before `Accelerator::submit`
+        // (as `CommandProcessor` does). Range checks run before the shared usage
+        // gate so overlapping faults prefer `OutOfBounds` over `PermissionDenied`.
         if queue.context_id != program.context_id
             || bindings
                 .iter()
@@ -521,10 +523,14 @@ impl Accelerator for MockAccelerator {
             if binding.range.end() > binding.buffer.desc.bytes() {
                 return Err(SubmitFailure::Rejected(BackendError::OutOfBounds));
             }
-            if !binding.buffer.desc.allows_access(binding.access) {
-                return Err(SubmitFailure::Rejected(BackendError::PermissionDenied));
-            }
         }
+        let descs: Vec<BufferDesc> = bindings.iter().map(|binding| binding.buffer.desc).collect();
+        BindingRef::validate_for_submit(
+            bindings,
+            &descs,
+            self.info.limits.max_bindings_per_submission,
+        )
+        .map_err(SubmitFailure::Rejected)?;
         let invocation = Self::prepare_invocation(program.operation, bindings)
             .map_err(SubmitFailure::Rejected)?;
         self.direct_binding_admissions
@@ -1060,5 +1066,34 @@ mod tests {
             backend.submit(&queue, &program, &bindings, Timeout::Infinite),
             Err(SubmitFailure::Rejected(BackendError::Incompatible))
         ));
+    }
+
+    #[test]
+    fn usage_mismatch_is_rejected_before_admission() {
+        let backend = MockAccelerator::default();
+        let context = backend.create_context(ContextDesc::default()).unwrap();
+        let allocation = backend
+            .allocate_buffer(
+                &context,
+                BufferDesc::new(16, 1, MemoryDomain::Host, BufferUsage::PROGRAM_INPUT).unwrap(),
+            )
+            .unwrap();
+        let (buffer, _) = allocation.into_parts();
+        let artifact = reference::ReferenceArtifact::barrier(0);
+        let program = load_reference(&backend, &context, &artifact);
+        let queue = backend
+            .create_queue(&context, QueueDesc::default())
+            .unwrap();
+        let bindings = [BindingRef {
+            slot: 0,
+            buffer: &buffer,
+            range: BufferRange::new(0, 16).unwrap(),
+            access: AccessMode::Write,
+        }];
+        assert!(matches!(
+            backend.submit(&queue, &program, &bindings, Timeout::Infinite),
+            Err(SubmitFailure::Rejected(BackendError::PermissionDenied))
+        ));
+        assert_eq!(backend.direct_binding_admissions(), 0);
     }
 }

--- a/docs/backend-implementer-guide.md
+++ b/docs/backend-implementer-guide.md
@@ -166,9 +166,10 @@ retained by the returned program handle, including compiled code and provider me
 to that program. Reject the load when that bound cannot be honored; do not treat it as an estimate.
 
 Submission validates nonempty bounded bindings, unique slots, nonempty in-range regions, declared
-buffer usage, program-specific slot/access compatibility, and one context across queue, program,
-and buffers. Validation and admission are bounded. The borrowed binding slice is not an owned
-per-binding mirror and must not survive the call as Rust references.
+buffer usage (access must be compatible with the buffer’s usage bits), program-specific
+slot/access compatibility, and one context across queue, program, and buffers. Reject usage
+mismatches before provider admission. Validation and admission are bounded. The borrowed binding
+slice is not an owned per-binding mirror and must not survive the call as Rust references.
 
 ### Events, cancellation, and time
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -539,7 +539,7 @@ model or is identified as an implementation helper.
 | `ArtifactFormat`, `TargetIdentity`, `ArtifactRef` | Opaque program artifact description over a byte source |
 | `QueueFlags`, `QueueDesc` | Accelerator execution-queue creation intent, not a Virtio queue |
 | `Timeout` | Relative admission timeout; zero on wire means infinite |
-| `BindingRef`, `validate_bindings` | Validated semantic binding and implementation helper |
+| `BindingRef` | Borrowed program binding view. Hosts must reject `AccessMode` incompatible with `BufferUsage` before backend admission |
 | `EventState` | Event completion state |
 | `SubmitFailure` | Rejected versus indeterminate submission acceptance boundary |
 | `ReleaseFailure` | Rejected versus indeterminate resource-release boundary |


### PR DESCRIPTION
## Summary
- Slot-only `validate_bindings` was incomplete for Wire ABI §4.4; hosts must also reject `AccessMode` incompatible with `BufferUsage` (`PERMISSION_DENIED`) before provider admission.
- Centralize that gate on `BindingRef::validate_for_submit`, wire the in-tree device/mock hosts through it, and clarify that `validate_bindings` is structural only.
- Fix Appendix A / implementer-guide wording so `BindingRef` is not described as a “validated semantic binding.”

Closes #63

## Test plan
- [x] `cargo test -p virtio-accel-core binding_access_rejects_usage_mismatch`
- [x] `cargo test -p virtio-accel-mock usage_mismatch_is_rejected_before_admission`
- [x] `cargo test -p virtio-accel-device --test command_processor submission_validation_rejects_before_backend_admission`