### PR TITLE
Add Core ML host backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
+name = "cc"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,6 +97,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "syn"
 version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,6 +154,15 @@ version = "0.1.0"
 dependencies = [
  "bitflags",
  "virtio-accel-transport",
+]
+
+[[package]]
+name = "virtio-accel-coreml"
+version = "0.1.0"
+dependencies = [
+ "cc",
+ "virtio-accel-conformance",
+ "virtio-accel-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "conformance/rust-clean-room",
     "crates/virtio-accel-conformance",
     "crates/virtio-accel-core",
+    "crates/virtio-accel-coreml",
     "crates/virtio-accel-device",
     "crates/virtio-accel-guest",
     "crates/virtio-accel-mock",
@@ -49,6 +50,7 @@ categories = ["no-std", "hardware-support", "virtualization"]
 
 [workspace.dependencies]
 bitflags = { version = "2.13.1", default-features = false }
+cc = "1.2"
 serde_json = "1.0.149"
 zerocopy = { version = "0.8.54", default-features = false, features = ["derive"] }
 virtio-accel-core = { path = "crates/virtio-accel-core", version = "0.1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,6 @@ categories = ["no-std", "hardware-support", "virtualization"]
 
 [workspace.dependencies]
 bitflags = { version = "2.13.1", default-features = false }
-cc = "1.2"
 serde_json = "1.0.149"
 zerocopy = { version = "0.8.54", default-features = false, features = ["derive"] }
 virtio-accel-core = { path = "crates/virtio-accel-core", version = "0.1.0" }

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ guest: contexts, buffers, opaque programs, execution queues, submissions, and ev
 target is NPU execution, while the object model deliberately leaves room for GPUs, DSPs, and other
 program-driven accelerators.
 
-The repository is the portable majority of such a system, and nothing else. It contains no Linux
-ioctls, macOS frameworks, Windows APIs, guest physical addresses, vendor command formats, or claimed
-virtio device ID. Those adapters are meant to be written against these layers, not inside them.
+The repository is mostly portable protocol and lifecycle code. Host integrations are isolated in
+adapter crates and never become dependencies of the portable facade; the first such adapter is the
+macOS Core ML backend. The project claims no Virtio device ID.
 
 This project is pre-standardization and experimental. Protocol 1.0 is frozen as a versioned review
 input for independent implementation — it is stable enough to build against and to disagree with in
@@ -31,6 +31,7 @@ writing, not an approved Virtio specification.
 | `virtio-accel-proto` | `core` | Pointer-free, little-endian protocol 1.0 wire structures |
 | `virtio-accel-transport` | `core` | Dependency-free descriptor-chain, queue, reset, and notification ports |
 | `virtio-accel-core` | `core` | Backend lifecycle, memory, program, queue, and event contracts |
+| `virtio-accel-coreml` | macOS `std` | Core ML backend with direct buffers and asynchronous ANE-capable prediction |
 | `virtio-accel-split-queue` | `core + alloc` | Bounded in-memory split-ring reference model |
 | `virtio-accel-guest` | `core + alloc` | Typed reference client with bounded request tracking |
 | `virtio-accel-device` | `core + alloc` | Device-owned state, including bounded generational IDs |
@@ -53,7 +54,8 @@ virtio-accel-guest -----------> virtio-accel-transport
           +--------------------> virtio-accel-proto
 
 virtio-accel-conformance --------------------> virtio-accel-core
-provider adapters --------------------------> virtio-accel-core
+virtio-accel-coreml -------------------------> virtio-accel-core
+other provider adapters --------------------> virtio-accel-core
 ```
 
 The transport crate exposes reset-scoped chain identities, flattened direction/length metadata, and
@@ -73,6 +75,9 @@ The facade is `no_std`. Add the reference backend as a dev-dependency to run the
 [dev-dependencies]
 virtio-accel-mock = "0.1"
 ```
+
+On an ANE-capable Mac, add `virtio-accel-coreml = "0.1"` separately for the host-native Core ML
+backend. It is intentionally not re-exported by the portable facade.
 
 ## Example
 
@@ -206,17 +211,18 @@ optional resource-accounting and progress adapters, and the fault-injection harn
 
 ## Portability
 
-Every crate is `#![forbid(unsafe_code)]`. CI enforces the tier of each crate on
-`aarch64-unknown-none`, `riscv64gc-unknown-none-elf`, and `wasm32-unknown-unknown`, so a crate
-cannot quietly acquire a host dependency.
+Every portable and reference crate is `#![forbid(unsafe_code)]`. The audited Core ML adapter keeps
+its unsafe FFI isolated to macOS. CI enforces each portability tier, including compile-only checks
+of the adapter's unsupported-platform surface.
 
 | Tier | Allowed runtime surface |
 | --- | --- |
 | `core` | `core` only; no allocation |
 | `core + alloc` | `core + alloc`; no OS, filesystem, sockets, threads, or host synchronization |
 | `std` | Portable `std`; no host-OS or vendor-specific API |
+| macOS `std` | Host-native Core ML/Foundation adapter; never a portable default dependency |
 
-Concrete VMM, kernel, OS, and vendor adapters are outside the portable v1 milestone and must not
+Concrete VMM, kernel, OS, and vendor adapters do not change the portable v1 protocol and must not
 become default dependencies of a portable crate. Cargo features must be additive: disabling default
 features may remove convenience behavior, but must never select a different protocol interpretation.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -59,7 +59,9 @@ In scope, in the crates published from this repository:
   across the boundaries described in [docs/threat-model.md](docs/threat-model.md);
 - unbounded resource growth reachable from a bounded guest request; and
 - any breach of the `#![forbid(unsafe_code)]` invariant recorded in
-  [docs/release-policy.md](docs/release-policy.md).
+  [docs/release-policy.md](docs/release-policy.md); and
+- memory-safety, path-containment, direct-backing, or event-publication defects in the audited
+  `virtio-accel-coreml` unsafe boundary.
 
 Out of scope:
 
@@ -70,6 +72,10 @@ Out of scope:
 - The absence of a claimed Virtio device ID. That is deliberate and documented.
 - Vulnerabilities in a downstream VMM, kernel, operating system, or vendor adapter that merely
   depends on these crates. Please report those to the relevant project.
+
+The in-repository Core ML adapter is in scope; it is not considered a downstream vendor adapter.
+Its unsafe invariants and ownership scheme are recorded in
+[`crates/virtio-accel-coreml/SAFETY.md`](crates/virtio-accel-coreml/SAFETY.md).
 
 ## Advisories
 

--- a/ci/check-release-policy.py
+++ b/ci/check-release-policy.py
@@ -25,6 +25,7 @@ PUBLISHED_PACKAGES = {
     "conformance/rust-clean-room": "virtio-accel-cleanroom",
     "crates/virtio-accel-conformance": "virtio-accel-conformance",
     "crates/virtio-accel-core": "virtio-accel-core",
+    "crates/virtio-accel-coreml": "virtio-accel-coreml",
     "crates/virtio-accel-device": "virtio-accel-device",
     "crates/virtio-accel-guest": "virtio-accel-guest",
     "crates/virtio-accel-mock": "virtio-accel-mock",
@@ -33,7 +34,7 @@ PUBLISHED_PACKAGES = {
     "crates/virtio-accel-transport": "virtio-accel-transport",
 }
 
-# Publish metadata that must be inherited from [workspace.package] so ten manifests cannot drift
+# Publish metadata that must be inherited from [workspace.package] so manifests cannot drift
 # apart, mapped to the value the workspace is required to declare. `None` means "any value, but it
 # must be present and inherited".
 INHERITED_PACKAGE_KEYS = {
@@ -65,6 +66,11 @@ CRATE_ROOTS = (
     ROOT / "fuzz" / "src" / "lib.rs",
     *((manifest.parent / "src" / "lib.rs") for manifest in (ROOT / "crates").glob("*/Cargo.toml")),
 )
+
+UNSAFE_AUDITS = {
+    ROOT / "crates" / "virtio-accel-coreml" / "src" / "lib.rs":
+        ROOT / "crates" / "virtio-accel-coreml" / "SAFETY.md",
+}
 
 REQUIRED_LINKS = {
     ROOT / "README.md": (
@@ -147,7 +153,7 @@ def check_manifest(path: pathlib.Path) -> None:
     if not isinstance(description, str) or not description.strip():
         fail(f"{rel(path)} package.description must be present")
 
-    # These ten are published. `publish = false` on any of them is a regression, and an explicit
+    # These packages are published. `publish = false` on any of them is a regression, and an explicit
     # allowlist beats a blanket rule the next new crate would silently join.
     publish = package.get("publish")
     if publish not in (None, True):
@@ -186,8 +192,17 @@ def check_crate_root(path: pathlib.Path) -> None:
     if not path.exists():
         fail(f"missing crate root {rel(path)}")
     text = path.read_text()
-    if "#![forbid(unsafe_code)]" not in text:
+    if "#![forbid(unsafe_code)]" in text:
+        return
+    audit = UNSAFE_AUDITS.get(path)
+    if audit is None or not audit.is_file():
         fail(f"{rel(path)} must keep #![forbid(unsafe_code)] or document an audited exception")
+    if 'cfg_attr(not(target_os = "macos"), forbid(unsafe_code))' not in text:
+        fail(f"{rel(path)} unsafe exception must remain confined to macOS")
+    audit_text = audit.read_text()
+    for required in ("Objective-C bridge", "AlignedAllocation", "atomic two-reference"):
+        if required not in audit_text:
+            fail(f"{rel(audit)} must document the {required!r} unsafe invariant")
 
 
 def check_links() -> None:
@@ -199,7 +214,7 @@ def check_links() -> None:
 
 
 def check_publication_order_agrees() -> None:
-    """The publication order and the published-package allowlist must describe the same ten crates.
+    """The publication order and the published-package allowlist must describe the same crates.
 
     They live in different files for good reasons -- one is an order, the other is a policy -- but a
     crate added to only one of them would either never be published or never be verified.
@@ -233,7 +248,7 @@ def check_publication_order_agrees() -> None:
 
 
 def check_fuzz_stays_unpublished() -> None:
-    """The fuzz harness is a separate workspace and is deliberately not one of the ten."""
+    """The fuzz harness is a separate workspace and is deliberately not published."""
     manifest = ROOT / "fuzz" / "Cargo.toml"
     package = tomllib.loads(manifest.read_text()).get("package", {})
     if package.get("publish") is not False:

--- a/ci/publish-dry-run.py
+++ b/ci/publish-dry-run.py
@@ -51,6 +51,7 @@ PUBLISH_ORDER = (
     "virtio-accel-mock",
     "virtio-accel-device",
     "virtio-accel-conformance",
+    "virtio-accel-coreml",
     "virtio-accel",
 )
 

--- a/conformance/rust-clean-room/README.md
+++ b/conformance/rust-clean-room/README.md
@@ -5,9 +5,9 @@ shared protocol types. It exists to cross-check the primary `zerocopy` ABI: the 
 exchanges bytes only, so the conformance codec never becomes a production dependency.
 
 Part of the [`virtio-accel`](https://github.com/MicroPerceptron/virtio-accel) workspace: an experimental, native-Rust foundation for a
-transport-neutral virtual accelerator device. The workspace contains no Linux ioctls, macOS
-frameworks, Windows APIs, guest physical addresses, vendor command formats, or claimed virtio
-device ID.
+transport-neutral virtual accelerator device. Portable crates contain no host-OS or vendor APIs;
+host integrations live in separate adapter crates and never become their dependencies. The
+project claims no Virtio device ID.
 
 **Portability tier:** `core-only` — `core` only; no `alloc`, no operating system, no host synchronization.
 

--- a/crates/virtio-accel-conformance/README.md
+++ b/crates/virtio-accel-conformance/README.md
@@ -5,9 +5,9 @@ provider target, progress, and optional resource-accounting adapters. Third-part
 authors run this suite to check their implementation against the normative semantics.
 
 Part of the [`virtio-accel`](https://github.com/MicroPerceptron/virtio-accel) workspace: an experimental, native-Rust foundation for a
-transport-neutral virtual accelerator device. The workspace contains no Linux ioctls, macOS
-frameworks, Windows APIs, guest physical addresses, vendor command formats, or claimed virtio
-device ID.
+transport-neutral virtual accelerator device. Portable crates contain no host-OS or vendor APIs;
+host integrations live in separate adapter crates and never become their dependencies. The
+project claims no Virtio device ID.
 
 **Portability tier:** `std-reference` — Portable `std`; no host-OS or vendor-specific API.
 

--- a/crates/virtio-accel-core/README.md
+++ b/crates/virtio-accel-core/README.md
@@ -5,9 +5,9 @@ execution-queue, and event contracts. Provider backends written against this cra
 receive guest addresses or virtqueue descriptors.
 
 Part of the [`virtio-accel`](https://github.com/MicroPerceptron/virtio-accel) workspace: an experimental, native-Rust foundation for a
-transport-neutral virtual accelerator device. The workspace contains no Linux ioctls, macOS
-frameworks, Windows APIs, guest physical addresses, vendor command formats, or claimed virtio
-device ID.
+transport-neutral virtual accelerator device. Portable crates contain no host-OS or vendor APIs;
+host integrations live in separate adapter crates and never become their dependencies. The
+project claims no Virtio device ID.
 
 **Portability tier:** `core-only` — `core` only; no `alloc`, no operating system, no host synchronization.
 

--- a/crates/virtio-accel-coreml/Cargo.toml
+++ b/crates/virtio-accel-coreml/Cargo.toml
@@ -18,4 +18,4 @@ virtio-accel-core.workspace = true
 virtio-accel-conformance.workspace = true
 
 [build-dependencies]
-cc.workspace = true
+cc = "1.2"

--- a/crates/virtio-accel-coreml/Cargo.toml
+++ b/crates/virtio-accel-coreml/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "virtio-accel-coreml"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "macOS Core ML and Apple Neural Engine backend for virtio-accel"
+readme = "README.md"
+
+[dependencies]
+virtio-accel-core.workspace = true
+
+[dev-dependencies]
+virtio-accel-conformance.workspace = true
+
+[build-dependencies]
+cc.workspace = true

--- a/crates/virtio-accel-coreml/LICENSE-APACHE
+++ b/crates/virtio-accel-coreml/LICENSE-APACHE
@@ -1,0 +1,176 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/crates/virtio-accel-coreml/LICENSE-MIT
+++ b/crates/virtio-accel-coreml/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2026 MicroPerceptron contributors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/crates/virtio-accel-coreml/README.md
+++ b/crates/virtio-accel-coreml/README.md
@@ -16,9 +16,10 @@ cross-target dependency checks intact.
 ## Model artifacts
 
 `CoreMlAccelerator::new(model_root)` establishes a host-controlled root. A `CoreMlArtifact` names a
-`.mlmodel` file or `.mlmodelc` directory beneath that root and maps every model input/output feature
-to a virtio-accel slot. Absolute paths, parent traversal, symlink escape, unmapped features, optional
-features, non-`MLMultiArray` features, and incompatible aliased layouts are rejected.
+`.mlmodel` file, `.mlpackage` directory, or `.mlmodelc` directory beneath that root and maps every
+model input/output feature to a virtio-accel slot. Absolute paths, parent traversal, symlink escape,
+unmapped features, optional features, non-`MLMultiArray` features, and incompatible aliased layouts
+are rejected.
 
 ```rust,no_run
 # #[cfg(target_os = "macos")]
@@ -36,28 +37,52 @@ assert!(!artifact.is_empty());
 # }
 ```
 
-Source `.mlmodel` files are compiled synchronously during `load_program`; compiled `.mlmodelc`
-directories load directly. Core ML does not publish a finite model-residency ceiling, so artifacts
-must declare `REQUIRED_RESIDENT_BYTES` (`u64::MAX`). This deliberately forces the device's aggregate
-resident-program policy to opt into one Core ML model instead of pretending an unverifiable smaller
-charge is exact.
+Artifact ABI v1 supports nonoptional `MLMultiArray` features with `Float16`, `Float32`, `Float64`,
+or `Int32` elements. Each feature uses the model constraint's declared default shape; alternate
+flexible shapes are not selected by the artifact. Image, sequence, dictionary, scalar, optional,
+and Core ML state features are rejected at model load rather than failing after admission. The
+model's default function is used for multi-function assets.
+
+Source `.mlmodel` files and `.mlpackage` directories are compiled synchronously during
+`load_program`; compiled `.mlmodelc` directories load directly and are recommended for predictable
+startup latency. Fixed-shape models receive Core ML's infrequent-reshape hint on macOS 14.4+ and the
+fast-prediction specialization strategy on macOS 15+. Core ML does not publish a finite
+model-residency ceiling, so artifacts must declare `REQUIRED_RESIDENT_BYTES` (`u64::MAX`). This
+deliberately forces the device's aggregate resident-program policy to opt into one Core ML model
+instead of pretending an unverifiable smaller charge is exact.
 
 ## Direct buffers and events
 
 The backend advertises host and shared memory. Both are page-aligned provider allocations. Program
 bindings wrap the exact bound range in `MLMultiArray`, and outputs use `MLPredictionOptions` output
-backings. Completion fails with `BackendError::Incompatible` if Core ML returns a different output
-object, so a hidden provider-side result copy is never reported as direct execution.
+backings. Completion verifies the returned output's data pointer, element type, shape, and strides;
+a different Objective-C wrapper over the same exact storage remains valid, while a provider-side
+result allocation fails with `BackendError::Incompatible`. Binding offsets must be aligned for the
+model's scalar type.
 
 Prediction uses Core ML's asynchronous completion API. Events retain every Rust allocation until
-the native callback reaches a terminal state. Event cancellation is not advertised because Core ML
-does not expose cancellation for an admitted prediction.
+the native callback reaches a terminal state. Separate predictions may reuse a read-only input
+allocation concurrently; any output or read-write binding retains exclusive native access. Host
+transfers return `BackendError::Busy` while either access mode is active. Event cancellation is not
+advertised because Core ML does not expose cancellation for an admitted prediction.
+
+Submission sorts its bounded binding metadata once (`O(b log b)`) and the native bridge then performs
+a linear validation and wrapping pass. It never copies tensor contents. Cumulative direct-binding
+admissions and explicit-transfer bytes are available through `direct_binding_admissions()` and
+`explicit_transfer_bytes()`.
 
 The FFI and allocation invariants are documented in [SAFETY.md](SAFETY.md). Run the native
 end-to-end and conformance tests on an ANE-capable Mac with:
 
 ```sh
 cargo test -p virtio-accel-coreml
+```
+
+For local warm-path latency evidence, run the ignored release-mode measurement:
+
+```sh
+cargo test --release -p virtio-accel-coreml \
+  measures_warm_submission_and_completion_latency -- --ignored --nocapture
 ```
 
 ## License

--- a/crates/virtio-accel-coreml/README.md
+++ b/crates/virtio-accel-coreml/README.md
@@ -1,0 +1,66 @@
+# virtio-accel-coreml
+
+A host-native [`virtio_accel_core::Accelerator`](https://docs.rs/virtio-accel-core)
+implementation for Apple's Core ML runtime and Neural Engine.
+
+The backend requires macOS 14 or newer and refuses construction when Core ML does not report an
+accessible `MLNeuralEngineComputeDevice`. Models are loaded with
+`MLComputeUnitsCPUAndNeuralEngine`, which gives Core ML access to the ANE without permitting GPU
+placement. Apple still decides placement per operation; a model containing unsupported ANE
+operations can fall back to the CPU.
+
+**Portability tier:** `host-native` — the real implementation is macOS-only. Other targets compile
+a placeholder constructor that returns `InitError::UnsupportedPlatform`, keeping workspace and
+cross-target dependency checks intact.
+
+## Model artifacts
+
+`CoreMlAccelerator::new(model_root)` establishes a host-controlled root. A `CoreMlArtifact` names a
+`.mlmodel` file or `.mlmodelc` directory beneath that root and maps every model input/output feature
+to a virtio-accel slot. Absolute paths, parent traversal, symlink escape, unmapped features, optional
+features, non-`MLMultiArray` features, and incompatible aliased layouts are rejected.
+
+```rust,no_run
+# #[cfg(target_os = "macos")]
+# fn example() -> Result<(), Box<dyn std::error::Error>> {
+use virtio_accel_coreml::CoreMlArtifact;
+
+let artifact = CoreMlArtifact::new("models/TwicePlusOne.mlmodel")?
+    .map_input(7, "x")?
+    .map_output(7, "y")?
+    .encode()?;
+
+// Input x and output y share slot 7, so submissions bind one ReadWrite range.
+assert!(!artifact.is_empty());
+# Ok(())
+# }
+```
+
+Source `.mlmodel` files are compiled synchronously during `load_program`; compiled `.mlmodelc`
+directories load directly. Core ML does not publish a finite model-residency ceiling, so artifacts
+must declare `REQUIRED_RESIDENT_BYTES` (`u64::MAX`). This deliberately forces the device's aggregate
+resident-program policy to opt into one Core ML model instead of pretending an unverifiable smaller
+charge is exact.
+
+## Direct buffers and events
+
+The backend advertises host and shared memory. Both are page-aligned provider allocations. Program
+bindings wrap the exact bound range in `MLMultiArray`, and outputs use `MLPredictionOptions` output
+backings. Completion fails with `BackendError::Incompatible` if Core ML returns a different output
+object, so a hidden provider-side result copy is never reported as direct execution.
+
+Prediction uses Core ML's asynchronous completion API. Events retain every Rust allocation until
+the native callback reaches a terminal state. Event cancellation is not advertised because Core ML
+does not expose cancellation for an admitted prediction.
+
+The FFI and allocation invariants are documented in [SAFETY.md](SAFETY.md). Run the native
+end-to-end and conformance tests on an ANE-capable Mac with:
+
+```sh
+cargo test -p virtio-accel-coreml
+```
+
+## License
+
+Licensed under either of [Apache License, Version 2.0](LICENSE-APACHE) or
+[MIT license](LICENSE-MIT) at your option.

--- a/crates/virtio-accel-coreml/SAFETY.md
+++ b/crates/virtio-accel-coreml/SAFETY.md
@@ -18,13 +18,17 @@ release-store to the event status; polling uses an acquire-load before Rust read
 
 `AlignedAllocation` owns exactly one `std::alloc::Layout`. Its pointer is non-null, is deallocated
 with the same layout, and is kept alive by completion-owned `Arc` clones. `CoreMlBuffer` is
-deliberately neither `Send` nor `Sync`, and an atomic in-flight gate rejects host transfers and a
-second submission until Core ML has stopped accessing the allocation. The completion callback drops
-its backing guards before publishing the terminal event state, so a successful acquire-poll makes
-the output bytes available to the next host transfer. The backend never creates public slices or
-raw-pointer accessors. A direct trait user can drop handles early without causing a dangling native
-pointer because the completion-owned `Arc`s outlive prediction.
+deliberately neither `Send` nor `Sync`. Its atomic in-flight state admits multiple native readers or
+one native writer, rejects host transfers while either mode is active, and rejects every conflicting
+submission. Multiple bindings from one event to the same allocation are collapsed to the strongest
+required access before acquiring a guard. The completion callback drops its backing guards before
+publishing the terminal event state, so a successful acquire-poll makes the output bytes available
+to the next host transfer. The backend never creates public slices or raw-pointer accessors. A
+direct trait user can drop handles early without causing a dangling native pointer because the
+completion-owned `Arc`s outlive prediction.
 
 Core ML receives `MLMultiArray` objects with a no-op deallocator because Rust owns the backing. The
-bridge verifies output object identity before reporting completion, making it an execution failure
-if Core ML declines the proposed direct output backing.
+bridge validates scalar alignment before exposing a bound pointer and verifies the output data
+pointer, element type, shape, and strides before reporting completion. A different Objective-C
+wrapper over the same storage is safe; declining the exact proposed output storage is an execution
+failure.

--- a/crates/virtio-accel-coreml/SAFETY.md
+++ b/crates/virtio-accel-coreml/SAFETY.md
@@ -1,0 +1,30 @@
+# Unsafe-code audit
+
+This crate is the single host-native exception to the portable workspace's `forbid(unsafe_code)`
+rule. Unsafe Rust is confined to `src/macos.rs` and has three responsibilities:
+
+1. declaring and calling the audited C ABI in `native/coreml_bridge.h`;
+2. owning page-aligned allocations made through `std::alloc`; and
+3. exposing those allocations as slices only while the `Accelerator` contract supplies the
+   required exclusive or terminal-event access.
+
+The Objective-C bridge uses ARC for Core ML/Foundation objects. Native model pointers cross the ABI
+with one retained reference. Native event pointers use an atomic two-reference scheme: one reference
+belongs to Rust and one to Core ML's completion block, so dropping a Rust event early cannot free
+memory still used by the callback. The submitted backing guards are boxed and owned by that native
+completion block through a C callback, independently of the Rust event handle; the callback drops
+them exactly once before publishing a terminal state. Completion publishes buffer writes before its
+release-store to the event status; polling uses an acquire-load before Rust reads output bytes.
+
+`AlignedAllocation` owns exactly one `std::alloc::Layout`. Its pointer is non-null, is deallocated
+with the same layout, and is kept alive by completion-owned `Arc` clones. `CoreMlBuffer` is
+deliberately neither `Send` nor `Sync`, and an atomic in-flight gate rejects host transfers and a
+second submission until Core ML has stopped accessing the allocation. The completion callback drops
+its backing guards before publishing the terminal event state, so a successful acquire-poll makes
+the output bytes available to the next host transfer. The backend never creates public slices or
+raw-pointer accessors. A direct trait user can drop handles early without causing a dangling native
+pointer because the completion-owned `Arc`s outlive prediction.
+
+Core ML receives `MLMultiArray` objects with a no-op deallocator because Rust owns the backing. The
+bridge verifies output object identity before reporting completion, making it an execution failure
+if Core ML declines the proposed direct output backing.

--- a/crates/virtio-accel-coreml/build.rs
+++ b/crates/virtio-accel-coreml/build.rs
@@ -1,6 +1,8 @@
 #![forbid(unsafe_code)]
 
 use std::env;
+use std::path::PathBuf;
+use std::process::Command;
 
 fn main() {
     println!("cargo:rerun-if-changed=native/coreml_bridge.h");
@@ -18,6 +20,35 @@ fn main() {
         .flag("-mmacosx-version-min=14.0")
         .warnings(true)
         .compile("virtio_accel_coreml_bridge");
+
+    // Apple's linker requires Mach-O members to begin at an 8-byte archive offset. The generic
+    // archiver selected by `cc` only guarantees the traditional 2-byte alignment, so whether a
+    // bridge links would otherwise depend on the preceding member sizes. Re-archive with Apple's
+    // `libtool`, which records the required member alignment deterministically.
+    let output = PathBuf::from(env::var_os("OUT_DIR").expect("Cargo must provide OUT_DIR"));
+    let archive = output.join("libvirtio_accel_coreml_bridge.a");
+    let aligned_archive = output.join("libvirtio_accel_coreml_bridge.aligned.a");
+    let object = std::fs::read_dir(&output)
+        .expect("failed to inspect native build output")
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .find(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.ends_with("-coreml_bridge.o"))
+        })
+        .expect("cc did not produce the Core ML bridge object");
+    let status = Command::new("xcrun")
+        .args(["libtool", "-static", "-o"])
+        .arg(&aligned_archive)
+        .arg(object)
+        .status()
+        .expect("failed to launch xcrun libtool");
+    assert!(
+        status.success(),
+        "xcrun libtool failed to align bridge archive"
+    );
+    std::fs::rename(aligned_archive, archive).expect("failed to install aligned bridge archive");
 
     println!("cargo:rustc-link-lib=framework=CoreML");
     println!("cargo:rustc-link-lib=framework=Foundation");

--- a/crates/virtio-accel-coreml/build.rs
+++ b/crates/virtio-accel-coreml/build.rs
@@ -1,0 +1,24 @@
+#![forbid(unsafe_code)]
+
+use std::env;
+
+fn main() {
+    println!("cargo:rerun-if-changed=native/coreml_bridge.h");
+    println!("cargo:rerun-if-changed=native/coreml_bridge.m");
+
+    if env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("macos") {
+        return;
+    }
+
+    cc::Build::new()
+        .file("native/coreml_bridge.m")
+        .flag("-fobjc-arc")
+        .flag("-fblocks")
+        .flag("-fmodules")
+        .flag("-mmacosx-version-min=14.0")
+        .warnings(true)
+        .compile("virtio_accel_coreml_bridge");
+
+    println!("cargo:rustc-link-lib=framework=CoreML");
+    println!("cargo:rustc-link-lib=framework=Foundation");
+}

--- a/crates/virtio-accel-coreml/native/coreml_bridge.h
+++ b/crates/virtio-accel-coreml/native/coreml_bridge.h
@@ -1,0 +1,79 @@
+#ifndef VIRTIO_ACCEL_COREML_BRIDGE_H
+#define VIRTIO_ACCEL_COREML_BRIDGE_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+enum va_coreml_error_kind {
+    VA_COREML_OK = 0,
+    VA_COREML_UNSUPPORTED = 1,
+    VA_COREML_INCOMPATIBLE = 2,
+    VA_COREML_INVALID_ARGUMENT = 3,
+    VA_COREML_OUT_OF_BOUNDS = 4,
+    VA_COREML_OUT_OF_MEMORY = 5,
+    VA_COREML_RESOURCE_LIMIT = 6,
+    VA_COREML_DEVICE_LOST = 7,
+    VA_COREML_EXTERNAL = 8,
+};
+
+enum va_coreml_feature_role {
+    VA_COREML_INPUT = 1,
+    VA_COREML_OUTPUT = 2,
+};
+
+enum va_coreml_access_mode {
+    VA_COREML_READ = 1,
+    VA_COREML_WRITE = 2,
+    VA_COREML_READ_WRITE = 3,
+};
+
+enum va_coreml_event_status {
+    VA_COREML_EVENT_PENDING = 0,
+    VA_COREML_EVENT_COMPLETE = 1,
+    VA_COREML_EVENT_FAILED = 2,
+};
+
+struct va_coreml_error {
+    uint32_t kind;
+    uint32_t domain;
+    int64_t code;
+};
+
+struct va_coreml_feature_mapping {
+    uint32_t slot;
+    uint8_t role;
+    const uint8_t *name;
+    size_t name_len;
+};
+
+struct va_coreml_binding {
+    uint32_t slot;
+    uint8_t access;
+    void *data;
+    uint64_t bytes;
+};
+
+typedef void (*va_coreml_release_context_fn)(void *context);
+
+int va_coreml_has_neural_engine(void);
+
+void *va_coreml_model_load(const uint8_t *path,
+                           size_t path_len,
+                           const struct va_coreml_feature_mapping *mappings,
+                           size_t mapping_count,
+                           struct va_coreml_error *error);
+
+void va_coreml_model_release(void *model);
+
+void *va_coreml_submit(void *model,
+                       const struct va_coreml_binding *bindings,
+                       size_t binding_count,
+                       void *context,
+                       va_coreml_release_context_fn release_context,
+                       struct va_coreml_error *error);
+
+uint32_t va_coreml_event_poll(void *event, struct va_coreml_error *error);
+
+void va_coreml_event_release(void *event);
+
+#endif

--- a/crates/virtio-accel-coreml/native/coreml_bridge.m
+++ b/crates/virtio-accel-coreml/native/coreml_bridge.m
@@ -1,0 +1,492 @@
+#import "coreml_bridge.h"
+
+#import <CoreML/CoreML.h>
+#import <CoreML/MLModel+MLComputeDevice.h>
+#import <CoreML/MLModel+MLModelCompilation.h>
+#import <CoreML/MLNeuralEngineComputeDevice.h>
+#import <Foundation/Foundation.h>
+#include <stdatomic.h>
+
+static const uint32_t VA_COREML_BRIDGE_DOMAIN = 0x434d4c42;
+static const uint32_t VA_COREML_NSError_DOMAIN = 0x434d4c45;
+
+@interface VAFeatureSpec : NSObject
+@property(nonatomic) uint32_t slot;
+@property(nonatomic) uint8_t role;
+@property(nonatomic, copy) NSString *name;
+@property(nonatomic, copy) NSArray<NSNumber *> *shape;
+@property(nonatomic, copy) NSArray<NSNumber *> *strides;
+@property(nonatomic) MLMultiArrayDataType dataType;
+@property(nonatomic) uint64_t bytes;
+@end
+
+@implementation VAFeatureSpec
+@end
+
+@interface VAProgram : NSObject
+@property(nonatomic, strong) MLModel *model;
+@property(nonatomic, copy) NSArray<VAFeatureSpec *> *features;
+@property(nonatomic, copy) NSSet<NSNumber *> *slots;
+@property(nonatomic, strong, nullable) NSURL *temporaryCompiledURL;
+@end
+
+@implementation VAProgram
+- (void)dealloc {
+    if (_temporaryCompiledURL != nil) {
+        [[NSFileManager defaultManager] removeItemAtURL:_temporaryCompiledURL error:nil];
+    }
+}
+@end
+
+struct VAEvent {
+    _Atomic uint32_t references;
+    _Atomic uint32_t status;
+    _Atomic uint32_t error_kind;
+    _Atomic uint32_t error_domain;
+    _Atomic int64_t error_code;
+};
+
+static void va_set_error(struct va_coreml_error *error,
+                         uint32_t kind,
+                         uint32_t domain,
+                         int64_t code) {
+    if (error != NULL) {
+        error->kind = kind;
+        error->domain = domain;
+        error->code = code;
+    }
+}
+
+static uint32_t va_hash_domain(NSString *domain) {
+    const char *bytes = domain.UTF8String;
+    if (bytes == NULL) {
+        return VA_COREML_NSError_DOMAIN;
+    }
+    uint32_t hash = 2166136261u;
+    for (const unsigned char *cursor = (const unsigned char *)bytes; *cursor != 0; cursor++) {
+        hash ^= *cursor;
+        hash *= 16777619u;
+    }
+    return hash == 0 ? VA_COREML_NSError_DOMAIN : hash;
+}
+
+static void va_set_nserror(struct va_coreml_error *target, NSError *error) {
+    if (error == nil) {
+        va_set_error(target, VA_COREML_EXTERNAL, VA_COREML_NSError_DOMAIN, 0);
+        return;
+    }
+    va_set_error(target, VA_COREML_EXTERNAL, va_hash_domain(error.domain), error.code);
+}
+
+static void va_event_release_inner(struct VAEvent *event) {
+    if (event != NULL && atomic_fetch_sub_explicit(&event->references, 1, memory_order_acq_rel) == 1) {
+        free(event);
+    }
+}
+
+static struct VAEvent *va_event_create(struct va_coreml_error *error) {
+    struct VAEvent *event = calloc(1, sizeof(struct VAEvent));
+    if (event == NULL) {
+        va_set_error(error, VA_COREML_OUT_OF_MEMORY, VA_COREML_BRIDGE_DOMAIN, 0);
+        return NULL;
+    }
+    atomic_init(&event->references, 2);
+    atomic_init(&event->status, VA_COREML_EVENT_PENDING);
+    atomic_init(&event->error_kind, VA_COREML_OK);
+    atomic_init(&event->error_domain, 0);
+    atomic_init(&event->error_code, 0);
+    return event;
+}
+
+int va_coreml_has_neural_engine(void) {
+    @autoreleasepool {
+        if (@available(macOS 14.0, *)) {
+            for (id device in MLModel.availableComputeDevices) {
+                if ([device isKindOfClass:MLNeuralEngineComputeDevice.class]) {
+                    return 1;
+                }
+            }
+        }
+        return 0;
+    }
+}
+
+static NSString *va_string(const uint8_t *bytes, size_t length) {
+    if (bytes == NULL || length == 0 || length > NSIntegerMax) {
+        return nil;
+    }
+    return [[NSString alloc] initWithBytes:bytes length:length encoding:NSUTF8StringEncoding];
+}
+
+static BOOL va_data_type_size(MLMultiArrayDataType type, uint64_t *size) {
+    switch (type) {
+    case MLMultiArrayDataTypeDouble:
+        *size = 8;
+        return YES;
+    case MLMultiArrayDataTypeFloat32:
+    case MLMultiArrayDataTypeInt32:
+        *size = 4;
+        return YES;
+    case MLMultiArrayDataTypeFloat16:
+        *size = 2;
+        return YES;
+    default:
+        return NO;
+    }
+}
+
+static VAFeatureSpec *va_feature_spec(MLFeatureDescription *description,
+                                      uint32_t slot,
+                                      uint8_t role,
+                                      struct va_coreml_error *error) {
+    if (description == nil || description.type != MLFeatureTypeMultiArray || description.optional) {
+        va_set_error(error, VA_COREML_UNSUPPORTED, VA_COREML_BRIDGE_DOMAIN, 1);
+        return nil;
+    }
+    MLMultiArrayConstraint *constraint = description.multiArrayConstraint;
+    if (constraint == nil || constraint.shape.count == 0) {
+        va_set_error(error, VA_COREML_UNSUPPORTED, VA_COREML_BRIDGE_DOMAIN, 2);
+        return nil;
+    }
+
+    uint64_t elementSize = 0;
+    if (!va_data_type_size(constraint.dataType, &elementSize)) {
+        va_set_error(error, VA_COREML_UNSUPPORTED, VA_COREML_BRIDGE_DOMAIN, 3);
+        return nil;
+    }
+
+    uint64_t elements = 1;
+    NSMutableArray<NSNumber *> *strides = [NSMutableArray arrayWithCapacity:constraint.shape.count];
+    for (NSNumber *dimension in constraint.shape.reverseObjectEnumerator) {
+        NSInteger value = dimension.integerValue;
+        if (value <= 0 || elements > UINT64_MAX / (uint64_t)value) {
+            va_set_error(error, VA_COREML_RESOURCE_LIMIT, VA_COREML_BRIDGE_DOMAIN, 4);
+            return nil;
+        }
+        [strides insertObject:@(elements) atIndex:0];
+        elements *= (uint64_t)value;
+    }
+    if (elements > UINT64_MAX / elementSize) {
+        va_set_error(error, VA_COREML_RESOURCE_LIMIT, VA_COREML_BRIDGE_DOMAIN, 5);
+        return nil;
+    }
+
+    VAFeatureSpec *spec = [VAFeatureSpec new];
+    spec.slot = slot;
+    spec.role = role;
+    spec.name = description.name;
+    spec.shape = constraint.shape;
+    spec.strides = strides;
+    spec.dataType = constraint.dataType;
+    spec.bytes = elements * elementSize;
+    return spec;
+}
+
+static BOOL va_same_layout(VAFeatureSpec *left, VAFeatureSpec *right) {
+    return left.bytes == right.bytes && left.dataType == right.dataType &&
+           [left.shape isEqualToArray:right.shape] && [left.strides isEqualToArray:right.strides];
+}
+
+void *va_coreml_model_load(const uint8_t *path,
+                           size_t path_len,
+                           const struct va_coreml_feature_mapping *mappings,
+                           size_t mapping_count,
+                           struct va_coreml_error *error) {
+    @autoreleasepool {
+        va_set_error(error, VA_COREML_OK, 0, 0);
+        if (mappings == NULL || mapping_count == 0) {
+            va_set_error(error, VA_COREML_INVALID_ARGUMENT, VA_COREML_BRIDGE_DOMAIN, 6);
+            return NULL;
+        }
+        NSString *pathString = va_string(path, path_len);
+        if (pathString == nil) {
+            va_set_error(error, VA_COREML_INVALID_ARGUMENT, VA_COREML_BRIDGE_DOMAIN, 7);
+            return NULL;
+        }
+
+        @try {
+            NSURL *sourceURL = [NSURL fileURLWithPath:pathString];
+            NSURL *modelURL = sourceURL;
+            NSURL *temporaryURL = nil;
+            NSError *nativeError = nil;
+            if ([sourceURL.pathExtension.lowercaseString isEqualToString:@"mlmodel"]) {
+                modelURL = [MLModel compileModelAtURL:sourceURL error:&nativeError];
+                if (modelURL == nil) {
+                    va_set_nserror(error, nativeError);
+                    return NULL;
+                }
+                temporaryURL = modelURL;
+            } else if (![sourceURL.pathExtension.lowercaseString isEqualToString:@"mlmodelc"]) {
+                va_set_error(error, VA_COREML_UNSUPPORTED, VA_COREML_BRIDGE_DOMAIN, 8);
+                return NULL;
+            }
+
+            MLModelConfiguration *configuration = [MLModelConfiguration new];
+            configuration.computeUnits = MLComputeUnitsCPUAndNeuralEngine;
+            MLModel *model = [MLModel modelWithContentsOfURL:modelURL
+                                              configuration:configuration
+                                                      error:&nativeError];
+            if (model == nil) {
+                if (temporaryURL != nil) {
+                    [[NSFileManager defaultManager] removeItemAtURL:temporaryURL error:nil];
+                }
+                va_set_nserror(error, nativeError);
+                return NULL;
+            }
+            VAProgram *program = [VAProgram new];
+            program.model = model;
+            program.temporaryCompiledURL = temporaryURL;
+
+            NSDictionary<NSString *, MLFeatureDescription *> *inputs =
+                model.modelDescription.inputDescriptionsByName;
+            NSDictionary<NSString *, MLFeatureDescription *> *outputs =
+                model.modelDescription.outputDescriptionsByName;
+            if (mapping_count != inputs.count + outputs.count) {
+                va_set_error(error, VA_COREML_INCOMPATIBLE, VA_COREML_BRIDGE_DOMAIN, 9);
+                return NULL;
+            }
+
+            NSMutableArray<VAFeatureSpec *> *features = [NSMutableArray arrayWithCapacity:mapping_count];
+            NSMutableSet<NSString *> *mappedInputs = [NSMutableSet set];
+            NSMutableSet<NSString *> *mappedOutputs = [NSMutableSet set];
+            NSMutableSet<NSNumber *> *slots = [NSMutableSet set];
+            for (size_t index = 0; index < mapping_count; index++) {
+                const struct va_coreml_feature_mapping *mapping = &mappings[index];
+                NSString *name = va_string(mapping->name, mapping->name_len);
+                if (name == nil) {
+                    va_set_error(error, VA_COREML_INVALID_ARGUMENT, VA_COREML_BRIDGE_DOMAIN, 10);
+                    return NULL;
+                }
+                MLFeatureDescription *description = nil;
+                NSMutableSet<NSString *> *mapped = nil;
+                if (mapping->role == VA_COREML_INPUT) {
+                    description = inputs[name];
+                    mapped = mappedInputs;
+                } else if (mapping->role == VA_COREML_OUTPUT) {
+                    description = outputs[name];
+                    mapped = mappedOutputs;
+                } else {
+                    va_set_error(error, VA_COREML_INVALID_ARGUMENT, VA_COREML_BRIDGE_DOMAIN, 11);
+                    return NULL;
+                }
+                if (description == nil || [mapped containsObject:name]) {
+                    va_set_error(error, VA_COREML_INCOMPATIBLE, VA_COREML_BRIDGE_DOMAIN, 12);
+                    return NULL;
+                }
+                VAFeatureSpec *spec = va_feature_spec(description, mapping->slot, mapping->role, error);
+                if (spec == nil) {
+                    return NULL;
+                }
+                [mapped addObject:name];
+                [slots addObject:@(mapping->slot)];
+                [features addObject:spec];
+            }
+            if (mappedInputs.count != inputs.count || mappedOutputs.count != outputs.count) {
+                va_set_error(error, VA_COREML_INCOMPATIBLE, VA_COREML_BRIDGE_DOMAIN, 13);
+                return NULL;
+            }
+            for (VAFeatureSpec *left in features) {
+                for (VAFeatureSpec *right in features) {
+                    if (left != right && left.slot == right.slot && !va_same_layout(left, right)) {
+                        va_set_error(error, VA_COREML_INCOMPATIBLE, VA_COREML_BRIDGE_DOMAIN, 14);
+                        return NULL;
+                    }
+                }
+            }
+
+            program.features = features;
+            program.slots = slots;
+            return (__bridge_retained void *)program;
+        } @catch (NSException *exception) {
+            va_set_error(error, VA_COREML_EXTERNAL, VA_COREML_BRIDGE_DOMAIN, 15);
+            return NULL;
+        }
+    }
+}
+
+void va_coreml_model_release(void *model) {
+    if (model != NULL) {
+        @autoreleasepool {
+            CFBridgingRelease(model);
+        }
+    }
+}
+
+static const struct va_coreml_binding *va_binding_for_slot(
+    const struct va_coreml_binding *bindings, size_t binding_count, uint32_t slot) {
+    for (size_t index = 0; index < binding_count; index++) {
+        if (bindings[index].slot == slot) {
+            return &bindings[index];
+        }
+    }
+    return NULL;
+}
+
+static uint8_t va_access_for_slot(NSArray<VAFeatureSpec *> *features, uint32_t slot) {
+    BOOL reads = NO;
+    BOOL writes = NO;
+    for (VAFeatureSpec *feature in features) {
+        if (feature.slot == slot) {
+            reads |= feature.role == VA_COREML_INPUT;
+            writes |= feature.role == VA_COREML_OUTPUT;
+        }
+    }
+    if (reads && writes) {
+        return VA_COREML_READ_WRITE;
+    }
+    return reads ? VA_COREML_READ : VA_COREML_WRITE;
+}
+
+void *va_coreml_submit(void *model,
+                       const struct va_coreml_binding *bindings,
+                       size_t binding_count,
+                       void *context,
+                       va_coreml_release_context_fn release_context,
+                       struct va_coreml_error *error) {
+    struct VAEvent *eventForException = NULL;
+    @autoreleasepool {
+        va_set_error(error, VA_COREML_OK, 0, 0);
+        if (model == NULL || bindings == NULL || context == NULL || release_context == NULL) {
+            va_set_error(error, VA_COREML_INVALID_ARGUMENT, VA_COREML_BRIDGE_DOMAIN, 16);
+            return NULL;
+        }
+        VAProgram *program = (__bridge VAProgram *)model;
+        if (binding_count != program.slots.count) {
+            va_set_error(error, VA_COREML_INCOMPATIBLE, VA_COREML_BRIDGE_DOMAIN, 17);
+            return NULL;
+        }
+        for (NSNumber *slotNumber in program.slots) {
+            uint32_t slot = slotNumber.unsignedIntValue;
+            const struct va_coreml_binding *binding =
+                va_binding_for_slot(bindings, binding_count, slot);
+            if (binding == NULL || binding->access != va_access_for_slot(program.features, slot)) {
+                va_set_error(error, VA_COREML_INCOMPATIBLE, VA_COREML_BRIDGE_DOMAIN, 18);
+                return NULL;
+            }
+        }
+
+        @try {
+            NSError *nativeError = nil;
+            NSMutableDictionary<NSString *, MLFeatureValue *> *inputValues = [NSMutableDictionary dictionary];
+            NSMutableDictionary<NSString *, MLMultiArray *> *outputBackings = [NSMutableDictionary dictionary];
+            NSMutableArray<VAFeatureSpec *> *outputFeatures = [NSMutableArray array];
+            for (VAFeatureSpec *feature in program.features) {
+                const struct va_coreml_binding *binding =
+                    va_binding_for_slot(bindings, binding_count, feature.slot);
+                if (binding == NULL || binding->data == NULL || binding->bytes != feature.bytes) {
+                    va_set_error(error, VA_COREML_INCOMPATIBLE, VA_COREML_BRIDGE_DOMAIN, 19);
+                    return NULL;
+                }
+                MLMultiArray *array = [[MLMultiArray alloc] initWithDataPointer:binding->data
+                                                                          shape:feature.shape
+                                                                       dataType:feature.dataType
+                                                                        strides:feature.strides
+                                                                    deallocator:nil
+                                                                          error:&nativeError];
+                if (array == nil) {
+                    va_set_nserror(error, nativeError);
+                    return NULL;
+                }
+                if (feature.role == VA_COREML_INPUT) {
+                    inputValues[feature.name] = [MLFeatureValue featureValueWithMultiArray:array];
+                } else {
+                    outputBackings[feature.name] = array;
+                    [outputFeatures addObject:feature];
+                }
+            }
+
+            MLDictionaryFeatureProvider *provider =
+                [[MLDictionaryFeatureProvider alloc] initWithDictionary:inputValues error:&nativeError];
+            if (provider == nil) {
+                va_set_nserror(error, nativeError);
+                return NULL;
+            }
+            MLPredictionOptions *options = [MLPredictionOptions new];
+            options.outputBackings = outputBackings;
+            eventForException = va_event_create(error);
+            if (eventForException == NULL) {
+                return NULL;
+            }
+            struct VAEvent *event = eventForException;
+
+            [program.model predictionFromFeatures:provider
+                                          options:options
+                                completionHandler:^(id<MLFeatureProvider> output, NSError *predictionError) {
+                uint32_t terminalStatus = VA_COREML_EVENT_COMPLETE;
+                @try {
+                    if (predictionError != nil || output == nil) {
+                        atomic_store_explicit(&event->error_kind,
+                                              VA_COREML_EXTERNAL,
+                                              memory_order_relaxed);
+                        atomic_store_explicit(&event->error_domain,
+                                              va_hash_domain(predictionError.domain),
+                                              memory_order_relaxed);
+                        atomic_store_explicit(&event->error_code,
+                                              predictionError.code,
+                                              memory_order_relaxed);
+                        terminalStatus = VA_COREML_EVENT_FAILED;
+                    } else {
+                        for (VAFeatureSpec *feature in outputFeatures) {
+                            MLMultiArray *actual =
+                                [output featureValueForName:feature.name].multiArrayValue;
+                            if (actual != outputBackings[feature.name]) {
+                                atomic_store_explicit(&event->error_kind,
+                                                      VA_COREML_INCOMPATIBLE,
+                                                      memory_order_relaxed);
+                                atomic_store_explicit(&event->error_domain,
+                                                      VA_COREML_BRIDGE_DOMAIN,
+                                                      memory_order_relaxed);
+                                atomic_store_explicit(&event->error_code, 20, memory_order_relaxed);
+                                terminalStatus = VA_COREML_EVENT_FAILED;
+                                break;
+                            }
+                        }
+                    }
+                } @catch (NSException *exception) {
+                    atomic_store_explicit(&event->error_kind,
+                                          VA_COREML_EXTERNAL,
+                                          memory_order_relaxed);
+                    atomic_store_explicit(&event->error_domain,
+                                          VA_COREML_BRIDGE_DOMAIN,
+                                          memory_order_relaxed);
+                    atomic_store_explicit(&event->error_code, 23, memory_order_relaxed);
+                    terminalStatus = VA_COREML_EVENT_FAILED;
+                }
+                release_context(context);
+                atomic_store_explicit(&event->status, terminalStatus, memory_order_release);
+                va_event_release_inner(event);
+            }];
+            eventForException = NULL;
+            return event;
+        } @catch (NSException *exception) {
+            if (eventForException != NULL) {
+                va_event_release_inner(eventForException);
+                va_event_release_inner(eventForException);
+            }
+            va_set_error(error, VA_COREML_EXTERNAL, VA_COREML_BRIDGE_DOMAIN, 21);
+            return NULL;
+        }
+    }
+}
+
+uint32_t va_coreml_event_poll(void *opaque, struct va_coreml_error *error) {
+    struct VAEvent *event = opaque;
+    if (event == NULL) {
+        va_set_error(error, VA_COREML_INVALID_ARGUMENT, VA_COREML_BRIDGE_DOMAIN, 22);
+        return VA_COREML_EVENT_FAILED;
+    }
+    uint32_t status = atomic_load_explicit(&event->status, memory_order_acquire);
+    if (status == VA_COREML_EVENT_FAILED) {
+        va_set_error(error,
+                     atomic_load_explicit(&event->error_kind, memory_order_relaxed),
+                     atomic_load_explicit(&event->error_domain, memory_order_relaxed),
+                     atomic_load_explicit(&event->error_code, memory_order_relaxed));
+    } else {
+        va_set_error(error, VA_COREML_OK, 0, 0);
+    }
+    return status;
+}
+
+void va_coreml_event_release(void *event) {
+    va_event_release_inner(event);
+}

--- a/crates/virtio-accel-coreml/native/coreml_bridge.m
+++ b/crates/virtio-accel-coreml/native/coreml_bridge.m
@@ -17,16 +17,27 @@ static const uint32_t VA_COREML_NSError_DOMAIN = 0x434d4c45;
 @property(nonatomic, copy) NSArray<NSNumber *> *shape;
 @property(nonatomic, copy) NSArray<NSNumber *> *strides;
 @property(nonatomic) MLMultiArrayDataType dataType;
+@property(nonatomic) uint64_t elementSize;
 @property(nonatomic) uint64_t bytes;
+@property(nonatomic) NSUInteger bindingIndex;
 @end
 
 @implementation VAFeatureSpec
 @end
 
+@interface VASlotSpec : NSObject
+@property(nonatomic) uint32_t slot;
+@property(nonatomic) uint8_t access;
+@end
+
+@implementation VASlotSpec
+@end
+
 @interface VAProgram : NSObject
 @property(nonatomic, strong) MLModel *model;
-@property(nonatomic, copy) NSArray<VAFeatureSpec *> *features;
-@property(nonatomic, copy) NSSet<NSNumber *> *slots;
+@property(nonatomic, copy) NSArray<VAFeatureSpec *> *inputFeatures;
+@property(nonatomic, copy) NSArray<VAFeatureSpec *> *outputFeatures;
+@property(nonatomic, copy) NSArray<VASlotSpec *> *slots;
 @property(nonatomic, strong, nullable) NSURL *temporaryCompiledURL;
 @end
 
@@ -178,6 +189,7 @@ static VAFeatureSpec *va_feature_spec(MLFeatureDescription *description,
     spec.shape = constraint.shape;
     spec.strides = strides;
     spec.dataType = constraint.dataType;
+    spec.elementSize = elementSize;
     spec.bytes = elements * elementSize;
     return spec;
 }
@@ -185,6 +197,21 @@ static VAFeatureSpec *va_feature_spec(MLFeatureDescription *description,
 static BOOL va_same_layout(VAFeatureSpec *left, VAFeatureSpec *right) {
     return left.bytes == right.bytes && left.dataType == right.dataType &&
            [left.shape isEqualToArray:right.shape] && [left.strides isEqualToArray:right.strides];
+}
+
+static uint8_t va_access_for_slot(NSArray<VAFeatureSpec *> *features, uint32_t slot) {
+    BOOL reads = NO;
+    BOOL writes = NO;
+    for (VAFeatureSpec *feature in features) {
+        if (feature.slot == slot) {
+            reads |= feature.role == VA_COREML_INPUT;
+            writes |= feature.role == VA_COREML_OUTPUT;
+        }
+    }
+    if (reads && writes) {
+        return VA_COREML_READ_WRITE;
+    }
+    return reads ? VA_COREML_READ : VA_COREML_WRITE;
 }
 
 void *va_coreml_model_load(const uint8_t *path,
@@ -209,7 +236,9 @@ void *va_coreml_model_load(const uint8_t *path,
             NSURL *modelURL = sourceURL;
             NSURL *temporaryURL = nil;
             NSError *nativeError = nil;
-            if ([sourceURL.pathExtension.lowercaseString isEqualToString:@"mlmodel"]) {
+            NSString *extension = sourceURL.pathExtension.lowercaseString;
+            if ([extension isEqualToString:@"mlmodel"] ||
+                [extension isEqualToString:@"mlpackage"]) {
                 modelURL = [MLModel compileModelAtURL:sourceURL error:&nativeError];
                 if (modelURL == nil) {
                     va_set_nserror(error, nativeError);
@@ -223,6 +252,14 @@ void *va_coreml_model_load(const uint8_t *path,
 
             MLModelConfiguration *configuration = [MLModelConfiguration new];
             configuration.computeUnits = MLComputeUnitsCPUAndNeuralEngine;
+            if (@available(macOS 14.4, *)) {
+                MLOptimizationHints *hints = [MLOptimizationHints new];
+                hints.reshapeFrequency = MLReshapeFrequencyHintInfrequent;
+                if (@available(macOS 15.0, *)) {
+                    hints.specializationStrategy = MLSpecializationStrategyFastPrediction;
+                }
+                configuration.optimizationHints = hints;
+            }
             MLModel *model = [MLModel modelWithContentsOfURL:modelURL
                                               configuration:configuration
                                                       error:&nativeError];
@@ -241,6 +278,12 @@ void *va_coreml_model_load(const uint8_t *path,
                 model.modelDescription.inputDescriptionsByName;
             NSDictionary<NSString *, MLFeatureDescription *> *outputs =
                 model.modelDescription.outputDescriptionsByName;
+            if (@available(macOS 15.0, *)) {
+                if (model.modelDescription.stateDescriptionsByName.count != 0) {
+                    va_set_error(error, VA_COREML_UNSUPPORTED, VA_COREML_BRIDGE_DOMAIN, 24);
+                    return NULL;
+                }
+            }
             if (mapping_count != inputs.count + outputs.count) {
                 va_set_error(error, VA_COREML_INCOMPATIBLE, VA_COREML_BRIDGE_DOMAIN, 9);
                 return NULL;
@@ -294,8 +337,37 @@ void *va_coreml_model_load(const uint8_t *path,
                 }
             }
 
-            program.features = features;
-            program.slots = slots;
+            NSArray<NSNumber *> *sortedSlots =
+                [slots.allObjects sortedArrayUsingSelector:@selector(compare:)];
+            NSMutableArray<VASlotSpec *> *slotSpecs =
+                [NSMutableArray arrayWithCapacity:sortedSlots.count];
+            for (NSUInteger index = 0; index < sortedSlots.count; index++) {
+                uint32_t slot = sortedSlots[index].unsignedIntValue;
+                VASlotSpec *slotSpec = [VASlotSpec new];
+                slotSpec.slot = slot;
+                slotSpec.access = va_access_for_slot(features, slot);
+                [slotSpecs addObject:slotSpec];
+                for (VAFeatureSpec *feature in features) {
+                    if (feature.slot == slot) {
+                        feature.bindingIndex = index;
+                    }
+                }
+            }
+
+            NSMutableArray<VAFeatureSpec *> *inputFeatures =
+                [NSMutableArray arrayWithCapacity:inputs.count];
+            NSMutableArray<VAFeatureSpec *> *outputFeatures =
+                [NSMutableArray arrayWithCapacity:outputs.count];
+            for (VAFeatureSpec *feature in features) {
+                if (feature.role == VA_COREML_INPUT) {
+                    [inputFeatures addObject:feature];
+                } else {
+                    [outputFeatures addObject:feature];
+                }
+            }
+            program.inputFeatures = inputFeatures;
+            program.outputFeatures = outputFeatures;
+            program.slots = slotSpecs;
             return (__bridge_retained void *)program;
         } @catch (NSException *exception) {
             va_set_error(error, VA_COREML_EXTERNAL, VA_COREML_BRIDGE_DOMAIN, 15);
@@ -312,29 +384,26 @@ void va_coreml_model_release(void *model) {
     }
 }
 
-static const struct va_coreml_binding *va_binding_for_slot(
-    const struct va_coreml_binding *bindings, size_t binding_count, uint32_t slot) {
-    for (size_t index = 0; index < binding_count; index++) {
-        if (bindings[index].slot == slot) {
-            return &bindings[index];
-        }
+static MLMultiArray *va_array_for_feature(VAFeatureSpec *feature,
+                                          const struct va_coreml_binding *bindings,
+                                          NSError **nativeError,
+                                          struct va_coreml_error *error) {
+    const struct va_coreml_binding *binding = &bindings[feature.bindingIndex];
+    if (binding->data == NULL || binding->bytes != feature.bytes ||
+        (uintptr_t)binding->data % feature.elementSize != 0) {
+        va_set_error(error, VA_COREML_INCOMPATIBLE, VA_COREML_BRIDGE_DOMAIN, 19);
+        return nil;
     }
-    return NULL;
-}
-
-static uint8_t va_access_for_slot(NSArray<VAFeatureSpec *> *features, uint32_t slot) {
-    BOOL reads = NO;
-    BOOL writes = NO;
-    for (VAFeatureSpec *feature in features) {
-        if (feature.slot == slot) {
-            reads |= feature.role == VA_COREML_INPUT;
-            writes |= feature.role == VA_COREML_OUTPUT;
-        }
+    MLMultiArray *array = [[MLMultiArray alloc] initWithDataPointer:binding->data
+                                                              shape:feature.shape
+                                                           dataType:feature.dataType
+                                                            strides:feature.strides
+                                                        deallocator:nil
+                                                              error:nativeError];
+    if (array == nil) {
+        va_set_nserror(error, *nativeError);
     }
-    if (reads && writes) {
-        return VA_COREML_READ_WRITE;
-    }
-    return reads ? VA_COREML_READ : VA_COREML_WRITE;
+    return array;
 }
 
 void *va_coreml_submit(void *model,
@@ -355,11 +424,10 @@ void *va_coreml_submit(void *model,
             va_set_error(error, VA_COREML_INCOMPATIBLE, VA_COREML_BRIDGE_DOMAIN, 17);
             return NULL;
         }
-        for (NSNumber *slotNumber in program.slots) {
-            uint32_t slot = slotNumber.unsignedIntValue;
-            const struct va_coreml_binding *binding =
-                va_binding_for_slot(bindings, binding_count, slot);
-            if (binding == NULL || binding->access != va_access_for_slot(program.features, slot)) {
+        for (NSUInteger index = 0; index < program.slots.count; index++) {
+            VASlotSpec *slot = program.slots[index];
+            const struct va_coreml_binding *binding = &bindings[index];
+            if (binding->slot != slot.slot || binding->access != slot.access) {
                 va_set_error(error, VA_COREML_INCOMPATIBLE, VA_COREML_BRIDGE_DOMAIN, 18);
                 return NULL;
             }
@@ -367,33 +435,27 @@ void *va_coreml_submit(void *model,
 
         @try {
             NSError *nativeError = nil;
-            NSMutableDictionary<NSString *, MLFeatureValue *> *inputValues = [NSMutableDictionary dictionary];
-            NSMutableDictionary<NSString *, MLMultiArray *> *outputBackings = [NSMutableDictionary dictionary];
-            NSMutableArray<VAFeatureSpec *> *outputFeatures = [NSMutableArray array];
-            for (VAFeatureSpec *feature in program.features) {
-                const struct va_coreml_binding *binding =
-                    va_binding_for_slot(bindings, binding_count, feature.slot);
-                if (binding == NULL || binding->data == NULL || binding->bytes != feature.bytes) {
-                    va_set_error(error, VA_COREML_INCOMPATIBLE, VA_COREML_BRIDGE_DOMAIN, 19);
-                    return NULL;
-                }
-                MLMultiArray *array = [[MLMultiArray alloc] initWithDataPointer:binding->data
-                                                                          shape:feature.shape
-                                                                       dataType:feature.dataType
-                                                                        strides:feature.strides
-                                                                    deallocator:nil
-                                                                          error:&nativeError];
+            NSMutableDictionary<NSString *, MLFeatureValue *> *inputValues =
+                [NSMutableDictionary dictionaryWithCapacity:program.inputFeatures.count];
+            for (VAFeatureSpec *feature in program.inputFeatures) {
+                MLMultiArray *array =
+                    va_array_for_feature(feature, bindings, &nativeError, error);
                 if (array == nil) {
-                    va_set_nserror(error, nativeError);
                     return NULL;
                 }
-                if (feature.role == VA_COREML_INPUT) {
-                    inputValues[feature.name] = [MLFeatureValue featureValueWithMultiArray:array];
-                } else {
-                    outputBackings[feature.name] = array;
-                    [outputFeatures addObject:feature];
-                }
+                inputValues[feature.name] = [MLFeatureValue featureValueWithMultiArray:array];
             }
+            NSMutableDictionary<NSString *, MLMultiArray *> *outputBackings =
+                [NSMutableDictionary dictionaryWithCapacity:program.outputFeatures.count];
+            for (VAFeatureSpec *feature in program.outputFeatures) {
+                MLMultiArray *array =
+                    va_array_for_feature(feature, bindings, &nativeError, error);
+                if (array == nil) {
+                    return NULL;
+                }
+                outputBackings[feature.name] = array;
+            }
+            NSArray<VAFeatureSpec *> *outputFeatures = program.outputFeatures;
 
             MLDictionaryFeatureProvider *provider =
                 [[MLDictionaryFeatureProvider alloc] initWithDictionary:inputValues error:&nativeError];
@@ -412,49 +474,57 @@ void *va_coreml_submit(void *model,
             [program.model predictionFromFeatures:provider
                                           options:options
                                 completionHandler:^(id<MLFeatureProvider> output, NSError *predictionError) {
-                uint32_t terminalStatus = VA_COREML_EVENT_COMPLETE;
-                @try {
-                    if (predictionError != nil || output == nil) {
+                @autoreleasepool {
+                    uint32_t terminalStatus = VA_COREML_EVENT_COMPLETE;
+                    @try {
+                        if (predictionError != nil || output == nil) {
+                            atomic_store_explicit(&event->error_kind,
+                                                  VA_COREML_EXTERNAL,
+                                                  memory_order_relaxed);
+                            atomic_store_explicit(&event->error_domain,
+                                                  va_hash_domain(predictionError.domain),
+                                                  memory_order_relaxed);
+                            atomic_store_explicit(&event->error_code,
+                                                  predictionError.code,
+                                                  memory_order_relaxed);
+                            terminalStatus = VA_COREML_EVENT_FAILED;
+                        } else {
+                            for (VAFeatureSpec *feature in outputFeatures) {
+                                MLMultiArray *actual =
+                                    [output featureValueForName:feature.name].multiArrayValue;
+                                MLMultiArray *expected = outputBackings[feature.name];
+                                if (actual == nil || actual.dataPointer != expected.dataPointer ||
+                                    actual.dataType != feature.dataType ||
+                                    ![actual.shape isEqualToArray:feature.shape] ||
+                                    ![actual.strides isEqualToArray:feature.strides]) {
+                                    atomic_store_explicit(&event->error_kind,
+                                                          VA_COREML_INCOMPATIBLE,
+                                                          memory_order_relaxed);
+                                    atomic_store_explicit(&event->error_domain,
+                                                          VA_COREML_BRIDGE_DOMAIN,
+                                                          memory_order_relaxed);
+                                    atomic_store_explicit(&event->error_code,
+                                                          20,
+                                                          memory_order_relaxed);
+                                    terminalStatus = VA_COREML_EVENT_FAILED;
+                                    break;
+                                }
+                            }
+                        }
+                    } @catch (NSException *exception) {
                         atomic_store_explicit(&event->error_kind,
                                               VA_COREML_EXTERNAL,
                                               memory_order_relaxed);
                         atomic_store_explicit(&event->error_domain,
-                                              va_hash_domain(predictionError.domain),
+                                              VA_COREML_BRIDGE_DOMAIN,
                                               memory_order_relaxed);
-                        atomic_store_explicit(&event->error_code,
-                                              predictionError.code,
-                                              memory_order_relaxed);
+                        atomic_store_explicit(&event->error_code, 23, memory_order_relaxed);
                         terminalStatus = VA_COREML_EVENT_FAILED;
-                    } else {
-                        for (VAFeatureSpec *feature in outputFeatures) {
-                            MLMultiArray *actual =
-                                [output featureValueForName:feature.name].multiArrayValue;
-                            if (actual != outputBackings[feature.name]) {
-                                atomic_store_explicit(&event->error_kind,
-                                                      VA_COREML_INCOMPATIBLE,
-                                                      memory_order_relaxed);
-                                atomic_store_explicit(&event->error_domain,
-                                                      VA_COREML_BRIDGE_DOMAIN,
-                                                      memory_order_relaxed);
-                                atomic_store_explicit(&event->error_code, 20, memory_order_relaxed);
-                                terminalStatus = VA_COREML_EVENT_FAILED;
-                                break;
-                            }
-                        }
                     }
-                } @catch (NSException *exception) {
-                    atomic_store_explicit(&event->error_kind,
-                                          VA_COREML_EXTERNAL,
-                                          memory_order_relaxed);
-                    atomic_store_explicit(&event->error_domain,
-                                          VA_COREML_BRIDGE_DOMAIN,
-                                          memory_order_relaxed);
-                    atomic_store_explicit(&event->error_code, 23, memory_order_relaxed);
-                    terminalStatus = VA_COREML_EVENT_FAILED;
+                    release_context(context);
+                    atomic_store_explicit(&event->status, terminalStatus, memory_order_release);
+                    va_event_release_inner(event);
                 }
-                release_context(context);
-                atomic_store_explicit(&event->status, terminalStatus, memory_order_release);
-                va_event_release_inner(event);
             }];
             eventForException = NULL;
             return event;

--- a/crates/virtio-accel-coreml/src/artifact.rs
+++ b/crates/virtio-accel-coreml/src/artifact.rs
@@ -1,0 +1,313 @@
+#[cfg(any(target_os = "macos", test))]
+use std::collections::BTreeSet;
+
+const MAGIC: [u8; 4] = *b"CMLP";
+const VERSION_MAJOR: u8 = 1;
+const VERSION_MINOR: u8 = 0;
+const HEADER_BYTES: usize = 16;
+const ENTRY_HEADER_BYTES: usize = 8;
+pub(crate) const MAX_ARTIFACT_BYTES: u64 = 64 * 1024;
+const MAX_MODEL_PATH_BYTES: usize = 4 * 1024;
+const MAX_FEATURE_NAME_BYTES: usize = 1024;
+const MAX_MAPPINGS: usize = 256;
+
+/// A Core ML model feature's role in one virtio-accel binding.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum FeatureRole {
+    Input = 1,
+    Output = 2,
+}
+
+impl FeatureRole {
+    #[cfg(any(target_os = "macos", test))]
+    fn from_wire(value: u8) -> Result<Self, DecodeError> {
+        match value {
+            1 => Ok(Self::Input),
+            2 => Ok(Self::Output),
+            _ => Err(DecodeError::Invalid),
+        }
+    }
+}
+
+/// Invalid Core ML path artifact construction.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ArtifactBuildError {
+    EmptyModelPath,
+    ModelPathTooLong,
+    EmptyFeatureName,
+    FeatureNameTooLong,
+    DuplicateFeature,
+    EmptyMappings,
+    TooManyMappings,
+    ArtifactTooLarge,
+}
+
+impl std::fmt::Display for ArtifactBuildError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{self:?}")
+    }
+}
+
+impl std::error::Error for ArtifactBuildError {}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct FeatureMapping {
+    pub slot: u32,
+    pub role: FeatureRole,
+    pub name: String,
+}
+
+/// Builder for the provider-owned Core ML path artifact.
+///
+/// The model path is relative to the host-selected model root. Every nonoptional model input and
+/// output must be mapped exactly once. Mapping one input and one compatible output to the same slot
+/// creates an in-place `ReadWrite` binding.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CoreMlArtifact {
+    model_path: String,
+    mappings: Vec<FeatureMapping>,
+}
+
+impl CoreMlArtifact {
+    pub fn new(model_path: impl Into<String>) -> Result<Self, ArtifactBuildError> {
+        let model_path = model_path.into();
+        if model_path.is_empty() {
+            return Err(ArtifactBuildError::EmptyModelPath);
+        }
+        if model_path.len() > MAX_MODEL_PATH_BYTES || model_path.len() > u16::MAX as usize {
+            return Err(ArtifactBuildError::ModelPathTooLong);
+        }
+        Ok(Self {
+            model_path,
+            mappings: Vec::new(),
+        })
+    }
+
+    pub fn map_input(
+        self,
+        slot: u32,
+        feature_name: impl Into<String>,
+    ) -> Result<Self, ArtifactBuildError> {
+        self.map(slot, FeatureRole::Input, feature_name.into())
+    }
+
+    pub fn map_output(
+        self,
+        slot: u32,
+        feature_name: impl Into<String>,
+    ) -> Result<Self, ArtifactBuildError> {
+        self.map(slot, FeatureRole::Output, feature_name.into())
+    }
+
+    pub fn encode(&self) -> Result<Vec<u8>, ArtifactBuildError> {
+        if self.mappings.is_empty() {
+            return Err(ArtifactBuildError::EmptyMappings);
+        }
+        if self.mappings.len() > MAX_MAPPINGS || self.mappings.len() > u16::MAX as usize {
+            return Err(ArtifactBuildError::TooManyMappings);
+        }
+        let mut bytes = Vec::with_capacity(
+            HEADER_BYTES
+                + self.model_path.len()
+                + self
+                    .mappings
+                    .iter()
+                    .map(|mapping| ENTRY_HEADER_BYTES + mapping.name.len())
+                    .sum::<usize>(),
+        );
+        bytes.extend_from_slice(&MAGIC);
+        bytes.push(VERSION_MAJOR);
+        bytes.push(VERSION_MINOR);
+        bytes.extend_from_slice(&0u16.to_le_bytes());
+        bytes.extend_from_slice(&(self.model_path.len() as u16).to_le_bytes());
+        bytes.extend_from_slice(&(self.mappings.len() as u16).to_le_bytes());
+        bytes.extend_from_slice(&0u32.to_le_bytes());
+        bytes.extend_from_slice(self.model_path.as_bytes());
+        for mapping in &self.mappings {
+            bytes.extend_from_slice(&mapping.slot.to_le_bytes());
+            bytes.push(mapping.role as u8);
+            bytes.push(0);
+            bytes.extend_from_slice(&(mapping.name.len() as u16).to_le_bytes());
+            bytes.extend_from_slice(mapping.name.as_bytes());
+        }
+        if bytes.len() as u64 > MAX_ARTIFACT_BYTES {
+            return Err(ArtifactBuildError::ArtifactTooLarge);
+        }
+        Ok(bytes)
+    }
+
+    fn map(
+        mut self,
+        slot: u32,
+        role: FeatureRole,
+        name: String,
+    ) -> Result<Self, ArtifactBuildError> {
+        if name.is_empty() {
+            return Err(ArtifactBuildError::EmptyFeatureName);
+        }
+        if name.len() > MAX_FEATURE_NAME_BYTES || name.len() > u16::MAX as usize {
+            return Err(ArtifactBuildError::FeatureNameTooLong);
+        }
+        if self
+            .mappings
+            .iter()
+            .any(|mapping| mapping.role == role && mapping.name == name)
+        {
+            return Err(ArtifactBuildError::DuplicateFeature);
+        }
+        if self.mappings.len() == MAX_MAPPINGS {
+            return Err(ArtifactBuildError::TooManyMappings);
+        }
+        self.mappings.push(FeatureMapping { slot, role, name });
+        Ok(self)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg(any(target_os = "macos", test))]
+pub(crate) enum DecodeError {
+    Invalid,
+    OutOfBounds,
+    ResourceLimit,
+}
+
+#[derive(Debug)]
+#[cfg(any(target_os = "macos", test))]
+pub(crate) struct DecodedArtifact {
+    pub model_path: String,
+    pub mappings: Vec<FeatureMapping>,
+}
+
+#[cfg(any(target_os = "macos", test))]
+pub(crate) fn decode<S: virtio_accel_core::ByteSource + ?Sized>(
+    source: &S,
+) -> Result<DecodedArtifact, DecodeError> {
+    if source.len() > MAX_ARTIFACT_BYTES {
+        return Err(DecodeError::ResourceLimit);
+    }
+    if source.len() < HEADER_BYTES as u64 {
+        return Err(DecodeError::Invalid);
+    }
+
+    let mut header = [0; HEADER_BYTES];
+    source
+        .read_at(0, &mut header)
+        .map_err(|_| DecodeError::OutOfBounds)?;
+    if header[..4] != MAGIC
+        || header[4] != VERSION_MAJOR
+        || header[5] != VERSION_MINOR
+        || header[6..8] != [0, 0]
+        || header[12..16] != [0, 0, 0, 0]
+    {
+        return Err(DecodeError::Invalid);
+    }
+    let path_len = u16::from_le_bytes([header[8], header[9]]) as usize;
+    let mapping_count = u16::from_le_bytes([header[10], header[11]]) as usize;
+    if path_len == 0 || path_len > MAX_MODEL_PATH_BYTES || mapping_count > MAX_MAPPINGS {
+        return Err(DecodeError::Invalid);
+    }
+
+    let mut cursor = HEADER_BYTES as u64;
+    let mut path = vec![0; path_len];
+    source
+        .read_at(cursor, &mut path)
+        .map_err(|_| DecodeError::OutOfBounds)?;
+    cursor += path_len as u64;
+    let model_path = String::from_utf8(path).map_err(|_| DecodeError::Invalid)?;
+
+    let mut mappings = Vec::new();
+    mappings
+        .try_reserve_exact(mapping_count)
+        .map_err(|_| DecodeError::ResourceLimit)?;
+    let mut features = BTreeSet::new();
+    for _ in 0..mapping_count {
+        let mut entry = [0; ENTRY_HEADER_BYTES];
+        source
+            .read_at(cursor, &mut entry)
+            .map_err(|_| DecodeError::OutOfBounds)?;
+        cursor += ENTRY_HEADER_BYTES as u64;
+        if entry[5] != 0 {
+            return Err(DecodeError::Invalid);
+        }
+        let slot = u32::from_le_bytes(entry[..4].try_into().unwrap());
+        let role = FeatureRole::from_wire(entry[4])?;
+        let name_len = u16::from_le_bytes([entry[6], entry[7]]) as usize;
+        if name_len == 0 || name_len > MAX_FEATURE_NAME_BYTES {
+            return Err(DecodeError::Invalid);
+        }
+        let mut name = vec![0; name_len];
+        source
+            .read_at(cursor, &mut name)
+            .map_err(|_| DecodeError::OutOfBounds)?;
+        cursor += name_len as u64;
+        let name = String::from_utf8(name).map_err(|_| DecodeError::Invalid)?;
+        if !features.insert((role as u8, name.clone())) {
+            return Err(DecodeError::Invalid);
+        }
+        mappings.push(FeatureMapping { slot, role, name });
+    }
+    if cursor != source.len() || mappings.is_empty() {
+        return Err(DecodeError::Invalid);
+    }
+    Ok(DecodedArtifact {
+        model_path,
+        mappings,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn path_artifact_round_trips() {
+        let artifact = CoreMlArtifact::new("models/twice.mlmodel")
+            .unwrap()
+            .map_input(7, "x")
+            .unwrap()
+            .map_output(7, "y")
+            .unwrap();
+        let bytes = artifact.encode().unwrap();
+        let decoded = decode(bytes.as_slice()).unwrap();
+        assert_eq!(decoded.model_path, "models/twice.mlmodel");
+        assert_eq!(decoded.mappings, artifact.mappings);
+    }
+
+    #[test]
+    fn malformed_envelopes_are_rejected() {
+        assert_eq!(
+            CoreMlArtifact::new("model.mlmodel").unwrap().encode(),
+            Err(ArtifactBuildError::EmptyMappings)
+        );
+        let artifact = CoreMlArtifact::new("model.mlmodel")
+            .unwrap()
+            .map_input(0, "x")
+            .unwrap();
+        let mut bytes = artifact.encode().unwrap();
+        bytes[6] = 1;
+        assert_eq!(decode(bytes.as_slice()).unwrap_err(), DecodeError::Invalid);
+
+        let duplicate = CoreMlArtifact {
+            model_path: "model.mlmodel".into(),
+            mappings: vec![
+                FeatureMapping {
+                    slot: 0,
+                    role: FeatureRole::Input,
+                    name: "x".into(),
+                },
+                FeatureMapping {
+                    slot: 1,
+                    role: FeatureRole::Input,
+                    name: "x".into(),
+                },
+            ],
+        }
+        .encode()
+        .unwrap();
+        assert_eq!(
+            decode(duplicate.as_slice()).unwrap_err(),
+            DecodeError::Invalid
+        );
+    }
+}

--- a/crates/virtio-accel-coreml/src/lib.rs
+++ b/crates/virtio-accel-coreml/src/lib.rs
@@ -1,0 +1,83 @@
+//! Core ML host backend for Apple Neural Engine capable Macs.
+//!
+//! The backend loads a provider-specific path artifact rooted beneath a directory selected by the
+//! host. Core ML models are configured with `CPUAndNeuralEngine`: supported operations may execute
+//! on the ANE, while Core ML remains free to place unsupported operations on the CPU. Program
+//! buffers are page-aligned allocations wrapped directly by `MLMultiArray`; output execution is
+//! accepted only when Core ML uses the same allocation as its output backing.
+
+#![cfg_attr(not(target_os = "macos"), forbid(unsafe_code))]
+
+mod artifact;
+
+pub use artifact::{ArtifactBuildError, CoreMlArtifact, FeatureRole};
+
+use virtio_accel_core::{ArtifactFormat, TargetIdentity};
+
+/// Provider artifact format for [`CoreMlArtifact`].
+pub const ARTIFACT_FORMAT: ArtifactFormat = match ArtifactFormat::new(0x434d_4c50) {
+    Some(format) => format,
+    None => panic!("Core ML artifact format must be nonzero"),
+};
+
+/// Core ML path-artifact ABI v1 targeting CPU plus Apple Neural Engine execution.
+pub const TARGET_IDENTITY: TargetIdentity = TargetIdentity([
+    0x434f_5245,
+    0x4d4c_0001,
+    0x414e_4503,
+    0x4d41_434f,
+    0x000e_0000,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+]);
+
+/// The Core ML runtime does not publish a finite upper bound for model residency.
+///
+/// Requiring the maximal charge makes the provider promise truthful: a process cannot retain
+/// `u64::MAX` bytes for one model. Device integrations must set their aggregate program-residency
+/// policy accordingly when admitting a Core ML program.
+pub const REQUIRED_RESIDENT_BYTES: u64 = u64::MAX;
+
+/// Failure to initialize a Core ML backend instance.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum InitError {
+    /// The backend is only executable on macOS 14 or newer.
+    UnsupportedPlatform,
+    /// The configured model root is missing, not a directory, or not representable as UTF-8.
+    InvalidModelRoot,
+    /// Core ML does not report an accessible Apple Neural Engine.
+    NeuralEngineUnavailable,
+}
+
+impl std::fmt::Display for InitError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{self:?}")
+    }
+}
+
+impl std::error::Error for InitError {}
+
+#[cfg(target_os = "macos")]
+mod macos;
+#[cfg(target_os = "macos")]
+pub use macos::{
+    CoreMlAccelerator, CoreMlBuffer, CoreMlContext, CoreMlEvent, CoreMlProgram, CoreMlQueue,
+};
+
+/// Non-macOS placeholder that keeps workspace consumers portable.
+#[cfg(not(target_os = "macos"))]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct CoreMlAccelerator;
+
+#[cfg(not(target_os = "macos"))]
+impl CoreMlAccelerator {
+    /// Report that Core ML is unavailable on this target.
+    pub fn new(_model_root: impl AsRef<std::path::Path>) -> Result<Self, InitError> {
+        Err(InitError::UnsupportedPlatform)
+    }
+}

--- a/crates/virtio-accel-coreml/src/macos.rs
+++ b/crates/virtio-accel-coreml/src/macos.rs
@@ -1,0 +1,727 @@
+//! Audited macOS implementation. See `SAFETY.md`.
+
+use crate::artifact::{DecodeError, FeatureRole, MAX_ARTIFACT_BYTES, decode};
+use crate::{ARTIFACT_FORMAT, InitError, REQUIRED_RESIDENT_BYTES, TARGET_IDENTITY};
+use core::ffi::c_void;
+use std::alloc::{Layout, alloc_zeroed, dealloc};
+use std::collections::BTreeSet;
+use std::fmt;
+use std::marker::PhantomData;
+use std::os::unix::ffi::OsStrExt;
+use std::path::{Component, Path, PathBuf};
+use std::ptr::NonNull;
+use std::rc::Rc;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use virtio_accel_core::{
+    Accelerator, AcceleratorClass, AllocatedBuffer, ArtifactRef, BackendError, BindingRef,
+    BufferDesc, BufferInfo, BufferProperties, BufferUsage, ByteSink, ByteSource, Capabilities,
+    ContextDesc, DeviceIdentity, DeviceInfo, DeviceLimits, EventState, MemoryDomain, QueueDesc,
+    ReleaseFailure, SubmitFailure, Timeout, validate_bindings,
+};
+
+const COREML_MIN_ALIGNMENT: usize = 16 * 1024;
+const TRANSFER_CHUNK_BYTES: usize = 16 * 1024;
+const COREML_EXTERNAL_DOMAIN: u32 = 0x434d_4c45;
+
+const ERROR_UNSUPPORTED: u32 = 1;
+const ERROR_INCOMPATIBLE: u32 = 2;
+const ERROR_INVALID_ARGUMENT: u32 = 3;
+const ERROR_OUT_OF_BOUNDS: u32 = 4;
+const ERROR_OUT_OF_MEMORY: u32 = 5;
+const ERROR_RESOURCE_LIMIT: u32 = 6;
+const ERROR_DEVICE_LOST: u32 = 7;
+const ERROR_EXTERNAL: u32 = 8;
+
+const EVENT_PENDING: u32 = 0;
+const EVENT_COMPLETE: u32 = 1;
+const EVENT_FAILED: u32 = 2;
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default)]
+struct NativeError {
+    kind: u32,
+    domain: u32,
+    code: i64,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+struct NativeFeatureMapping {
+    slot: u32,
+    role: u8,
+    name: *const u8,
+    name_len: usize,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+struct NativeBinding {
+    slot: u32,
+    access: u8,
+    data: *mut c_void,
+    bytes: u64,
+}
+
+type NativeReleaseContext = unsafe extern "C" fn(*mut c_void);
+
+unsafe extern "C" {
+    fn va_coreml_has_neural_engine() -> std::ffi::c_int;
+    fn va_coreml_model_load(
+        path: *const u8,
+        path_len: usize,
+        mappings: *const NativeFeatureMapping,
+        mapping_count: usize,
+        error: *mut NativeError,
+    ) -> *mut c_void;
+    fn va_coreml_model_release(model: *mut c_void);
+    fn va_coreml_submit(
+        model: *mut c_void,
+        bindings: *const NativeBinding,
+        binding_count: usize,
+        context: *mut c_void,
+        release_context: NativeReleaseContext,
+        error: *mut NativeError,
+    ) -> *mut c_void;
+    fn va_coreml_event_poll(event: *mut c_void, error: *mut NativeError) -> u32;
+    fn va_coreml_event_release(event: *mut c_void);
+}
+
+#[derive(Debug)]
+struct AlignedAllocation {
+    pointer: NonNull<u8>,
+    layout: Layout,
+    in_flight: AtomicU64,
+}
+
+impl AlignedAllocation {
+    fn new(bytes: u64, requested_alignment: u64) -> Result<Self, BackendError> {
+        let bytes = usize::try_from(bytes).map_err(|_| BackendError::OutOfMemory)?;
+        let requested_alignment =
+            usize::try_from(requested_alignment).map_err(|_| BackendError::OutOfMemory)?;
+        let alignment = requested_alignment.max(COREML_MIN_ALIGNMENT);
+        let allocation_bytes = bytes
+            .checked_add(alignment - 1)
+            .map(|value| value & !(alignment - 1))
+            .ok_or(BackendError::OutOfMemory)?;
+        let layout = Layout::from_size_align(allocation_bytes, alignment)
+            .map_err(|_| BackendError::OutOfMemory)?;
+        // SAFETY: `layout` is valid and nonzero. The returned pointer is owned by this value and is
+        // released with the identical layout in `Drop`.
+        let pointer =
+            NonNull::new(unsafe { alloc_zeroed(layout) }).ok_or(BackendError::OutOfMemory)?;
+        Ok(Self {
+            pointer,
+            layout,
+            in_flight: AtomicU64::new(0),
+        })
+    }
+
+    fn allocation_bytes(&self) -> u64 {
+        self.layout.size() as u64
+    }
+
+    fn alignment(&self) -> u64 {
+        self.layout.align() as u64
+    }
+
+    fn pointer_at(&self, offset: usize) -> *mut u8 {
+        // SAFETY: every caller first validates `offset` against the allocation's logical buffer
+        // range, which is no larger than this layout.
+        unsafe { self.pointer.as_ptr().add(offset) }
+    }
+}
+
+#[derive(Debug)]
+struct InFlightBacking(Arc<AlignedAllocation>);
+
+impl InFlightBacking {
+    fn acquire(allocation: Arc<AlignedAllocation>) -> Result<Self, BackendError> {
+        allocation
+            .in_flight
+            .compare_exchange(0, 1, Ordering::AcqRel, Ordering::Acquire)
+            .map_err(|_| BackendError::Busy)?;
+        Ok(Self(allocation))
+    }
+}
+
+impl Drop for InFlightBacking {
+    fn drop(&mut self) {
+        let prior = self.0.in_flight.fetch_sub(1, Ordering::Release);
+        debug_assert_eq!(prior, 1);
+    }
+}
+
+// SAFETY: allocation access is available only through the `Accelerator` methods. The buffer handle
+// is neither Send nor Sync, and its atomic in-flight gate excludes host transfers while native
+// prediction owns a backing guard. Completion synchronizes through the native release/acquire event
+// status. See `SAFETY.md`.
+unsafe impl Send for AlignedAllocation {}
+// SAFETY: same invariant as the `Send` implementation.
+unsafe impl Sync for AlignedAllocation {}
+
+impl Drop for AlignedAllocation {
+    fn drop(&mut self) {
+        // SAFETY: `pointer` was returned by `alloc_zeroed(self.layout)` and has not been freed.
+        unsafe { dealloc(self.pointer.as_ptr(), self.layout) };
+    }
+}
+
+/// Core ML context handle.
+#[derive(Clone, Debug)]
+pub struct CoreMlContext {
+    id: u64,
+}
+
+/// Page-aligned buffer directly wrapped by Core ML `MLMultiArray` objects.
+#[derive(Debug)]
+pub struct CoreMlBuffer {
+    context_id: u64,
+    desc: BufferDesc,
+    allocation: Arc<AlignedAllocation>,
+    _not_send_sync: PhantomData<Rc<()>>,
+}
+
+/// Resident Core ML model handle.
+pub struct CoreMlProgram {
+    context_id: u64,
+    native: NonNull<c_void>,
+}
+
+impl fmt::Debug for CoreMlProgram {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("CoreMlProgram")
+            .field("context_id", &self.context_id)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Drop for CoreMlProgram {
+    fn drop(&mut self) {
+        // SAFETY: `native` owns one bridge retain and is released exactly once here.
+        unsafe { va_coreml_model_release(self.native.as_ptr()) };
+    }
+}
+
+/// Core ML execution queue handle.
+#[derive(Clone, Debug)]
+pub struct CoreMlQueue {
+    context_id: u64,
+}
+
+/// Asynchronous Core ML prediction event.
+pub struct CoreMlEvent {
+    native: NonNull<c_void>,
+}
+
+impl fmt::Debug for CoreMlEvent {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("CoreMlEvent")
+            .finish_non_exhaustive()
+    }
+}
+
+impl Drop for CoreMlEvent {
+    fn drop(&mut self) {
+        // SAFETY: `native` owns the Rust-side event reference. The bridge's completion callback
+        // owns a separate reference, so this is safe even for an early Rust drop.
+        unsafe { va_coreml_event_release(self.native.as_ptr()) };
+    }
+}
+
+/// One Core ML backend instance rooted at a host-controlled model directory.
+#[derive(Debug)]
+pub struct CoreMlAccelerator {
+    model_root: PathBuf,
+    next_id: AtomicU64,
+    direct_binding_admissions: AtomicU64,
+    info: DeviceInfo,
+}
+
+impl CoreMlAccelerator {
+    /// Construct a backend and require an accessible Apple Neural Engine.
+    pub fn new(model_root: impl AsRef<Path>) -> Result<Self, InitError> {
+        // SAFETY: the function has no pointer arguments and returns a scalar availability result.
+        if unsafe { va_coreml_has_neural_engine() } == 0 {
+            return Err(InitError::NeuralEngineUnavailable);
+        }
+        let model_root = model_root
+            .as_ref()
+            .canonicalize()
+            .map_err(|_| InitError::InvalidModelRoot)?;
+        if !model_root.is_dir() || model_root.to_str().is_none() {
+            return Err(InitError::InvalidModelRoot);
+        }
+        Ok(Self {
+            model_root,
+            next_id: AtomicU64::new(1),
+            direct_binding_admissions: AtomicU64::new(0),
+            info: DeviceInfo {
+                identity: DeviceIdentity {
+                    uuid: *b"apple-coreml-ane",
+                    class: AcceleratorClass::NPU,
+                    vendor_id: 0x106b,
+                    device_id: 0,
+                },
+                capabilities: Capabilities::HOST_VISIBLE_MEMORY | Capabilities::SHARED_MEMORY,
+                limits: DeviceLimits {
+                    max_contexts: 64,
+                    max_buffers_per_context: 1_024,
+                    max_programs_per_context: 64,
+                    max_queues_per_context: 64,
+                    max_events_per_context: 4_096,
+                    max_bindings_per_submission: 256,
+                    max_buffer_bytes: 16 * 1024 * 1024 * 1024,
+                    max_artifact_bytes: MAX_ARTIFACT_BYTES,
+                },
+            },
+        })
+    }
+
+    /// Number of exact provider allocations admitted as Core ML bindings.
+    pub fn direct_binding_admissions(&self) -> u64 {
+        self.direct_binding_admissions.load(Ordering::Relaxed)
+    }
+
+    fn next_id(&self) -> Result<u64, BackendError> {
+        self.next_id
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+                current.checked_add(1)
+            })
+            .map_err(|_| BackendError::ResourceLimit)
+    }
+
+    fn resolve_model(&self, relative: &str) -> Result<PathBuf, BackendError> {
+        let path = Path::new(relative);
+        if path.is_absolute()
+            || path
+                .components()
+                .any(|component| !matches!(component, Component::Normal(_)))
+        {
+            return Err(BackendError::PermissionDenied);
+        }
+        let resolved = self
+            .model_root
+            .join(path)
+            .canonicalize()
+            .map_err(|_| BackendError::InvalidArgument)?;
+        if !resolved.starts_with(&self.model_root) || resolved.as_os_str().to_str().is_none() {
+            return Err(BackendError::PermissionDenied);
+        }
+        Ok(resolved)
+    }
+
+    fn checked_range(
+        buffer: &CoreMlBuffer,
+        offset: u64,
+        bytes: u64,
+    ) -> Result<(usize, usize), BackendError> {
+        if bytes == 0 {
+            return Err(BackendError::InvalidArgument);
+        }
+        let end = offset
+            .checked_add(bytes)
+            .filter(|end| *end <= buffer.desc.bytes())
+            .ok_or(BackendError::OutOfBounds)?;
+        let start = usize::try_from(offset).map_err(|_| BackendError::OutOfBounds)?;
+        let end = usize::try_from(end).map_err(|_| BackendError::OutOfBounds)?;
+        Ok((start, end))
+    }
+
+    fn native_error(error: NativeError) -> BackendError {
+        match error.kind {
+            ERROR_UNSUPPORTED => BackendError::Unsupported,
+            ERROR_INCOMPATIBLE => BackendError::Incompatible,
+            ERROR_INVALID_ARGUMENT => BackendError::InvalidArgument,
+            ERROR_OUT_OF_BOUNDS => BackendError::OutOfBounds,
+            ERROR_OUT_OF_MEMORY => BackendError::OutOfMemory,
+            ERROR_RESOURCE_LIMIT => BackendError::ResourceLimit,
+            ERROR_DEVICE_LOST => BackendError::DeviceLost,
+            ERROR_EXTERNAL => BackendError::External {
+                domain: if error.domain == 0 {
+                    COREML_EXTERNAL_DOMAIN
+                } else {
+                    error.domain
+                },
+                code: error.code,
+            },
+            _ => BackendError::External {
+                domain: COREML_EXTERNAL_DOMAIN,
+                code: error.code,
+            },
+        }
+    }
+}
+
+unsafe extern "C" fn release_event_backings(context: *mut c_void) {
+    // SAFETY: successful submission transfers exactly one pointer produced by `Box::into_raw` to
+    // the bridge, and its completion block calls this function exactly once.
+    drop(unsafe { Box::from_raw(context.cast::<Vec<InFlightBacking>>()) });
+}
+
+impl Accelerator for CoreMlAccelerator {
+    type Context = CoreMlContext;
+    type Buffer = CoreMlBuffer;
+    type Program = CoreMlProgram;
+    type Queue = CoreMlQueue;
+    type Event = CoreMlEvent;
+
+    fn device_info(&self) -> Result<DeviceInfo, BackendError> {
+        Ok(self.info)
+    }
+
+    fn create_context(&self, desc: ContextDesc) -> Result<Self::Context, BackendError> {
+        self.info.validate_context_desc(desc)?;
+        Ok(CoreMlContext {
+            id: self.next_id()?,
+        })
+    }
+
+    fn destroy_context(
+        &self,
+        _context: Self::Context,
+    ) -> Result<(), ReleaseFailure<Self::Context>> {
+        Ok(())
+    }
+
+    fn allocate_buffer(
+        &self,
+        context: &Self::Context,
+        desc: BufferDesc,
+    ) -> Result<AllocatedBuffer<Self::Buffer>, BackendError> {
+        self.info.validate_buffer_desc(desc)?;
+        let allocation = Arc::new(AlignedAllocation::new(desc.bytes(), desc.alignment())?);
+        let properties = BufferProperties::HOST_VISIBLE
+            | if desc.is_program_visible() || desc.domain == MemoryDomain::Shared {
+                BufferProperties::DIRECT_BINDING
+            } else {
+                BufferProperties::empty()
+            };
+        let info = BufferInfo::new(
+            desc,
+            allocation.allocation_bytes(),
+            allocation.alignment(),
+            properties,
+        )?;
+        Ok(AllocatedBuffer::new(
+            CoreMlBuffer {
+                context_id: context.id,
+                desc,
+                allocation,
+                _not_send_sync: PhantomData,
+            },
+            info,
+        ))
+    }
+
+    fn write_buffer(
+        &self,
+        buffer: &mut Self::Buffer,
+        offset: u64,
+        data: &dyn ByteSource,
+    ) -> Result<(), BackendError> {
+        if !buffer
+            .desc
+            .usage
+            .contains(BufferUsage::TRANSFER_DESTINATION)
+        {
+            return Err(BackendError::PermissionDenied);
+        }
+        if buffer.allocation.in_flight.load(Ordering::Acquire) != 0 {
+            return Err(BackendError::Busy);
+        }
+        let (start, end) = Self::checked_range(buffer, offset, data.len())?;
+        let target_len = end - start;
+        if let Some(source) = data.as_contiguous() {
+            if source.len() != target_len {
+                return Err(BackendError::InvalidArgument);
+            }
+            // SAFETY: the validated range lies within the owned allocation, `buffer` is exclusively
+            // borrowed, and the source is a distinct borrowed byte region for this call.
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    source.as_ptr(),
+                    buffer.allocation.pointer_at(start),
+                    target_len,
+                )
+            };
+            return Ok(());
+        }
+
+        let mut scratch = [0; TRANSFER_CHUNK_BYTES];
+        let mut copied = 0usize;
+        while copied < target_len {
+            let chunk = (target_len - copied).min(scratch.as_slice().len());
+            data.read_at(copied as u64, &mut scratch[..chunk])?;
+            // SAFETY: `start + copied .. + chunk` stays inside the validated exclusive range.
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    scratch.as_ptr(),
+                    buffer.allocation.pointer_at(start + copied),
+                    chunk,
+                )
+            };
+            copied += chunk;
+        }
+        Ok(())
+    }
+
+    fn read_buffer(
+        &self,
+        buffer: &Self::Buffer,
+        offset: u64,
+        data: &mut dyn ByteSink,
+    ) -> Result<(), BackendError> {
+        if !buffer.desc.usage.contains(BufferUsage::TRANSFER_SOURCE) {
+            return Err(BackendError::PermissionDenied);
+        }
+        if buffer.allocation.in_flight.load(Ordering::Acquire) != 0 {
+            return Err(BackendError::Busy);
+        }
+        let (start, end) = Self::checked_range(buffer, offset, data.len())?;
+        let source_len = end - start;
+        if let Some(target) = data.as_contiguous_mut() {
+            if target.len() != source_len {
+                return Err(BackendError::InvalidArgument);
+            }
+            // SAFETY: the source range is validated and the in-flight gate proved that no native
+            // event still mutates this buffer.
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    buffer.allocation.pointer_at(start),
+                    target.as_mut_ptr(),
+                    source_len,
+                )
+            };
+            return Ok(());
+        }
+
+        let mut scratch = [0; TRANSFER_CHUNK_BYTES];
+        let mut copied = 0usize;
+        while copied < source_len {
+            let chunk = (source_len - copied).min(scratch.as_slice().len());
+            // SAFETY: `start + copied .. + chunk` remains in the validated source range.
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    buffer.allocation.pointer_at(start + copied),
+                    scratch.as_mut_ptr(),
+                    chunk,
+                )
+            };
+            data.write_at(copied as u64, &scratch[..chunk])?;
+            copied += chunk;
+        }
+        Ok(())
+    }
+
+    fn free_buffer(&self, _buffer: Self::Buffer) -> Result<(), ReleaseFailure<Self::Buffer>> {
+        Ok(())
+    }
+
+    fn load_program(
+        &self,
+        context: &Self::Context,
+        artifact: ArtifactRef<'_>,
+    ) -> Result<Self::Program, BackendError> {
+        if artifact.format != ARTIFACT_FORMAT {
+            return Err(BackendError::Unsupported);
+        }
+        if artifact.target != TARGET_IDENTITY {
+            return Err(BackendError::Incompatible);
+        }
+        if artifact.payload.len() > self.info.limits.max_artifact_bytes {
+            return Err(BackendError::ResourceLimit);
+        }
+        if artifact.resident_bytes != REQUIRED_RESIDENT_BYTES {
+            return Err(BackendError::ResourceLimit);
+        }
+        let decoded = decode(artifact.payload).map_err(|error| match error {
+            DecodeError::Invalid => BackendError::InvalidArgument,
+            DecodeError::OutOfBounds => BackendError::OutOfBounds,
+            DecodeError::ResourceLimit => BackendError::ResourceLimit,
+        })?;
+        let model_path = self.resolve_model(&decoded.model_path)?;
+        let path = model_path.as_os_str().as_bytes();
+        let mappings = decoded
+            .mappings
+            .iter()
+            .map(|mapping| NativeFeatureMapping {
+                slot: mapping.slot,
+                role: match mapping.role {
+                    FeatureRole::Input => 1,
+                    FeatureRole::Output => 2,
+                },
+                name: mapping.name.as_ptr(),
+                name_len: mapping.name.len(),
+            })
+            .collect::<Vec<_>>();
+        let mut error = NativeError::default();
+        // SAFETY: every byte/name pointer remains valid for this synchronous call. The bridge copies
+        // all retained strings and returns one owned model reference on success.
+        let native = unsafe {
+            va_coreml_model_load(
+                path.as_ptr(),
+                path.len(),
+                mappings.as_ptr(),
+                mappings.len(),
+                &mut error,
+            )
+        };
+        let native = NonNull::new(native).ok_or_else(|| Self::native_error(error))?;
+        Ok(CoreMlProgram {
+            context_id: context.id,
+            native,
+        })
+    }
+
+    fn unload_program(&self, _program: Self::Program) -> Result<(), ReleaseFailure<Self::Program>> {
+        Ok(())
+    }
+
+    fn create_queue(
+        &self,
+        context: &Self::Context,
+        desc: QueueDesc,
+    ) -> Result<Self::Queue, BackendError> {
+        self.info.validate_queue_desc(desc)?;
+        Ok(CoreMlQueue {
+            context_id: context.id,
+        })
+    }
+
+    fn destroy_queue(&self, _queue: Self::Queue) -> Result<(), ReleaseFailure<Self::Queue>> {
+        Ok(())
+    }
+
+    fn submit(
+        &self,
+        queue: &Self::Queue,
+        program: &Self::Program,
+        bindings: &[BindingRef<'_, Self::Buffer>],
+        _timeout: Timeout,
+    ) -> Result<Self::Event, SubmitFailure<Self::Event>> {
+        validate_bindings(bindings, self.info.limits.max_bindings_per_submission)
+            .map_err(SubmitFailure::Rejected)?;
+        if queue.context_id != program.context_id {
+            return Err(SubmitFailure::Rejected(BackendError::InvalidArgument));
+        }
+
+        let mut native_bindings = Vec::new();
+        let mut allocations = Vec::new();
+        native_bindings
+            .try_reserve_exact(bindings.len())
+            .map_err(|_| SubmitFailure::Rejected(BackendError::OutOfMemory))?;
+        allocations
+            .try_reserve_exact(bindings.len())
+            .map_err(|_| SubmitFailure::Rejected(BackendError::OutOfMemory))?;
+        let mut contexts = BTreeSet::new();
+        for binding in bindings {
+            contexts.insert(binding.buffer.context_id);
+            if binding.buffer.context_id != queue.context_id {
+                return Err(SubmitFailure::Rejected(BackendError::InvalidArgument));
+            }
+            if !binding.buffer.desc.allows_access(binding.access) {
+                return Err(SubmitFailure::Rejected(BackendError::PermissionDenied));
+            }
+            let (start, _) =
+                Self::checked_range(binding.buffer, binding.range.offset, binding.range.bytes())
+                    .map_err(SubmitFailure::Rejected)?;
+            native_bindings.push(NativeBinding {
+                slot: binding.slot,
+                access: binding.access as u8,
+                data: binding.buffer.allocation.pointer_at(start).cast(),
+                bytes: binding.range.bytes(),
+            });
+            if !allocations
+                .iter()
+                .any(|prior| Arc::ptr_eq(prior, &binding.buffer.allocation))
+            {
+                allocations.push(Arc::clone(&binding.buffer.allocation));
+            }
+        }
+        if contexts.len() != 1 {
+            return Err(SubmitFailure::Rejected(BackendError::InvalidArgument));
+        }
+
+        let backings = allocations
+            .into_iter()
+            .map(InFlightBacking::acquire)
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(SubmitFailure::Rejected)?;
+        let backings = Box::new(backings);
+        let backing_context = Box::into_raw(backings).cast::<c_void>();
+        let mut error = NativeError::default();
+        // SAFETY: model and binding pointers remain valid through this admission call. The Core ML
+        // arrays created by the bridge borrow the allocations. On success the completion block
+        // owns `backing_context`; on rejection ownership remains here and is reconstructed below.
+        let native = unsafe {
+            va_coreml_submit(
+                program.native.as_ptr(),
+                native_bindings.as_ptr(),
+                native_bindings.len(),
+                backing_context,
+                release_event_backings,
+                &mut error,
+            )
+        };
+        let native = match NonNull::new(native) {
+            Some(native) => native,
+            None => {
+                // SAFETY: the bridge contract retains the context only when it returns an event.
+                drop(unsafe { Box::from_raw(backing_context.cast::<Vec<InFlightBacking>>()) });
+                return Err(SubmitFailure::Rejected(Self::native_error(error)));
+            }
+        };
+        self.direct_binding_admissions
+            .fetch_add(bindings.len() as u64, Ordering::Relaxed);
+        Ok(CoreMlEvent { native })
+    }
+
+    fn poll_event(&self, event: &Self::Event) -> Result<EventState, BackendError> {
+        let mut error = NativeError::default();
+        // SAFETY: `event.native` owns a live native event reference for this borrow.
+        let status = unsafe { va_coreml_event_poll(event.native.as_ptr(), &mut error) };
+        match status {
+            EVENT_PENDING => Ok(EventState::Pending),
+            EVENT_COMPLETE => Ok(EventState::Complete),
+            EVENT_FAILED => Ok(EventState::Failed(Self::native_error(error))),
+            _ => Err(BackendError::External {
+                domain: COREML_EXTERNAL_DOMAIN,
+                code: i64::from(status),
+            }),
+        }
+    }
+
+    fn destroy_event(&self, event: Self::Event) -> Result<(), ReleaseFailure<Self::Event>> {
+        match self.poll_event(&event) {
+            Ok(EventState::Pending) => Err(ReleaseFailure::Rejected {
+                error: BackendError::Busy,
+                resource: event,
+            }),
+            Ok(EventState::Complete | EventState::Failed(_) | EventState::Cancelled) => Ok(()),
+            Err(error) => Err(ReleaseFailure::Rejected {
+                error,
+                resource: event,
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn native_backing_guard_excludes_a_second_user() {
+        let allocation = Arc::new(AlignedAllocation::new(32, 16).unwrap());
+        let guard = InFlightBacking::acquire(Arc::clone(&allocation)).unwrap();
+        assert_eq!(
+            InFlightBacking::acquire(Arc::clone(&allocation)).unwrap_err(),
+            BackendError::Busy
+        );
+        drop(guard);
+        assert!(InFlightBacking::acquire(allocation).is_ok());
+    }
+}

--- a/crates/virtio-accel-coreml/src/macos.rs
+++ b/crates/virtio-accel-coreml/src/macos.rs
@@ -4,7 +4,6 @@ use crate::artifact::{DecodeError, FeatureRole, MAX_ARTIFACT_BYTES, decode};
 use crate::{ARTIFACT_FORMAT, InitError, REQUIRED_RESIDENT_BYTES, TARGET_IDENTITY};
 use core::ffi::c_void;
 use std::alloc::{Layout, alloc_zeroed, dealloc};
-use std::collections::BTreeSet;
 use std::fmt;
 use std::marker::PhantomData;
 use std::os::unix::ffi::OsStrExt;
@@ -14,15 +13,17 @@ use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use virtio_accel_core::{
-    Accelerator, AcceleratorClass, AllocatedBuffer, ArtifactRef, BackendError, BindingRef,
-    BufferDesc, BufferInfo, BufferProperties, BufferUsage, ByteSink, ByteSource, Capabilities,
-    ContextDesc, DeviceIdentity, DeviceInfo, DeviceLimits, EventState, MemoryDomain, QueueDesc,
-    ReleaseFailure, SubmitFailure, Timeout, validate_bindings,
+    Accelerator, AcceleratorClass, AccessMode, AllocatedBuffer, ArtifactRef, BackendError,
+    BindingRef, BufferDesc, BufferInfo, BufferProperties, BufferUsage, ByteSink, ByteSource,
+    Capabilities, ContextDesc, DeviceIdentity, DeviceInfo, DeviceLimits, EventState, MemoryDomain,
+    QueueDesc, ReleaseFailure, SubmitFailure, Timeout, validate_bindings,
 };
 
 const COREML_MIN_ALIGNMENT: usize = 16 * 1024;
 const TRANSFER_CHUNK_BYTES: usize = 16 * 1024;
 const COREML_EXTERNAL_DOMAIN: u32 = 0x434d_4c45;
+const EXCLUSIVE_NATIVE_ACCESS: u64 = 1 << 63;
+const MAX_SHARED_NATIVE_USERS: u64 = EXCLUSIVE_NATIVE_ACCESS - 1;
 
 const ERROR_UNSUPPORTED: u32 = 1;
 const ERROR_INCOMPATIBLE: u32 = 2;
@@ -132,23 +133,112 @@ impl AlignedAllocation {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum BackingAccess {
+    Shared,
+    Exclusive,
+}
+
+impl BackingAccess {
+    const fn for_binding(access: AccessMode) -> Self {
+        match access {
+            AccessMode::Read => Self::Shared,
+            AccessMode::Write | AccessMode::ReadWrite => Self::Exclusive,
+        }
+    }
+
+    const fn combine(self, other: Self) -> Self {
+        if matches!(self, Self::Exclusive) || matches!(other, Self::Exclusive) {
+            Self::Exclusive
+        } else {
+            Self::Shared
+        }
+    }
+}
+
 #[derive(Debug)]
-struct InFlightBacking(Arc<AlignedAllocation>);
+struct PendingBacking {
+    key: usize,
+    allocation: Arc<AlignedAllocation>,
+    access: BackingAccess,
+}
+
+impl PendingBacking {
+    fn new(allocation: Arc<AlignedAllocation>, access: AccessMode) -> Self {
+        Self {
+            key: Arc::as_ptr(&allocation) as usize,
+            allocation,
+            access: BackingAccess::for_binding(access),
+        }
+    }
+}
+
+fn deduplicate_backings(backings: &mut Vec<PendingBacking>) {
+    backings.sort_unstable_by_key(|backing| backing.key);
+    backings.dedup_by(|current, previous| {
+        if current.key != previous.key {
+            return false;
+        }
+        previous.access = previous.access.combine(current.access);
+        true
+    });
+}
+
+#[derive(Debug)]
+struct InFlightBacking {
+    allocation: Arc<AlignedAllocation>,
+    access: BackingAccess,
+}
 
 impl InFlightBacking {
-    fn acquire(allocation: Arc<AlignedAllocation>) -> Result<Self, BackendError> {
-        allocation
-            .in_flight
-            .compare_exchange(0, 1, Ordering::AcqRel, Ordering::Acquire)
-            .map_err(|_| BackendError::Busy)?;
-        Ok(Self(allocation))
+    fn acquire(pending: PendingBacking) -> Result<Self, BackendError> {
+        match pending.access {
+            BackingAccess::Shared => {
+                pending
+                    .allocation
+                    .in_flight
+                    .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+                        (current < MAX_SHARED_NATIVE_USERS).then_some(current + 1)
+                    })
+                    .map_err(|_| BackendError::Busy)?;
+            }
+            BackingAccess::Exclusive => {
+                pending
+                    .allocation
+                    .in_flight
+                    .compare_exchange(
+                        0,
+                        EXCLUSIVE_NATIVE_ACCESS,
+                        Ordering::AcqRel,
+                        Ordering::Acquire,
+                    )
+                    .map_err(|_| BackendError::Busy)?;
+            }
+        }
+        Ok(Self {
+            allocation: pending.allocation,
+            access: pending.access,
+        })
     }
 }
 
 impl Drop for InFlightBacking {
     fn drop(&mut self) {
-        let prior = self.0.in_flight.fetch_sub(1, Ordering::Release);
-        debug_assert_eq!(prior, 1);
+        match self.access {
+            BackingAccess::Shared => {
+                let prior = self.allocation.in_flight.fetch_sub(1, Ordering::Release);
+                debug_assert!((1..=MAX_SHARED_NATIVE_USERS).contains(&prior));
+            }
+            BackingAccess::Exclusive => {
+                let result = self.allocation.in_flight.compare_exchange(
+                    EXCLUSIVE_NATIVE_ACCESS,
+                    0,
+                    Ordering::Release,
+                    Ordering::Relaxed,
+                );
+                debug_assert_eq!(result, Ok(EXCLUSIVE_NATIVE_ACCESS));
+            }
+        }
     }
 }
 
@@ -168,7 +258,7 @@ impl Drop for AlignedAllocation {
 }
 
 /// Core ML context handle.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct CoreMlContext {
     id: u64,
 }
@@ -205,7 +295,7 @@ impl Drop for CoreMlProgram {
 }
 
 /// Core ML execution queue handle.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct CoreMlQueue {
     context_id: u64,
 }
@@ -237,6 +327,7 @@ pub struct CoreMlAccelerator {
     model_root: PathBuf,
     next_id: AtomicU64,
     direct_binding_admissions: AtomicU64,
+    explicit_transfer_bytes: AtomicU64,
     info: DeviceInfo,
 }
 
@@ -258,6 +349,7 @@ impl CoreMlAccelerator {
             model_root,
             next_id: AtomicU64::new(1),
             direct_binding_admissions: AtomicU64::new(0),
+            explicit_transfer_bytes: AtomicU64::new(0),
             info: DeviceInfo {
                 identity: DeviceIdentity {
                     uuid: *b"apple-coreml-ane",
@@ -283,6 +375,11 @@ impl CoreMlAccelerator {
     /// Number of exact provider allocations admitted as Core ML bindings.
     pub fn direct_binding_admissions(&self) -> u64 {
         self.direct_binding_admissions.load(Ordering::Relaxed)
+    }
+
+    /// Bytes copied through the two explicit transfer methods.
+    pub fn explicit_transfer_bytes(&self) -> u64 {
+        self.explicit_transfer_bytes.load(Ordering::Relaxed)
     }
 
     fn next_id(&self) -> Result<u64, BackendError> {
@@ -447,6 +544,8 @@ impl Accelerator for CoreMlAccelerator {
                     target_len,
                 )
             };
+            self.explicit_transfer_bytes
+                .fetch_add(target_len as u64, Ordering::Relaxed);
             return Ok(());
         }
 
@@ -463,6 +562,8 @@ impl Accelerator for CoreMlAccelerator {
                     chunk,
                 )
             };
+            self.explicit_transfer_bytes
+                .fetch_add(chunk as u64, Ordering::Relaxed);
             copied += chunk;
         }
         Ok(())
@@ -495,6 +596,8 @@ impl Accelerator for CoreMlAccelerator {
                     source_len,
                 )
             };
+            self.explicit_transfer_bytes
+                .fetch_add(source_len as u64, Ordering::Relaxed);
             return Ok(());
         }
 
@@ -511,6 +614,8 @@ impl Accelerator for CoreMlAccelerator {
                 )
             };
             data.write_at(copied as u64, &scratch[..chunk])?;
+            self.explicit_transfer_bytes
+                .fetch_add(chunk as u64, Ordering::Relaxed);
             copied += chunk;
         }
         Ok(())
@@ -609,16 +714,14 @@ impl Accelerator for CoreMlAccelerator {
         }
 
         let mut native_bindings = Vec::new();
-        let mut allocations = Vec::new();
+        let mut pending_backings = Vec::new();
         native_bindings
             .try_reserve_exact(bindings.len())
             .map_err(|_| SubmitFailure::Rejected(BackendError::OutOfMemory))?;
-        allocations
+        pending_backings
             .try_reserve_exact(bindings.len())
             .map_err(|_| SubmitFailure::Rejected(BackendError::OutOfMemory))?;
-        let mut contexts = BTreeSet::new();
         for binding in bindings {
-            contexts.insert(binding.buffer.context_id);
             if binding.buffer.context_id != queue.context_id {
                 return Err(SubmitFailure::Rejected(BackendError::InvalidArgument));
             }
@@ -634,18 +737,15 @@ impl Accelerator for CoreMlAccelerator {
                 data: binding.buffer.allocation.pointer_at(start).cast(),
                 bytes: binding.range.bytes(),
             });
-            if !allocations
-                .iter()
-                .any(|prior| Arc::ptr_eq(prior, &binding.buffer.allocation))
-            {
-                allocations.push(Arc::clone(&binding.buffer.allocation));
-            }
-        }
-        if contexts.len() != 1 {
-            return Err(SubmitFailure::Rejected(BackendError::InvalidArgument));
+            pending_backings.push(PendingBacking::new(
+                Arc::clone(&binding.buffer.allocation),
+                binding.access,
+            ));
         }
 
-        let backings = allocations
+        native_bindings.sort_unstable_by_key(|binding| binding.slot);
+        deduplicate_backings(&mut pending_backings);
+        let backings = pending_backings
             .into_iter()
             .map(InFlightBacking::acquire)
             .collect::<Result<Vec<_>, _>>()
@@ -714,14 +814,50 @@ mod tests {
     use super::*;
 
     #[test]
-    fn native_backing_guard_excludes_a_second_user() {
+    fn native_backing_guard_allows_shared_users_and_excludes_writers() {
         let allocation = Arc::new(AlignedAllocation::new(32, 16).unwrap());
-        let guard = InFlightBacking::acquire(Arc::clone(&allocation)).unwrap();
+        let first = InFlightBacking::acquire(PendingBacking::new(
+            Arc::clone(&allocation),
+            AccessMode::Read,
+        ))
+        .unwrap();
+        let second = InFlightBacking::acquire(PendingBacking::new(
+            Arc::clone(&allocation),
+            AccessMode::Read,
+        ))
+        .unwrap();
         assert_eq!(
-            InFlightBacking::acquire(Arc::clone(&allocation)).unwrap_err(),
+            InFlightBacking::acquire(PendingBacking::new(
+                Arc::clone(&allocation),
+                AccessMode::Write,
+            ))
+            .unwrap_err(),
             BackendError::Busy
         );
-        drop(guard);
-        assert!(InFlightBacking::acquire(allocation).is_ok());
+        drop(first);
+        drop(second);
+        let writer = InFlightBacking::acquire(PendingBacking::new(
+            Arc::clone(&allocation),
+            AccessMode::ReadWrite,
+        ))
+        .unwrap();
+        assert_eq!(
+            InFlightBacking::acquire(PendingBacking::new(allocation, AccessMode::Read,))
+                .unwrap_err(),
+            BackendError::Busy
+        );
+        drop(writer);
+    }
+
+    #[test]
+    fn duplicate_allocation_access_collapses_to_exclusive() {
+        let allocation = Arc::new(AlignedAllocation::new(32, 16).unwrap());
+        let mut pending = vec![
+            PendingBacking::new(Arc::clone(&allocation), AccessMode::Read),
+            PendingBacking::new(allocation, AccessMode::Write),
+        ];
+        deduplicate_backings(&mut pending);
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].access, BackingAccess::Exclusive);
     }
 }

--- a/crates/virtio-accel-coreml/tests/coreml.rs
+++ b/crates/virtio-accel-coreml/tests/coreml.rs
@@ -1,0 +1,306 @@
+#![cfg(target_os = "macos")]
+
+use std::fs;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+use virtio_accel_conformance::{
+    BindingFixture, ConformanceHooks, ProgramFixture, SubmissionPathDiagnostics, TargetDescription,
+    run,
+};
+use virtio_accel_core::{
+    Accelerator, AccessMode, ArtifactRef, BackendError, BindingRef, BufferDesc, BufferRange,
+    BufferUsage, ByteSource, ContextDesc, EventState, MemoryDomain, QueueDesc, Timeout,
+};
+use virtio_accel_coreml::{
+    ARTIFACT_FORMAT, CoreMlAccelerator, CoreMlArtifact, CoreMlEvent, InitError,
+    REQUIRED_RESIDENT_BYTES, TARGET_IDENTITY,
+};
+
+// Core ML protobuf for one Float32[8] neural network: y = 2*x + 1.
+const MODEL: &[u8] = &[
+    0x08, 0x01, 0x12, 0x20, 0x0a, 0x0e, 0x0a, 0x01, 0x78, 0x1a, 0x09, 0x2a, 0x07, 0x0a, 0x01, 0x08,
+    0x10, 0xa0, 0x80, 0x04, 0x52, 0x0e, 0x0a, 0x01, 0x79, 0x1a, 0x09, 0x2a, 0x07, 0x0a, 0x01, 0x08,
+    0x10, 0xa0, 0x80, 0x04, 0xa2, 0x1f, 0x27, 0x0a, 0x25, 0x0a, 0x0e, 0x74, 0x77, 0x69, 0x63, 0x65,
+    0x5f, 0x70, 0x6c, 0x75, 0x73, 0x5f, 0x6f, 0x6e, 0x65, 0x12, 0x01, 0x78, 0x1a, 0x01, 0x79, 0x92,
+    0x08, 0x0c, 0x2a, 0x0a, 0x0d, 0x00, 0x00, 0x00, 0x40, 0x15, 0x00, 0x00, 0x80, 0x3f,
+];
+
+static NEXT_FIXTURE: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Debug)]
+struct SliceSource<'a>(&'a [u8]);
+
+impl ByteSource for SliceSource<'_> {
+    fn len(&self) -> u64 {
+        self.0.len() as u64
+    }
+
+    fn read_at(&self, offset: u64, target: &mut [u8]) -> Result<(), BackendError> {
+        let start = usize::try_from(offset).map_err(|_| BackendError::OutOfBounds)?;
+        let end = start
+            .checked_add(target.len())
+            .filter(|end| *end <= self.0.len())
+            .ok_or(BackendError::OutOfBounds)?;
+        target.copy_from_slice(&self.0[start..end]);
+        Ok(())
+    }
+
+    fn as_contiguous(&self) -> Option<&[u8]> {
+        Some(self.0)
+    }
+}
+
+struct Fixture {
+    root: PathBuf,
+    artifact: Vec<u8>,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let unique = NEXT_FIXTURE.fetch_add(1, Ordering::Relaxed);
+        let root = std::env::temp_dir().join(format!(
+            "virtio-accel-coreml-{}-{unique}",
+            std::process::id()
+        ));
+        fs::create_dir(&root).unwrap();
+        fs::write(root.join("TwicePlusOne.mlmodel"), MODEL).unwrap();
+        let artifact = CoreMlArtifact::new("TwicePlusOne.mlmodel")
+            .unwrap()
+            .map_input(7, "x")
+            .unwrap()
+            .map_output(7, "y")
+            .unwrap()
+            .encode()
+            .unwrap();
+        Self { root, artifact }
+    }
+
+    fn backend(&self) -> Result<CoreMlAccelerator, InitError> {
+        CoreMlAccelerator::new(&self.root)
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        fs::remove_dir_all(&self.root).unwrap();
+    }
+}
+
+fn float_bytes(values: impl IntoIterator<Item = f32>) -> Vec<u8> {
+    values
+        .into_iter()
+        .flat_map(f32::to_ne_bytes)
+        .collect::<Vec<_>>()
+}
+
+fn wait_for_terminal(
+    backend: &CoreMlAccelerator,
+    event: &CoreMlEvent,
+) -> Result<EventState, BackendError> {
+    let deadline = Instant::now() + Duration::from_secs(15);
+    loop {
+        match backend.poll_event(event)? {
+            EventState::Pending if Instant::now() < deadline => std::thread::yield_now(),
+            EventState::Pending => return Err(BackendError::DeadlineExpired),
+            terminal => return Ok(terminal),
+        }
+    }
+}
+
+#[test]
+fn executes_a_coreml_model_with_exact_shared_backing() {
+    let fixture = Fixture::new();
+    let backend = match fixture.backend() {
+        Ok(backend) => backend,
+        Err(InitError::NeuralEngineUnavailable) => return,
+        Err(error) => panic!("Core ML backend initialization failed: {error}"),
+    };
+    let context = backend.create_context(ContextDesc::default()).unwrap();
+    let initial = float_bytes((0..8).map(|value| value as f32));
+    let expected = float_bytes((0..8).map(|value| value as f32 * 2.0 + 1.0));
+    let desc = BufferDesc::new(
+        initial.len() as u64,
+        16 * 1024,
+        MemoryDomain::Shared,
+        BufferUsage::TRANSFER_SOURCE
+            | BufferUsage::TRANSFER_DESTINATION
+            | BufferUsage::MUTABLE_STATE,
+    )
+    .unwrap();
+    let (mut buffer, info) = backend
+        .allocate_buffer(&context, desc)
+        .unwrap()
+        .into_parts();
+    assert!(
+        info.properties()
+            .contains(virtio_accel_core::BufferProperties::DIRECT_BINDING)
+    );
+    backend
+        .write_buffer(&mut buffer, 0, &SliceSource(&initial))
+        .unwrap();
+
+    let artifact_source = SliceSource(&fixture.artifact);
+    let program = backend
+        .load_program(
+            &context,
+            ArtifactRef {
+                format: ARTIFACT_FORMAT,
+                target: TARGET_IDENTITY,
+                payload: &artifact_source,
+                resident_bytes: REQUIRED_RESIDENT_BYTES,
+            },
+        )
+        .unwrap();
+    let queue = backend
+        .create_queue(&context, QueueDesc::default())
+        .unwrap();
+    let event = backend
+        .submit(
+            &queue,
+            &program,
+            &[BindingRef {
+                slot: 7,
+                buffer: &buffer,
+                range: BufferRange::new(0, initial.len() as u64).unwrap(),
+                access: AccessMode::ReadWrite,
+            }],
+            Timeout::Infinite,
+        )
+        .unwrap();
+    assert_eq!(
+        wait_for_terminal(&backend, &event).unwrap(),
+        EventState::Complete
+    );
+    assert_eq!(backend.direct_binding_admissions(), 1);
+
+    let mut output = [0; 32];
+    backend.read_buffer(&buffer, 0, &mut output).unwrap();
+    assert_eq!(output.as_slice(), expected);
+
+    backend.destroy_event(event).unwrap();
+    backend.destroy_queue(queue).unwrap();
+    backend.unload_program(program).unwrap();
+    backend.free_buffer(buffer).unwrap();
+    backend.destroy_context(context).unwrap();
+}
+
+struct Hooks;
+
+impl ConformanceHooks<CoreMlAccelerator> for Hooks {
+    fn complete_event(
+        &self,
+        backend: &CoreMlAccelerator,
+        event: &CoreMlEvent,
+    ) -> Result<(), BackendError> {
+        match wait_for_terminal(backend, event)? {
+            EventState::Complete => Ok(()),
+            EventState::Failed(error) => Err(error),
+            EventState::Cancelled => Err(BackendError::DeviceLost),
+            EventState::Pending => Err(BackendError::DeadlineExpired),
+        }
+    }
+
+    fn submission_path_diagnostics(
+        &self,
+        backend: &CoreMlAccelerator,
+    ) -> Option<SubmissionPathDiagnostics> {
+        Some(SubmissionPathDiagnostics {
+            direct_bindings: backend.direct_binding_admissions(),
+            ..SubmissionPathDiagnostics::default()
+        })
+    }
+}
+
+fn target(artifact: &[u8]) -> TargetDescription {
+    TargetDescription::new(
+        ProgramFixture::new(
+            ARTIFACT_FORMAT,
+            TARGET_IDENTITY,
+            artifact,
+            REQUIRED_RESIDENT_BYTES,
+        )
+        .unwrap(),
+        BindingFixture::new(
+            7,
+            AccessMode::ReadWrite,
+            MemoryDomain::Shared,
+            16 * 1024,
+            float_bytes((0..8).map(|value| value as f32)),
+            float_bytes((0..8).map(|value| value as f32 * 2.0 + 1.0)),
+        )
+        .unwrap(),
+    )
+}
+
+#[test]
+fn coreml_backend_passes_the_standard_semantic_suite() {
+    let fixture = Fixture::new();
+    if matches!(fixture.backend(), Err(InitError::NeuralEngineUnavailable)) {
+        return;
+    }
+    let report = run(
+        || fixture.backend().unwrap(),
+        &target(&fixture.artifact),
+        &Hooks,
+    );
+    report.assert_conformant();
+}
+
+#[test]
+fn model_paths_cannot_escape_the_host_root() {
+    let fixture = Fixture::new();
+    let backend = match fixture.backend() {
+        Ok(backend) => backend,
+        Err(InitError::NeuralEngineUnavailable) => return,
+        Err(error) => panic!("Core ML backend initialization failed: {error}"),
+    };
+    let context = backend.create_context(ContextDesc::default()).unwrap();
+    let escaped = CoreMlArtifact::new("../TwicePlusOne.mlmodel")
+        .unwrap()
+        .map_input(7, "x")
+        .unwrap()
+        .map_output(7, "y")
+        .unwrap()
+        .encode()
+        .unwrap();
+    let escaped_source = SliceSource(&escaped);
+    assert!(matches!(
+        backend.load_program(
+            &context,
+            ArtifactRef {
+                format: ARTIFACT_FORMAT,
+                target: TARGET_IDENTITY,
+                payload: &escaped_source,
+                resident_bytes: REQUIRED_RESIDENT_BYTES,
+            },
+        ),
+        Err(BackendError::PermissionDenied)
+    ));
+    backend.destroy_context(context).unwrap();
+}
+
+#[test]
+fn nonmaximal_resident_charge_is_rejected_before_native_loading() {
+    let fixture = Fixture::new();
+    let backend = match fixture.backend() {
+        Ok(backend) => backend,
+        Err(InitError::NeuralEngineUnavailable) => return,
+        Err(error) => panic!("Core ML backend initialization failed: {error}"),
+    };
+    let context = backend.create_context(ContextDesc::default()).unwrap();
+    let artifact_source = SliceSource(&fixture.artifact);
+    assert!(matches!(
+        backend.load_program(
+            &context,
+            ArtifactRef {
+                format: ARTIFACT_FORMAT,
+                target: TARGET_IDENTITY,
+                payload: &artifact_source,
+                resident_bytes: u64::MAX - 1,
+            },
+        ),
+        Err(BackendError::ResourceLimit)
+    ));
+    backend.destroy_context(context).unwrap();
+}

--- a/crates/virtio-accel-coreml/tests/coreml.rs
+++ b/crates/virtio-accel-coreml/tests/coreml.rs
@@ -94,6 +94,17 @@ fn float_bytes(values: impl IntoIterator<Item = f32>) -> Vec<u8> {
         .collect::<Vec<_>>()
 }
 
+fn split_artifact() -> Vec<u8> {
+    CoreMlArtifact::new("TwicePlusOne.mlmodel")
+        .unwrap()
+        .map_input(7, "x")
+        .unwrap()
+        .map_output(8, "y")
+        .unwrap()
+        .encode()
+        .unwrap()
+}
+
 fn wait_for_terminal(
     backend: &CoreMlAccelerator,
     event: &CoreMlEvent,
@@ -185,6 +196,172 @@ fn executes_a_coreml_model_with_exact_shared_backing() {
     backend.destroy_context(context).unwrap();
 }
 
+#[test]
+fn accepts_unsorted_distinct_input_and_output_bindings() {
+    let fixture = Fixture::new();
+    let backend = match fixture.backend() {
+        Ok(backend) => backend,
+        Err(InitError::NeuralEngineUnavailable) => return,
+        Err(error) => panic!("Core ML backend initialization failed: {error}"),
+    };
+    let context = backend.create_context(ContextDesc::default()).unwrap();
+    let input_bytes = float_bytes((0..8).map(|value| value as f32));
+    let expected = float_bytes((0..8).map(|value| value as f32 * 2.0 + 1.0));
+    let input_desc = BufferDesc::new(
+        input_bytes.len() as u64,
+        16 * 1024,
+        MemoryDomain::Shared,
+        BufferUsage::TRANSFER_DESTINATION | BufferUsage::PROGRAM_INPUT,
+    )
+    .unwrap();
+    let output_desc = BufferDesc::new(
+        expected.len() as u64,
+        16 * 1024,
+        MemoryDomain::Shared,
+        BufferUsage::TRANSFER_SOURCE | BufferUsage::PROGRAM_OUTPUT,
+    )
+    .unwrap();
+    let (mut input, _) = backend
+        .allocate_buffer(&context, input_desc)
+        .unwrap()
+        .into_parts();
+    let (output, _) = backend
+        .allocate_buffer(&context, output_desc)
+        .unwrap()
+        .into_parts();
+    backend
+        .write_buffer(&mut input, 0, &SliceSource(&input_bytes))
+        .unwrap();
+
+    let artifact = split_artifact();
+    let artifact_source = SliceSource(&artifact);
+    let program = backend
+        .load_program(
+            &context,
+            ArtifactRef {
+                format: ARTIFACT_FORMAT,
+                target: TARGET_IDENTITY,
+                payload: &artifact_source,
+                resident_bytes: REQUIRED_RESIDENT_BYTES,
+            },
+        )
+        .unwrap();
+    let queue = backend
+        .create_queue(&context, QueueDesc::default())
+        .unwrap();
+    let bindings = [
+        BindingRef {
+            slot: 8,
+            buffer: &output,
+            range: BufferRange::new(0, expected.len() as u64).unwrap(),
+            access: AccessMode::Write,
+        },
+        BindingRef {
+            slot: 7,
+            buffer: &input,
+            range: BufferRange::new(0, input_bytes.len() as u64).unwrap(),
+            access: AccessMode::Read,
+        },
+    ];
+    let event = backend
+        .submit(&queue, &program, &bindings, Timeout::Infinite)
+        .unwrap();
+    assert_eq!(
+        wait_for_terminal(&backend, &event).unwrap(),
+        EventState::Complete
+    );
+    backend.destroy_event(event).unwrap();
+
+    let mut actual = [0; 32];
+    backend.read_buffer(&output, 0, &mut actual).unwrap();
+    assert_eq!(actual.as_slice(), expected);
+    assert_eq!(backend.direct_binding_admissions(), 2);
+    assert_eq!(backend.explicit_transfer_bytes(), 64);
+
+    backend.destroy_queue(queue).unwrap();
+    backend.unload_program(program).unwrap();
+    backend.free_buffer(output).unwrap();
+    backend.free_buffer(input).unwrap();
+    backend.destroy_context(context).unwrap();
+}
+
+#[test]
+fn rejects_misaligned_tensor_bindings_before_admission() {
+    let fixture = Fixture::new();
+    let backend = match fixture.backend() {
+        Ok(backend) => backend,
+        Err(InitError::NeuralEngineUnavailable) => return,
+        Err(error) => panic!("Core ML backend initialization failed: {error}"),
+    };
+    let context = backend.create_context(ContextDesc::default()).unwrap();
+    let input_bytes = float_bytes((0..8).map(|value| value as f32));
+    let input_desc = BufferDesc::new(
+        input_bytes.len() as u64 + 1,
+        16 * 1024,
+        MemoryDomain::Shared,
+        BufferUsage::TRANSFER_DESTINATION | BufferUsage::PROGRAM_INPUT,
+    )
+    .unwrap();
+    let output_desc = BufferDesc::new(
+        input_bytes.len() as u64,
+        16 * 1024,
+        MemoryDomain::Shared,
+        BufferUsage::PROGRAM_OUTPUT,
+    )
+    .unwrap();
+    let (mut input, _) = backend
+        .allocate_buffer(&context, input_desc)
+        .unwrap()
+        .into_parts();
+    let (output, _) = backend
+        .allocate_buffer(&context, output_desc)
+        .unwrap()
+        .into_parts();
+    backend
+        .write_buffer(&mut input, 1, &SliceSource(&input_bytes))
+        .unwrap();
+    let artifact = split_artifact();
+    let artifact_source = SliceSource(&artifact);
+    let program = backend
+        .load_program(
+            &context,
+            ArtifactRef {
+                format: ARTIFACT_FORMAT,
+                target: TARGET_IDENTITY,
+                payload: &artifact_source,
+                resident_bytes: REQUIRED_RESIDENT_BYTES,
+            },
+        )
+        .unwrap();
+    let queue = backend
+        .create_queue(&context, QueueDesc::default())
+        .unwrap();
+    let bindings = [
+        BindingRef {
+            slot: 7,
+            buffer: &input,
+            range: BufferRange::new(1, input_bytes.len() as u64).unwrap(),
+            access: AccessMode::Read,
+        },
+        BindingRef {
+            slot: 8,
+            buffer: &output,
+            range: BufferRange::new(0, input_bytes.len() as u64).unwrap(),
+            access: AccessMode::Write,
+        },
+    ];
+    match backend.submit(&queue, &program, &bindings, Timeout::Infinite) {
+        Err(virtio_accel_core::SubmitFailure::Rejected(BackendError::Incompatible)) => {}
+        result => panic!("misaligned binding was not rejected: {result:?}"),
+    }
+
+    backend.destroy_queue(queue).unwrap();
+    backend.unload_program(program).unwrap();
+    backend.free_buffer(output).unwrap();
+    backend.free_buffer(input).unwrap();
+    backend.destroy_context(context).unwrap();
+}
+
 struct Hooks;
 
 impl ConformanceHooks<CoreMlAccelerator> for Hooks {
@@ -207,6 +384,7 @@ impl ConformanceHooks<CoreMlAccelerator> for Hooks {
     ) -> Option<SubmissionPathDiagnostics> {
         Some(SubmissionPathDiagnostics {
             direct_bindings: backend.direct_binding_admissions(),
+            explicit_transfer_bytes: backend.explicit_transfer_bytes(),
             ..SubmissionPathDiagnostics::default()
         })
     }
@@ -302,5 +480,119 @@ fn nonmaximal_resident_charge_is_rejected_before_native_loading() {
         ),
         Err(BackendError::ResourceLimit)
     ));
+    backend.destroy_context(context).unwrap();
+}
+
+#[test]
+#[ignore = "manual native performance evidence"]
+fn measures_warm_submission_and_completion_latency() {
+    const WARMUPS: usize = 20;
+    const ITERATIONS: usize = 200;
+
+    let fixture = Fixture::new();
+    let backend = match fixture.backend() {
+        Ok(backend) => backend,
+        Err(InitError::NeuralEngineUnavailable) => return,
+        Err(error) => panic!("Core ML backend initialization failed: {error}"),
+    };
+    let context = backend.create_context(ContextDesc::default()).unwrap();
+    let input_bytes = float_bytes((0..8).map(|value| value as f32));
+    let expected = float_bytes((0..8).map(|value| value as f32 * 2.0 + 1.0));
+    let input_desc = BufferDesc::new(
+        input_bytes.len() as u64,
+        16 * 1024,
+        MemoryDomain::Shared,
+        BufferUsage::TRANSFER_DESTINATION | BufferUsage::PROGRAM_INPUT,
+    )
+    .unwrap();
+    let output_desc = BufferDesc::new(
+        expected.len() as u64,
+        16 * 1024,
+        MemoryDomain::Shared,
+        BufferUsage::TRANSFER_SOURCE | BufferUsage::PROGRAM_OUTPUT,
+    )
+    .unwrap();
+    let (mut input, _) = backend
+        .allocate_buffer(&context, input_desc)
+        .unwrap()
+        .into_parts();
+    let (output, _) = backend
+        .allocate_buffer(&context, output_desc)
+        .unwrap()
+        .into_parts();
+    backend
+        .write_buffer(&mut input, 0, &SliceSource(&input_bytes))
+        .unwrap();
+
+    let artifact = split_artifact();
+    let artifact_source = SliceSource(&artifact);
+    let program = backend
+        .load_program(
+            &context,
+            ArtifactRef {
+                format: ARTIFACT_FORMAT,
+                target: TARGET_IDENTITY,
+                payload: &artifact_source,
+                resident_bytes: REQUIRED_RESIDENT_BYTES,
+            },
+        )
+        .unwrap();
+    let queue = backend
+        .create_queue(&context, QueueDesc::default())
+        .unwrap();
+    let bindings = [
+        BindingRef {
+            slot: 7,
+            buffer: &input,
+            range: BufferRange::new(0, input_bytes.len() as u64).unwrap(),
+            access: AccessMode::Read,
+        },
+        BindingRef {
+            slot: 8,
+            buffer: &output,
+            range: BufferRange::new(0, expected.len() as u64).unwrap(),
+            access: AccessMode::Write,
+        },
+    ];
+
+    let mut admission = Vec::with_capacity(ITERATIONS);
+    let mut completion = Vec::with_capacity(ITERATIONS);
+    for iteration in 0..WARMUPS + ITERATIONS {
+        let started = Instant::now();
+        let event = backend
+            .submit(&queue, &program, &bindings, Timeout::Infinite)
+            .unwrap();
+        let admitted = Instant::now();
+        assert_eq!(
+            wait_for_terminal(&backend, &event).unwrap(),
+            EventState::Complete
+        );
+        let completed = Instant::now();
+        backend.destroy_event(event).unwrap();
+        if iteration >= WARMUPS {
+            admission.push(admitted.duration_since(started));
+            completion.push(completed.duration_since(started));
+        }
+    }
+    admission.sort_unstable();
+    completion.sort_unstable();
+    let percentile = |samples: &[Duration], numerator: usize, denominator: usize| {
+        samples[(samples.len() - 1) * numerator / denominator]
+    };
+    eprintln!(
+        "Core ML warm path ({ITERATIONS} iterations): admission median={:?} p95={:?}; completion median={:?} p95={:?}",
+        percentile(&admission, 1, 2),
+        percentile(&admission, 95, 100),
+        percentile(&completion, 1, 2),
+        percentile(&completion, 95, 100),
+    );
+
+    let mut actual = [0; 32];
+    backend.read_buffer(&output, 0, &mut actual).unwrap();
+    assert_eq!(actual.as_slice(), expected);
+    backend.destroy_queue(queue).unwrap();
+    backend.unload_program(program).unwrap();
+    backend.free_buffer(output).unwrap();
+    backend.free_buffer(input).unwrap();
     backend.destroy_context(context).unwrap();
 }

--- a/crates/virtio-accel-device/README.md
+++ b/crates/virtio-accel-device/README.md
@@ -5,9 +5,9 @@ IDs. A future rust-vmm adapter translates descriptor chains into this layer; the
 engine and provider backend never see guest addresses or virtqueue descriptors.
 
 Part of the [`virtio-accel`](https://github.com/MicroPerceptron/virtio-accel) workspace: an experimental, native-Rust foundation for a
-transport-neutral virtual accelerator device. The workspace contains no Linux ioctls, macOS
-frameworks, Windows APIs, guest physical addresses, vendor command formats, or claimed virtio
-device ID.
+transport-neutral virtual accelerator device. Portable crates contain no host-OS or vendor APIs;
+host integrations live in separate adapter crates and never become their dependencies. The
+project claims no Virtio device ID.
 
 **Portability tier:** `alloc-portable` — `core + alloc`; no operating system, filesystem, sockets, or threads.
 

--- a/crates/virtio-accel-guest/README.md
+++ b/crates/virtio-accel-guest/README.md
@@ -5,9 +5,9 @@ requests, matches responses to in-flight requests, and rejects malformed or unkn
 values without allocating per-response state.
 
 Part of the [`virtio-accel`](https://github.com/MicroPerceptron/virtio-accel) workspace: an experimental, native-Rust foundation for a
-transport-neutral virtual accelerator device. The workspace contains no Linux ioctls, macOS
-frameworks, Windows APIs, guest physical addresses, vendor command formats, or claimed virtio
-device ID.
+transport-neutral virtual accelerator device. Portable crates contain no host-OS or vendor APIs;
+host integrations live in separate adapter crates and never become their dependencies. The
+project claims no Virtio device ID.
 
 **Portability tier:** `alloc-portable` — `core + alloc`; no operating system, filesystem, sockets, or threads.
 

--- a/crates/virtio-accel-mock/README.md
+++ b/crates/virtio-accel-mock/README.md
@@ -5,9 +5,9 @@ harness-controlled execution, and scripted ownership-boundary faults. It is the 
 workspace examples and conformance suite run against.
 
 Part of the [`virtio-accel`](https://github.com/MicroPerceptron/virtio-accel) workspace: an experimental, native-Rust foundation for a
-transport-neutral virtual accelerator device. The workspace contains no Linux ioctls, macOS
-frameworks, Windows APIs, guest physical addresses, vendor command formats, or claimed virtio
-device ID.
+transport-neutral virtual accelerator device. Portable crates contain no host-OS or vendor APIs;
+host integrations live in separate adapter crates and never become their dependencies. The
+project claims no Virtio device ID.
 
 **Portability tier:** `std-reference` — Portable `std`; no host-OS or vendor-specific API.
 

--- a/crates/virtio-accel-proto/README.md
+++ b/crates/virtio-accel-proto/README.md
@@ -5,9 +5,9 @@ candidate. Decoding untrusted bytes never constructs an invalid Rust enum: unkno
 statuses, flags, and event states stay raw integers until they are validated.
 
 Part of the [`virtio-accel`](https://github.com/MicroPerceptron/virtio-accel) workspace: an experimental, native-Rust foundation for a
-transport-neutral virtual accelerator device. The workspace contains no Linux ioctls, macOS
-frameworks, Windows APIs, guest physical addresses, vendor command formats, or claimed virtio
-device ID.
+transport-neutral virtual accelerator device. Portable crates contain no host-OS or vendor APIs;
+host integrations live in separate adapter crates and never become their dependencies. The
+project claims no Virtio device ID.
 
 **Portability tier:** `core-only` — `core` only; no `alloc`, no operating system, no host synchronization.
 

--- a/crates/virtio-accel-split-queue/README.md
+++ b/crates/virtio-accel-split-queue/README.md
@@ -5,9 +5,9 @@ against plain memory so protocol and device behavior can be exercised with no VM
 or guest physical addresses involved.
 
 Part of the [`virtio-accel`](https://github.com/MicroPerceptron/virtio-accel) workspace: an experimental, native-Rust foundation for a
-transport-neutral virtual accelerator device. The workspace contains no Linux ioctls, macOS
-frameworks, Windows APIs, guest physical addresses, vendor command formats, or claimed virtio
-device ID.
+transport-neutral virtual accelerator device. Portable crates contain no host-OS or vendor APIs;
+host integrations live in separate adapter crates and never become their dependencies. The
+project claims no Virtio device ID.
 
 **Portability tier:** `alloc-portable` — `core + alloc`; no operating system, filesystem, sockets, or threads.
 

--- a/crates/virtio-accel-transport/README.md
+++ b/crates/virtio-accel-transport/README.md
@@ -5,9 +5,9 @@ exposes reset-scoped chain identities, flattened direction/length metadata, and 
 publication/completion tokens without leaking guest addresses or concrete descriptor types.
 
 Part of the [`virtio-accel`](https://github.com/MicroPerceptron/virtio-accel) workspace: an experimental, native-Rust foundation for a
-transport-neutral virtual accelerator device. The workspace contains no Linux ioctls, macOS
-frameworks, Windows APIs, guest physical addresses, vendor command formats, or claimed virtio
-device ID.
+transport-neutral virtual accelerator device. Portable crates contain no host-OS or vendor APIs;
+host integrations live in separate adapter crates and never become their dependencies. The
+project claims no Virtio device ID.
 
 **Portability tier:** `core-only` — `core` only; no `alloc`, no operating system, no host synchronization.
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -53,3 +53,23 @@ python3 ci/check-performance-budgets.py --check
 cargo test --test performance_budgets --all-features
 cargo test -p virtio-accel-conformance --all-features
 ```
+
+## Core ML provider evidence
+
+`virtio-accel-coreml` sorts validated binding metadata once in Rust (`O(b log b)`) and uses a
+model-load-time slot plan for a linear Objective-C validation/wrapping pass. Its submission path
+copies no tensor bytes. Read-only allocations may be shared by overlapping predictions; any output
+or read-write use remains exclusive.
+
+The crate includes an ignored release-mode measurement for fixed provider overhead:
+
+```sh
+cargo test --release -p virtio-accel-coreml \
+  measures_warm_submission_and_completion_latency -- --ignored --nocapture
+```
+
+On an Apple M4 running macOS 26.5.2, five runs of 200 measured iterations after 20 warmups reported
+per-run median admission between 5.00 and 5.42 microseconds and median completion between 84.13 and
+91.08 microseconds for the embedded `Float32[8]` model. The pre-pass measurement was 5.25
+microseconds admission and 98.46 microseconds completion. This tiny model is evidence for host and
+Core ML fixed overhead, not representative ANE throughput, and remains non-gating wall-clock data.

--- a/docs/portability.md
+++ b/docs/portability.md
@@ -37,6 +37,13 @@ directly, and they must keep working on any platform the portable crates support
 | `core-only` | `virtio-accel-cleanroom`, `virtio-accel-proto`, `virtio-accel-transport`, `virtio-accel-core` | `core`; the clean-room codec and transport ports have no normal/build dependencies, while proc-macros used by other crates may execute with `std` on the build host |
 | `alloc-portable` | `virtio-accel-guest`, `virtio-accel-split-queue`, `virtio-accel-device`, `virtio-accel` | `core + alloc`; no OS, filesystem, sockets, threads, or host synchronization |
 | `std-reference` | `virtio-accel-mock`, `virtio-accel-conformance` | Portable `std`; no host-OS or vendor-specific API |
+| `host-native` | `virtio-accel-coreml` | Core ML/Foundation on macOS 14+; a compile-only unsupported-platform placeholder elsewhere |
+
+The Core ML crate is not a dependency of the facade or any portable layer. Its Objective-C bridge
+is compiled only when the Cargo target is macOS. The Linux, Windows, and Wasm workspace jobs compile
+the placeholder API, while the macOS native job executes its real model and semantic-conformance
+tests. An accessible Apple Neural Engine is required to construct the real backend; macOS runners
+without one skip execution after checking that availability through Core ML.
 
 Concrete VMM, kernel, OS, and vendor adapters are outside the portable-v1 milestone and must not
 become default dependencies of a portable crate.

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -45,8 +45,9 @@ lifecycle against the portable mock backend.
 Baseline v1 is the mandatory command, queue, object, reset, error, and conformance behavior in the
 normative documents. Reserved feature bits, opcodes, flags, and fields are not optional features;
 they are invalid until a later policy assigns semantics. Platform integrations such as KVM,
-vhost-user, VFIO, Windows, macOS, or vendor SDK adapters are post-v1 work and must not leak into
-portable default dependencies.
+vhost-user, VFIO, Windows, macOS, or vendor SDK adapters do not change protocol 1.0 and must not
+leak into portable default dependencies. `virtio-accel-coreml` is the first concrete example: it
+depends inward on `virtio-accel-core`, while the facade and portable crates do not depend on it.
 
 The compatibility and release classification rules are in
 [`release-policy.md`](release-policy.md). The protocol 1.0 frozen surface is summarized in

--- a/docs/release-policy.md
+++ b/docs/release-policy.md
@@ -92,8 +92,11 @@ tier of an existing crate.
 
 ## Unsafe-code policy
 
-All current crates and fuzz harness support code forbid unsafe code at the crate root. This is an
-intentional v1 invariant, not incidental linting.
+Portable crates, reference crates, and fuzz harness support code forbid unsafe code at the crate
+root. This is an intentional v1 invariant, not incidental linting. The host-native
+`virtio-accel-coreml` adapter is the reviewed exception: its Rust FFI and aligned-allocation code is
+locally documented and audited in `crates/virtio-accel-coreml/SAFETY.md`; non-macOS builds still
+forbid unsafe code.
 
 A future unsafe exception requires all of the following in one reviewed change:
 
@@ -127,7 +130,7 @@ declares its own `description` and `readme`, and carries its own byte-identical 
 root license files do not reach the sub-crate tarballs; the copies exist for that reason and are
 copies rather than symlinks because CI runs `windows-latest`.
 
-`ci/check-release-policy.py` enforces all of this against an explicit ten-crate allowlist. A new
+`ci/check-release-policy.py` enforces all of this against an explicit eleven-crate allowlist. A new
 package fails that check until it is added to the allowlist, which forces a decision about whether
 it is public rather than letting it default either way. The check also validates the crates.io
 keyword and category limits, which neither `cargo package` nor `cargo publish --dry-run` catches
@@ -137,7 +140,7 @@ The `fuzz/` harness is a separate workspace at version `0.0.0` and stays `publis
 
 ## Publication, yank, and rollback
 
-Ten packages are published to crates.io. Publication is ordered: a crate cannot be published before
+Eleven packages are published to crates.io. Publication is ordered: a crate cannot be published before
 every crate it depends on, and that includes development dependencies, because a published crate's
 versioned dev-dependencies must resolve from the registry for `cargo test` to run on the packaged
 source.
@@ -153,7 +156,8 @@ source.
 | 7 | `virtio-accel-mock` | `core` | — |
 | 8 | `virtio-accel-device` | `core`, `proto`, `transport` | `mock` |
 | 9 | `virtio-accel-conformance` | `core` | `mock` |
-| 10 | `virtio-accel` | the six runtime crates | `conformance`, `mock`, `cleanroom` |
+| 10 | `virtio-accel-coreml` | `core` | `conformance` |
+| 11 | `virtio-accel` | the six runtime crates | `conformance`, `mock`, `cleanroom` |
 
 This order is executable, not just documentary: `ci/publish-dry-run.py` walks it against an isolated
 local registry, adding each crate only after it has been built, tested, and documented from its own


### PR DESCRIPTION
## Summary

- add the first host-native accelerator backend using Apple Core ML with `CPUAndNeuralEngine` compute units
- bind host/shared allocations directly to `MLMultiArray` inputs and `MLPredictionOptions.outputBackings`
- integrate asynchronous Core ML completion with the accelerator event model and protect in-flight buffers
- add canonical model-root enforcement, artifact validation, an unsafe-code audit, native end-to-end tests, and reusable conformance coverage
- integrate the new crate into workspace portability, release-policy, and publication checks

## Why

This provides a functioning Apple Silicon host backend capable of making Core ML models available through the portable `virtio-accel-core` provider contract while preserving the protocol's explicit buffer and event semantics.

Core ML is configured to permit CPU and Apple Neural Engine execution. Apple retains per-operation placement control and may use CPU fallback where necessary.

## Validation

- `cargo test -p virtio-accel-coreml`
- `cargo test --workspace --all-targets --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps`
- `cargo check --workspace --target wasm32-unknown-unknown --all-features`
- `cargo +1.85.0 check --workspace --all-targets --all-features`
- `cargo package -p virtio-accel-coreml --allow-dirty --no-verify`
- `python3 ci/publish-dry-run.py --jobs 4`
- release-policy, normative-requirements, portability, formatting, and whitespace checks

## Follow-up in this draft

A completeness and performance pass will follow as additional commits before this draft is marked ready for review.