### PR TITLE
Add C wire ABI and streamline submission admission

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Check release policy invariants
         run: python3 ci/check-release-policy.py
 
+      - name: Check C wire header
+        run: python3 ci/check-c-header.py
+
       - name: Lint all targets
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ include = [
     "/LICENSE-APACHE",
     "/src/**",
     "/examples/**",
+    "/include/**",
     "/tests/**",
     "/docs/**",
     "/conformance/v1.0/**",

--- a/README.md
+++ b/README.md
@@ -251,6 +251,11 @@ The primary `zerocopy` ABI and the manual clean-room codec both decode and re-en
 frame. Their bridge test exchanges bytes only, providing an independent implementation check without
 making the conformance codec a production dependency.
 
+Non-Rust device and driver implementations can include
+[`include/virtio_accel.h`](include/virtio_accel.h). The header is a packed C projection of the wire
+contract, not a host backend plugin ABI. CI compiles it as C11 and C++11 and derives constant,
+size, alignment, and offset assertions from the frozen layout manifest.
+
 ## Writing a backend
 
 Implement the `Accelerator` contract from `virtio-accel-core`, then run the standard semantic suite
@@ -278,6 +283,7 @@ optional resource-accounting and progress adapters, and the fault-injection harn
 | ----------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
 | [specification.md](docs/specification.md)                         | Normative terminology, object model, compatibility rules, mandatory baseline                 |
 | [wire-abi.md](docs/wire-abi.md)                                   | Exact byte layouts and the coordinated change procedure                                      |
+| [virtio_accel.h](include/virtio_accel.h)                          | Checked C and C++ projection of the protocol 1.0 wire contract                               |
 | [virtqueue.md](docs/virtqueue.md)                                 | Command-chain rules                                                                          |
 | [architecture.md](docs/architecture.md)                           | Implementation invariants                                                                    |
 | [threat-model.md](docs/threat-model.md)                           | Trust boundaries and finite resource policy                                                  |

--- a/ci/check-c-header.py
+++ b/ci/check-c-header.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""Compile the public C wire header against the frozen layout manifest."""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+INCLUDE = ROOT / "include"
+MANIFEST = ROOT / "conformance" / "v1.0" / "layout.json"
+
+STRUCT_NAMES = {
+    "WireConfig": "virtio_accel_config",
+    "RequestHeader": "virtio_accel_request_header",
+    "ResponseHeader": "virtio_accel_response_header",
+    "WireDeviceInfo": "virtio_accel_device_info",
+    "CreateContextRequest": "virtio_accel_create_context_request",
+    "ObjectPayload": "virtio_accel_object_payload",
+    "AllocateBufferRequest": "virtio_accel_allocate_buffer_request",
+    "TransferBufferRequest": "virtio_accel_transfer_buffer_request",
+    "LoadProgramRequest": "virtio_accel_load_program_request",
+    "CreateQueueRequest": "virtio_accel_create_queue_request",
+    "SubmitRequest": "virtio_accel_submit_request",
+    "WireBinding": "virtio_accel_binding",
+    "SubmitResponse": "virtio_accel_submit_response",
+    "WireEventState": "virtio_accel_event_state",
+}
+
+FIELD_NAMES = {
+    ("WireDeviceInfo", "class"): "accelerator_class",
+}
+
+SCALAR_NAMESPACES = {
+    "accelerator_classes": "VIRTIO_ACCEL_CLASS_",
+    "memory_domains": "VIRTIO_ACCEL_MEMORY_",
+    "binding_access": "VIRTIO_ACCEL_ACCESS_",
+    "opcodes": "VIRTIO_ACCEL_OP_",
+    "statuses": "VIRTIO_ACCEL_STATUS_",
+    "event_states": "VIRTIO_ACCEL_EVENT_",
+}
+
+
+class Failure(Exception):
+    pass
+
+
+def integer(value: object) -> int:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        return int(value, 0)
+    raise Failure(f"expected an integer or integer string, found {value!r}")
+
+
+def keys(mapping: object, expected: set[str], name: str) -> dict[str, object]:
+    if not isinstance(mapping, dict):
+        raise Failure(f"{name} must be an object")
+    actual = set(mapping)
+    if actual != expected:
+        raise Failure(
+            f"{name} keys changed; missing={sorted(expected - actual)}, "
+            f"unexpected={sorted(actual - expected)}"
+        )
+    return mapping
+
+
+def assertion(expression: str, value: object, name: str) -> str:
+    expected = integer(value)
+    return (
+        f'VA_STATIC_ASSERT((uint64_t)({expression}) == UINT64_C({expected}), "{name}");'
+    )
+
+
+def manifest_assertions(manifest: dict[str, object]) -> list[str]:
+    lines: list[str] = []
+
+    protocol = keys(manifest.get("protocol"), {"major", "minor"}, "protocol")
+    lines.append(assertion("VIRTIO_ACCEL_PROTOCOL_MAJOR", protocol["major"], "protocol.major"))
+    lines.append(assertion("VIRTIO_ACCEL_PROTOCOL_MINOR", protocol["minor"], "protocol.minor"))
+
+    queue_names = {
+        "command_index": "VIRTIO_ACCEL_COMMAND_QUEUE",
+        "baseline_count": "VIRTIO_ACCEL_BASELINE_COMMAND_QUEUES",
+        "hard_max_chain_descriptors": "VIRTIO_ACCEL_HARD_MAX_CHAIN_DESCRIPTORS",
+        "min_max_request_bytes": "VIRTIO_ACCEL_MIN_MAX_REQUEST_BYTES",
+        "min_max_response_bytes": "VIRTIO_ACCEL_MIN_MAX_RESPONSE_BYTES",
+        "hard_max_request_bytes": "VIRTIO_ACCEL_HARD_MAX_REQUEST_BYTES",
+        "hard_max_response_bytes": "VIRTIO_ACCEL_HARD_MAX_RESPONSE_BYTES",
+        "hard_max_bindings": "VIRTIO_ACCEL_HARD_MAX_BINDINGS",
+    }
+    queue = keys(manifest.get("queue"), set(queue_names), "queue")
+    for name, macro in queue_names.items():
+        lines.append(assertion(macro, queue[name], f"queue.{name}"))
+
+    features = keys(manifest.get("features"), {"baseline", "reserved"}, "features")
+    lines.append(
+        assertion("VIRTIO_ACCEL_BASELINE_FEATURES", features["baseline"], "features.baseline")
+    )
+    reserved_features = keys(
+        features["reserved"],
+        {
+            "MULTI_QUEUE",
+            "EVENT_QUEUE",
+            "EXTERNAL_MEMORY",
+            "TIMELINE_FENCES",
+            "SECURE_CONTEXTS",
+        },
+        "features.reserved",
+    )
+    reserved_mask = 0
+    for name, value in reserved_features.items():
+        reserved_mask |= integer(value)
+        lines.append(
+            assertion(
+                f"UINT64_C(1) << VIRTIO_ACCEL_F_{name}", value, f"features.reserved.{name}"
+            )
+        )
+    lines.append(
+        assertion("VIRTIO_ACCEL_RESERVED_FEATURES", reserved_mask, "features.reserved mask")
+    )
+
+    capabilities = keys(
+        manifest.get("capabilities"), {"assigned", "reserved"}, "capabilities"
+    )
+    for group in ("assigned", "reserved"):
+        values = capabilities[group]
+        if not isinstance(values, dict):
+            raise Failure(f"capabilities.{group} must be an object")
+        for name, value in values.items():
+            lines.append(
+                assertion(
+                    f"VIRTIO_ACCEL_CAP_{name}", value, f"capabilities.{group}.{name}"
+                )
+            )
+
+    for namespace, prefix in SCALAR_NAMESPACES.items():
+        values = manifest.get(namespace)
+        if not isinstance(values, dict) or not values:
+            raise Failure(f"{namespace} must be a nonempty object")
+        for name, value in values.items():
+            lines.append(assertion(f"{prefix}{name}", value, f"{namespace}.{name}"))
+
+    buffer_usage = keys(
+        manifest.get("buffer_usage"),
+        {
+            "TRANSFER_SOURCE",
+            "TRANSFER_DESTINATION",
+            "PROGRAM_INPUT",
+            "PROGRAM_OUTPUT",
+            "MUTABLE_STATE",
+            "KNOWN_BITS",
+        },
+        "buffer_usage",
+    )
+    for name, value in buffer_usage.items():
+        macro = (
+            "VIRTIO_ACCEL_KNOWN_BUFFER_USAGE_BITS"
+            if name == "KNOWN_BITS"
+            else f"VIRTIO_ACCEL_BUFFER_{name}"
+        )
+        lines.append(assertion(macro, value, f"buffer_usage.{name}"))
+
+    flag_names = {
+        "REQUEST": "VIRTIO_ACCEL_KNOWN_REQUEST_FLAGS",
+        "CONTEXT": "VIRTIO_ACCEL_KNOWN_CONTEXT_FLAGS",
+        "PROGRAM": "VIRTIO_ACCEL_KNOWN_PROGRAM_FLAGS",
+        "QUEUE": "VIRTIO_ACCEL_KNOWN_QUEUE_FLAGS",
+        "SUBMIT": "VIRTIO_ACCEL_KNOWN_SUBMIT_FLAGS",
+    }
+    flags = keys(manifest.get("known_flags"), set(flag_names), "known_flags")
+    for name, macro in flag_names.items():
+        lines.append(assertion(macro, flags[name], f"known_flags.{name}"))
+
+    structures = keys(manifest.get("structures"), set(STRUCT_NAMES), "structures")
+    for manifest_name, c_name in STRUCT_NAMES.items():
+        layout = keys(structures[manifest_name], {"size", "align", "fields"}, manifest_name)
+        lines.append(
+            assertion(f"sizeof(struct {c_name})", layout["size"], f"{manifest_name}.size")
+        )
+        lines.append(
+            assertion(f"VA_ALIGNOF(struct {c_name})", layout["align"], f"{manifest_name}.align")
+        )
+        fields = layout["fields"]
+        if not isinstance(fields, dict) or not fields:
+            raise Failure(f"{manifest_name}.fields must be a nonempty object")
+        for field, offset in fields.items():
+            c_field = FIELD_NAMES.get((manifest_name, field), field)
+            lines.append(
+                assertion(
+                    f"offsetof(struct {c_name}, {c_field})",
+                    offset,
+                    f"{manifest_name}.{field}",
+                )
+            )
+
+    return lines
+
+
+def compiler(variable: str, fallbacks: tuple[str, ...]) -> list[str]:
+    configured = os.environ.get(variable)
+    if configured:
+        return shlex.split(configured)
+    for candidate in fallbacks:
+        resolved = shutil.which(candidate)
+        if resolved:
+            return [resolved]
+    raise Failure(f"no compiler found for {variable}; tried {', '.join(fallbacks)}")
+
+
+def compile_source(command: list[str], source: pathlib.Path, output: pathlib.Path, cxx: bool) -> None:
+    executable = pathlib.Path(command[0]).stem.lower()
+    if executable in {"cl", "clang-cl"}:
+        standard = "/std:c++14" if cxx else "/std:c11"
+        argv = [
+            *command,
+            "/nologo",
+            standard,
+            "/W4",
+            "/WX",
+            f"/I{INCLUDE}",
+            "/c",
+            str(source),
+            f"/Fo{output}",
+        ]
+    else:
+        standard = "-std=c++11" if cxx else "-std=c11"
+        argv = [
+            *command,
+            standard,
+            "-Wall",
+            "-Wextra",
+            "-Werror",
+            "-pedantic",
+            "-I",
+            str(INCLUDE),
+            "-c",
+            str(source),
+            "-o",
+            str(output),
+        ]
+    print("$", " ".join(shlex.quote(part) for part in argv), flush=True)
+    result = subprocess.run(argv, cwd=ROOT)
+    if result.returncode != 0:
+        raise Failure(f"{source.suffix} header check failed with exit code {result.returncode}")
+
+
+def main() -> int:
+    manifest = json.loads(MANIFEST.read_text())
+    if manifest.get("schema") != "virtio-accel-layout-1":
+        raise Failure(f"unexpected layout schema {manifest.get('schema')!r}")
+
+    checks = "\n".join(manifest_assertions(manifest))
+    common = f"""#include <stddef.h>
+#include <stdint.h>
+#include \"virtio_accel.h\"
+#include \"virtio_accel.h\"
+
+#if defined(__cplusplus)
+#define VA_STATIC_ASSERT(condition, message) static_assert(condition, message)
+#define VA_ALIGNOF(type) alignof(type)
+#else
+#define VA_STATIC_ASSERT(condition, message) _Static_assert(condition, message)
+#define VA_ALIGNOF(type) _Alignof(type)
+#endif
+
+{checks}
+"""
+
+    cc = compiler("CC", ("cc", "clang", "gcc", "cl"))
+    cxx = compiler("CXX", ("c++", "clang++", "g++", "clang-cl", "cl"))
+    with tempfile.TemporaryDirectory(prefix="virtio-accel-c-header-") as temporary:
+        directory = pathlib.Path(temporary)
+        c_source = directory / "check.c"
+        cxx_source = directory / "check.cc"
+        c_source.write_text(common)
+        cxx_source.write_text(common)
+        compile_source(cc, c_source, directory / "check-c.o", cxx=False)
+        compile_source(cxx, cxx_source, directory / "check-cxx.o", cxx=True)
+
+    print(f"validated {len(STRUCT_NAMES)} structures and all scalar namespaces in C and C++")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Failure as error:
+        print(error, file=sys.stderr)
+        raise SystemExit(1)

--- a/ci/publish-dry-run.py
+++ b/ci/publish-dry-run.py
@@ -135,6 +135,9 @@ def check_contents(crate_file: pathlib.Path, name: str, version: str) -> None:
             if required not in contents:
                 raise Failure(f"{name}: tarball is missing {required}")
 
+        if name == "virtio-accel" and "include/virtio_accel.h" not in contents:
+            raise Failure("virtio-accel: tarball is missing include/virtio_accel.h")
+
         for license_name in ("LICENSE-MIT", "LICENSE-APACHE"):
             packaged = tar.extractfile(prefix + license_name)
             assert packaged is not None

--- a/conformance/v1.0/README.md
+++ b/conformance/v1.0/README.md
@@ -4,6 +4,8 @@ This directory contains implementation-independent inputs for the portable proto
 
 - [`layout.json`](layout.json) records protocol constants and every structure size, byte alignment,
   and field offset.
+- [`../../include/virtio_accel.h`](../../include/virtio_accel.h) is the packed C11/C++11 wire
+  projection. CI derives compile-time constant and layout assertions from `layout.json`.
 - [`vectors.json`](vectors.json) contains canonical hexadecimal bytes for the device configuration,
   all 15 request opcodes, every success and command-specific response shape, all event states, and
   reviewed malformed/unknown boundary cases.

--- a/conformance/v1.0/layout.json
+++ b/conformance/v1.0/layout.json
@@ -36,6 +36,37 @@
       "SECURE_CONTEXTS": "0x0000000000000010"
     }
   },
+  "accelerator_classes": {
+    "OTHER": 0,
+    "NPU": 1,
+    "GPU": 2,
+    "DSP": 3
+  },
+  "memory_domains": {
+    "HOST": 1,
+    "DEVICE": 2,
+    "SHARED": 3
+  },
+  "buffer_usage": {
+    "TRANSFER_SOURCE": "0x00000001",
+    "TRANSFER_DESTINATION": "0x00000002",
+    "PROGRAM_INPUT": "0x00000004",
+    "PROGRAM_OUTPUT": "0x00000008",
+    "MUTABLE_STATE": "0x00000010",
+    "KNOWN_BITS": "0x0000001f"
+  },
+  "binding_access": {
+    "READ": 1,
+    "WRITE": 2,
+    "READ_WRITE": 3
+  },
+  "known_flags": {
+    "REQUEST": 0,
+    "CONTEXT": 0,
+    "PROGRAM": 0,
+    "QUEUE": 0,
+    "SUBMIT": 0
+  },
   "opcodes": {
     "GET_DEVICE_INFO": "0x0001",
     "CREATE_CONTEXT": "0x0100",

--- a/conformance/v1.0/performance-budgets.json
+++ b/conformance/v1.0/performance-budgets.json
@@ -80,8 +80,8 @@
     {
       "id": "device.submission_admission",
       "path": "hot",
-      "complexity": "O(b log b + object lookups)",
-      "allocation_profile": "bounded event dependency storage and native binding metadata after decode validation; providers must not allocate hidden direct-binding bounce buffers",
+      "complexity": "O(b log b + object lookups), including O(b) revalidation after canonical slot sorting",
+      "allocation_profile": "bounded event dependency storage and native binding metadata after decode validation; resolved buffer descriptors are validated in place without a mirror allocation; providers must not allocate hidden direct-binding bounce buffers",
       "copy_profile": "metadata only; no full-range program-buffer copy",
       "permitted_copy_boundary": "none",
       "allocates_from_unvalidated_guest_count": false,

--- a/conformance/v1.0/performance-budgets.json
+++ b/conformance/v1.0/performance-budgets.json
@@ -50,7 +50,7 @@
     {
       "id": "transport.segmented_region_access",
       "path": "hot",
-      "complexity": "O(log s + k + n), where s is segment count, k is touched segments, and n is requested bytes",
+      "complexity": "O(s + n) portable worst case; indexed split queue O(log s + k + n), where s is segment count, k is touched segments, and n is requested bytes",
       "allocation_profile": "zero allocations per access; bounded logical span metadata is created with caller-owned chain storage before publication",
       "copy_profile": "exact requested byte range only",
       "permitted_copy_boundary": "explicit ByteSource::read_at or ByteSink::write_at caller request",

--- a/conformance/v1.0/performance-budgets.json
+++ b/conformance/v1.0/performance-budgets.json
@@ -50,8 +50,8 @@
     {
       "id": "transport.segmented_region_access",
       "path": "hot",
-      "complexity": "O(s + n), where s is segment count and n is requested bytes",
-      "allocation_profile": "zero allocations",
+      "complexity": "O(log s + k + n), where s is segment count, k is touched segments, and n is requested bytes",
+      "allocation_profile": "zero allocations per access; bounded logical span metadata is created with caller-owned chain storage before publication",
       "copy_profile": "exact requested byte range only",
       "permitted_copy_boundary": "explicit ByteSource::read_at or ByteSink::write_at caller request",
       "allocates_from_unvalidated_guest_count": false,

--- a/crates/virtio-accel-core/src/lib.rs
+++ b/crates/virtio-accel-core/src/lib.rs
@@ -785,9 +785,13 @@ pub struct BindingRef<'a, B> {
 impl<'a, B> BindingRef<'a, B> {
     /// Slot/count checks plus [`BufferDesc::allows_access`] for each binding.
     ///
-    /// Hosts must call this before [`Accelerator::submit`]. `descs[i]` must be the
-    /// descriptor for the buffer behind `bindings[i].buffer` (equal length alone is
-    /// not enough). A usage mismatch returns [`BackendError::PermissionDenied`].
+    /// Hosts must enforce both checks before [`Accelerator::submit`]. This combined
+    /// helper is suitable when descriptors are already available as a slice. A host
+    /// resolving descriptors individually may call [`validate_bindings`] once and
+    /// [`BufferDesc::allows_access`] as each buffer is resolved, avoiding a descriptor
+    /// mirror allocation. `descs[i]` must be the descriptor for the buffer behind
+    /// `bindings[i].buffer` (equal length alone is not enough). A usage mismatch
+    /// returns [`BackendError::PermissionDenied`].
     pub fn validate_for_submit(
         bindings: &[Self],
         descs: &[BufferDesc],
@@ -811,7 +815,9 @@ impl<'a, B> BindingRef<'a, B> {
 /// Structural only: nonempty, bounded by `max_bindings`, and unique slots. This is
 /// **incomplete** for pre-admission checks -- it does not enforce access/usage
 /// compatibility required before backend admission. Prefer
-/// [`BindingRef::validate_for_submit`] before [`Accelerator::submit`].
+/// [`BindingRef::validate_for_submit`] before [`Accelerator::submit`]. Strictly
+/// slot-ordered input takes a linear, allocation-free path; arbitrary order remains
+/// supported by the allocation-free fallback.
 pub fn validate_bindings<B>(
     bindings: &[BindingRef<'_, B>],
     max_bindings: u32,
@@ -819,6 +825,14 @@ pub fn validate_bindings<B>(
     if bindings.is_empty() || bindings.len() > max_bindings as usize {
         return Err(BackendError::ResourceLimit);
     }
+
+    // The wire decoder canonicalizes bindings into slot order. Recognizing that
+    // invariant here avoids a second quadratic uniqueness pass on every host
+    // submission while preserving the public API's order-independent semantics.
+    if bindings.windows(2).all(|pair| pair[0].slot < pair[1].slot) {
+        return Ok(());
+    }
+
     for (index, binding) in bindings.iter().enumerate() {
         if bindings[..index]
             .iter()
@@ -1054,8 +1068,9 @@ pub trait Accelerator {
     /// Attempt to admit one program execution and return its event.
     ///
     /// Hosts must reject an [`AccessMode`] incompatible with each buffer's [`BufferUsage`] before
-    /// calling this method (see [`BindingRef::validate_for_submit`]). Providers may repeat the check
-    /// as defense in depth, but host-side rejection is required by Wire ABI section 4.4.
+    /// calling this method (see [`BufferDesc::allows_access`] and
+    /// [`BindingRef::validate_for_submit`]). Providers may repeat the check as defense in depth, but
+    /// host-side rejection is required by Wire ABI section 4.4.
     ///
     /// - **Ownership/lifetime:** queue, program, buffers, and the binding slice are borrowed only
     ///   during admission and must not be retained as Rust references. The caller keeps every
@@ -1362,6 +1377,38 @@ mod tests {
             validate_bindings::<()>(&[], 1),
             Err(BackendError::ResourceLimit)
         );
+
+        let arbitrary_order = [
+            BindingRef {
+                slot: 7,
+                buffer: &buffer,
+                range,
+                access: AccessMode::Read,
+            },
+            BindingRef {
+                slot: 2,
+                buffer: &buffer,
+                range,
+                access: AccessMode::Write,
+            },
+        ];
+        assert!(validate_bindings(&arbitrary_order, 2).is_ok());
+
+        let canonical_order = [
+            BindingRef {
+                slot: 2,
+                buffer: &buffer,
+                range,
+                access: AccessMode::Read,
+            },
+            BindingRef {
+                slot: 7,
+                buffer: &buffer,
+                range,
+                access: AccessMode::Write,
+            },
+        ];
+        assert!(validate_bindings(&canonical_order, 2).is_ok());
     }
 
     #[test]

--- a/crates/virtio-accel-device/src/engine.rs
+++ b/crates/virtio-accel-device/src/engine.rs
@@ -8,9 +8,9 @@
 use alloc::vec::Vec;
 
 use virtio_accel_core::{
-    Accelerator, ArtifactRef, BackendError, BindingRef, BufferDesc, BufferRange, BufferUsage,
-    ByteSink, ByteSource, Capabilities, DeviceInfo, DeviceInfoError, EventState, ReleaseFailure,
-    SubmitFailure, Timeout,
+    Accelerator, ArtifactRef, BackendError, BindingRef, BufferRange, BufferUsage, ByteSink,
+    ByteSource, Capabilities, DeviceInfo, DeviceInfoError, EventState, ReleaseFailure,
+    SubmitFailure, Timeout, validate_bindings,
 };
 use virtio_accel_proto::{
     KnownEventState, Le16, Le32, Le64, ObjectPayload, StatusCode, SubmitResponse, WireConfig,
@@ -459,11 +459,7 @@ impl<A: Accelerator> CommandProcessor<A> {
             .state
             .create_event_with(queue_id, program_id, buffer_ids, |resources| {
                 let mut native_bindings = Vec::new();
-                let mut descs: Vec<BufferDesc> = Vec::new();
                 native_bindings
-                    .try_reserve_exact(bindings.len())
-                    .map_err(|_| SubmitCreateError::OutOfMemory)?;
-                descs
                     .try_reserve_exact(bindings.len())
                     .map_err(|_| SubmitCreateError::OutOfMemory)?;
                 for binding in &bindings {
@@ -474,7 +470,9 @@ impl<A: Accelerator> CommandProcessor<A> {
                     if binding.range.end() > desc.bytes() {
                         return Err(SubmitCreateError::Validation(StatusCode::OUT_OF_BOUNDS));
                     }
-                    descs.push(desc);
+                    if !desc.allows_access(binding.access) {
+                        return Err(SubmitCreateError::Validation(StatusCode::PERMISSION_DENIED));
+                    }
                     native_bindings.push(BindingRef {
                         slot: binding.slot,
                         buffer,
@@ -482,9 +480,9 @@ impl<A: Accelerator> CommandProcessor<A> {
                         access: binding.access,
                     });
                 }
-                BindingRef::validate_for_submit(&native_bindings, &descs, max_bindings).map_err(
-                    |error| SubmitCreateError::Validation(status_from_backend_error(error)),
-                )?;
+                validate_bindings(&native_bindings, max_bindings).map_err(|error| {
+                    SubmitCreateError::Validation(status_from_backend_error(error))
+                })?;
                 match accelerator.submit(
                     resources.queue(),
                     resources.program(),

--- a/crates/virtio-accel-guest/src/client.rs
+++ b/crates/virtio-accel-guest/src/client.rs
@@ -835,6 +835,10 @@ where
         if binding_count > info.max_bindings_per_submission {
             return self.start_failure(chain, operation, StartErrorKind::DeviceLimit);
         }
+        // Canonical slot order proves uniqueness in one linear pass. Keep the
+        // prefix-scan fallback below so arbitrary binding order and its existing
+        // validation precedence remain unchanged without allocating scratch space.
+        let bindings_are_canonical = bindings.windows(2).all(|pair| pair[0].slot < pair[1].slot);
         for (index, binding) in bindings.iter().enumerate() {
             if binding.buffer.epoch() != epoch {
                 return self.start_failure(chain, operation, StartErrorKind::StaleHandle);
@@ -842,9 +846,10 @@ where
             if binding.buffer.context != context
                 || !binding.range.fits(binding.buffer.desc.bytes)
                 || !usage_allows(binding.buffer.desc.usage, binding.access)
-                || bindings[..index]
-                    .iter()
-                    .any(|prior| prior.slot == binding.slot)
+                || (!bindings_are_canonical
+                    && bindings[..index]
+                        .iter()
+                        .any(|prior| prior.slot == binding.slot))
             {
                 return self.start_failure(chain, operation, StartErrorKind::InvalidArgument);
             }

--- a/crates/virtio-accel-split-queue/src/chain.rs
+++ b/crates/virtio-accel-split-queue/src/chain.rs
@@ -143,10 +143,16 @@ pub enum ChainBuildError {
 enum ChainAnalysis {
     Valid {
         layout: ChainLayout,
-        order: Box<[u16]>,
+        spans: Box<[DescriptorSpan]>,
         regions: Box<[ChainRegion]>,
     },
     Invalid(MalformedChain),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct DescriptorSpan {
+    descriptor: u16,
+    end: u64,
 }
 
 impl ChainAnalysis {
@@ -157,9 +163,16 @@ impl ChainAnalysis {
         }
     }
 
-    fn order(&self) -> &[u16] {
+    fn spans(&self, writable: bool) -> &[DescriptorSpan] {
         match self {
-            Self::Valid { order, .. } => order,
+            Self::Valid { layout, spans, .. } => {
+                let readable = usize::from(layout.readable_descriptors());
+                if writable {
+                    &spans[readable..]
+                } else {
+                    &spans[..readable]
+                }
+            }
             Self::Invalid(_) => &[],
         }
     }
@@ -491,8 +504,8 @@ fn analyze_chain(
     head: u16,
     visited: &mut [u16],
 ) -> Result<ChainAnalysis, ChainBuildError> {
-    let mut order = Vec::new();
-    order
+    let mut spans = Vec::new();
+    spans
         .try_reserve_exact(descriptors.len())
         .map_err(|_| ChainBuildError::AllocationFailed)?;
     let mut regions = Vec::new();
@@ -500,6 +513,8 @@ fn analyze_chain(
         .try_reserve_exact(descriptors.len())
         .map_err(|_| ChainBuildError::AllocationFailed)?;
 
+    let mut readable_end = 0_u64;
+    let mut writable_end = 0_u64;
     let mut current = head;
     loop {
         let Some(descriptor) = descriptors.get(usize::from(current)) else {
@@ -519,7 +534,19 @@ fn analyze_chain(
             return Ok(ChainAnalysis::Invalid(MalformedChain::Address));
         }
 
-        order.push(current);
+        let logical_end = if descriptor.is_writable() {
+            &mut writable_end
+        } else {
+            &mut readable_end
+        };
+        let Some(end) = logical_end.checked_add(descriptor.len()) else {
+            return Ok(ChainAnalysis::Invalid(MalformedChain::LengthOverflow));
+        };
+        *logical_end = end;
+        spans.push(DescriptorSpan {
+            descriptor: current,
+            end,
+        });
         regions.push(if descriptor.is_writable() {
             ChainRegion::writable(descriptor.len())
         } else {
@@ -532,7 +559,7 @@ fn analyze_chain(
         current = descriptor.next;
     }
 
-    if order.len() != descriptors.len() {
+    if spans.len() != descriptors.len() {
         return Ok(ChainAnalysis::Invalid(MalformedChain::DescriptorCount));
     }
 
@@ -542,9 +569,13 @@ fn analyze_chain(
     };
     Ok(ChainAnalysis::Valid {
         layout,
-        order: order.into_boxed_slice(),
+        spans: spans.into_boxed_slice(),
         regions: regions.into_boxed_slice(),
     })
+}
+
+fn first_touched_span(spans: &[DescriptorSpan], offset: u64) -> usize {
+    spans.partition_point(|span| span.end <= offset)
 }
 
 fn copy_from_descriptors(
@@ -556,24 +587,26 @@ fn copy_from_descriptors(
     if target.is_empty() {
         return Ok(());
     }
-    let mut skip = offset;
     let mut copied = 0;
-    for index in data.analysis.order() {
-        let descriptor = &data.descriptors[usize::from(*index)];
-        if descriptor.is_writable() != writable {
-            continue;
-        }
-        if skip >= descriptor.len() {
-            skip -= descriptor.len();
-            continue;
-        }
-        let available = usize::try_from(descriptor.len() - skip).unwrap_or(usize::MAX);
+    let spans = data.analysis.spans(writable);
+    let first = first_touched_span(spans, offset);
+    for (index, span) in spans.iter().enumerate().skip(first) {
+        let descriptor = &data.descriptors[usize::from(span.descriptor)];
+        let span_start = index.checked_sub(1).map_or(0, |prior| spans[prior].end);
+        let logical_offset = offset + copied as u64;
+        let descriptor_offset = logical_offset
+            .checked_sub(span_start)
+            .ok_or(ByteAccessError::OutOfBounds)?;
+        let span_remaining = span
+            .end
+            .checked_sub(logical_offset)
+            .ok_or(ByteAccessError::OutOfBounds)?;
+        let available = usize::try_from(span_remaining).unwrap_or(usize::MAX);
         let count = min(available, target.len() - copied);
         descriptor
             .buffer
-            .read_at(skip, &mut target[copied..copied + count])?;
+            .read_at(descriptor_offset, &mut target[copied..copied + count])?;
         copied += count;
-        skip = 0;
         if copied == target.len() {
             return Ok(());
         }
@@ -590,24 +623,26 @@ fn copy_to_descriptors(
     if source.is_empty() {
         return Ok(());
     }
-    let mut skip = offset;
     let mut copied = 0;
-    for index in data.analysis.order() {
-        let descriptor = &data.descriptors[usize::from(*index)];
-        if descriptor.is_writable() != writable {
-            continue;
-        }
-        if skip >= descriptor.len() {
-            skip -= descriptor.len();
-            continue;
-        }
-        let available = usize::try_from(descriptor.len() - skip).unwrap_or(usize::MAX);
+    let spans = data.analysis.spans(writable);
+    let first = first_touched_span(spans, offset);
+    for (index, span) in spans.iter().enumerate().skip(first) {
+        let descriptor = &data.descriptors[usize::from(span.descriptor)];
+        let span_start = index.checked_sub(1).map_or(0, |prior| spans[prior].end);
+        let logical_offset = offset + copied as u64;
+        let descriptor_offset = logical_offset
+            .checked_sub(span_start)
+            .ok_or(ByteAccessError::OutOfBounds)?;
+        let span_remaining = span
+            .end
+            .checked_sub(logical_offset)
+            .ok_or(ByteAccessError::OutOfBounds)?;
+        let available = usize::try_from(span_remaining).unwrap_or(usize::MAX);
         let count = min(available, source.len() - copied);
         descriptor
             .buffer
-            .write_at(skip, &source[copied..copied + count])?;
+            .write_at(descriptor_offset, &source[copied..copied + count])?;
         copied += count;
-        skip = 0;
         if copied == source.len() {
             return Ok(());
         }
@@ -646,4 +681,34 @@ fn checked_range(
         .filter(|end| *end <= len)
         .ok_or(ByteAccessError::OutOfBounds)?;
     Ok(start..end)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DescriptorSpan, first_touched_span};
+
+    #[test]
+    fn logical_span_search_skips_every_untouched_descriptor_prefix() {
+        let spans = [
+            DescriptorSpan {
+                descriptor: 4,
+                end: 8,
+            },
+            DescriptorSpan {
+                descriptor: 2,
+                end: 24,
+            },
+            DescriptorSpan {
+                descriptor: 7,
+                end: 32,
+            },
+        ];
+
+        assert_eq!(first_touched_span(&spans, 0), 0);
+        assert_eq!(first_touched_span(&spans, 7), 0);
+        assert_eq!(first_touched_span(&spans, 8), 1);
+        assert_eq!(first_touched_span(&spans, 23), 1);
+        assert_eq!(first_touched_span(&spans, 24), 2);
+        assert_eq!(first_touched_span(&spans, 32), 3);
+    }
 }

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -14,7 +14,7 @@ evidence, but they are not stable enough for ordinary pull-request gating across
 | Config and scalar request decode | `O(1)` | none | fixed scalar bytes only |
 | Non-`SUBMIT` request decode | `O(1)` plus descriptor validation | none | transfer and artifact tails stay borrowed |
 | `SUBMIT` decode | `O(b log b)` | one bounded metadata vector after binding-count validation | binding metadata only |
-| Segmented byte-port access | `O(s + n)` | none | exact caller-requested range |
+| Segmented byte-port access | `O(log s + k + n)` after construction-time indexing | none per access | exact caller-requested range |
 | Object lookup | `O(1)` | none | none |
 | Command dispatch | request-specific | bounded object-table reservation before mutation | response publication, except explicit transfers |
 | Submission admission | `O(b log b)` plus lookups; canonical binding revalidation is `O(b)` | bounded event dependency and binding metadata | no hidden buffer staging |
@@ -25,9 +25,9 @@ evidence, but they are not stable enough for ordinary pull-request gating across
 | TOSA dynamic specialization | `O(d)` plus exact-key cache lookup | caller-bounded key and LRU entries | dynamic CTC bytes only; ordinary tensor inputs are not scanned |
 
 `b` is a validated binding count, `s` is segment count (or the largest TOSA symbol table in the
-TOSA row), `n` is explicitly requested bytes, `f` is verified FlatBuffer structure, and `g` is the
-number of graph objects and edges, and `c` is compile-time-constant data inspected by the semantic
-pass.
+TOSA row), `k` is the number of descriptor segments touched by one logical byte access, `n` is
+explicitly requested bytes, `f` is verified FlatBuffer structure, `g` is the number of graph objects
+and edges, and `c` is compile-time-constant data inspected by the semantic pass.
 
 ## Copy accounting
 
@@ -52,6 +52,11 @@ The decoder's slot sort is also the canonical handoff to core admission. Core an
 recognize strictly increasing slot order in `O(b)` without allocation. Their public APIs continue to
 accept arbitrary binding order through an allocation-free fallback, so this optimization does not
 make ordering semantic.
+
+Split-queue chain construction records bounded logical descriptor spans alongside the flattened
+regions. Each later byte access binary-searches the first touched span instead of rescanning from
+descriptor zero. This metadata is allocated only while the driver owns and constructs the bounded
+chain; queue publication, command decoding, completion, and reset remain allocation-free.
 
 Device admission validates each resolved buffer descriptor in place instead of retaining a parallel
 descriptor vector. The provider-facing binding vector and event-owned buffer dependency vector remain

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -14,7 +14,7 @@ evidence, but they are not stable enough for ordinary pull-request gating across
 | Config and scalar request decode | `O(1)` | none | fixed scalar bytes only |
 | Non-`SUBMIT` request decode | `O(1)` plus descriptor validation | none | transfer and artifact tails stay borrowed |
 | `SUBMIT` decode | `O(b log b)` | one bounded metadata vector after binding-count validation | binding metadata only |
-| Segmented byte-port access | `O(log s + k + n)` after construction-time indexing | none per access | exact caller-requested range |
+| Segmented byte-port access | portable worst case `O(s + n)`; indexed split queue `O(log s + k + n)` | none per access | exact caller-requested range |
 | Object lookup | `O(1)` | none | none |
 | Command dispatch | request-specific | bounded object-table reservation before mutation | response publication, except explicit transfers |
 | Submission admission | `O(b log b)` plus lookups; canonical binding revalidation is `O(b)` | bounded event dependency and binding metadata | no hidden buffer staging |

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -17,7 +17,7 @@ evidence, but they are not stable enough for ordinary pull-request gating across
 | Segmented byte-port access | `O(s + n)` | none | exact caller-requested range |
 | Object lookup | `O(1)` | none | none |
 | Command dispatch | request-specific | bounded object-table reservation before mutation | response publication, except explicit transfers |
-| Submission admission | `O(b log b)` plus lookups | bounded event dependency and binding metadata | no hidden buffer staging |
+| Submission admission | `O(b log b)` plus lookups; canonical binding revalidation is `O(b)` | bounded event dependency and binding metadata | no hidden buffer staging |
 | Polling | `O(1)` | none | event-state response only |
 | Reset | object graph walk | releases existing state; no new guest-count allocation | none |
 | TOSA parse + target semantics | `O(f + g log s + c)` | bounded borrowed-name/symbol/control-flow metadata after FlatBuffer verification | no graph, string, or constant-data copy |
@@ -47,6 +47,15 @@ The portable decoder keeps one bounded `DecodedBinding` vector for `SUBMIT` dupl
 validation. The command engine also owns bounded event dependency and binding metadata while
 admitting a submission. These allocations are deliberately after guest count validation and contain
 metadata only, never program-buffer contents.
+
+The decoder's slot sort is also the canonical handoff to core admission. Core and guest validation
+recognize strictly increasing slot order in `O(b)` without allocation. Their public APIs continue to
+accept arbitrary binding order through an allocation-free fallback, so this optimization does not
+make ordering semantic.
+
+Device admission validates each resolved buffer descriptor in place instead of retaining a parallel
+descriptor vector. The provider-facing binding vector and event-owned buffer dependency vector remain
+necessary, but descriptor validation adds no per-submission allocation.
 
 The current v1 budget treats those metadata allocations as acceptable. It does not permit an
 allocation sized by an unvalidated guest count and does not permit full-range program-buffer copies

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -5,7 +5,8 @@ The public Rust API is split into three documentation layers:
 1. Human-facing contracts in `virtio-accel-core`, `virtio-accel-guest`,
    `virtio-accel-device`, `virtio-accel-transport`, `virtio-accel-tosa`, and
    `virtio-accel-conformance`.
-2. Pointer-free wire mirrors in `virtio-accel-proto`.
+2. Pointer-free wire mirrors in `virtio-accel-proto` and the checked C projection in
+   [`include/virtio_accel.h`](../include/virtio_accel.h).
 3. Independent conformance artifacts and the clean-room codec under `conformance/`.
 
 The first layer documents ownership, blocking behavior, allocation, copy boundaries, and recovery
@@ -21,6 +22,11 @@ normative wire names exactly. Field-level rustdoc would mostly duplicate
 [`wire-abi.md`](wire-abi.md) and increase drift risk. The authoritative field semantics are the
 normative document, [`layout.json`](../conformance/v1.0/layout.json), and
 [`vectors.json`](../conformance/v1.0/vectors.json).
+
+`include/virtio_accel.h` exposes the same constants and packed layouts to C11 and C++11 consumers.
+It deliberately contains no functions, provider handles, allocator hooks, or callbacks: it is a
+wire header, not a stable backend plugin ABI. `ci/check-c-header.py` compiles manifest-derived
+assertions so adding or changing a recorded namespace or layout cannot silently drift the header.
 
 `virtio-accel-cleanroom` is also intentionally raw. It is a dependency-free independent decoder for
 golden-vector validation, not the ergonomic production API. Its public names mirror protocol

--- a/docs/virtqueue.md
+++ b/docs/virtqueue.md
@@ -285,6 +285,12 @@ record table, available ring, and used ring from a validated power-of-two `Queue
 available consumption, out-of-order completion, used consumption, and notification rechecks move
 owned values or update fixed slots; none allocates or coalesces payload bytes.
 
+`DriverChain` records each descriptor's logical byte span during its bounded construction pass.
+Segmented byte access binary-searches the first intersecting span and visits only descriptors that
+contain requested bytes, avoiding repeated prefix scans when a command decoder performs many small
+reads. The span metadata remains caller-owned chain storage and is never allocated from descriptor
+byte lengths.
+
 `DriverChain::direct` constructs the baseline direct profile. `DriverChain::raw` retains malformed
 topology for deterministic device tests, while `SplitQueue::inject_available` bypasses only normal
 driver-side profile validation. Traversal remains bounded by the supplied descriptor table and

--- a/include/virtio_accel.h
+++ b/include/virtio_accel.h
@@ -1,0 +1,346 @@
+/* SPDX-License-Identifier: MIT OR Apache-2.0 */
+#ifndef VIRTIO_ACCEL_H
+#define VIRTIO_ACCEL_H
+
+/*
+ * Language-neutral wire definitions for virtio-accel protocol 1.0.
+ *
+ * The normative contract is docs/wire-abi.md plus docs/virtqueue.md.  This
+ * header is a checked C projection of conformance/v1.0/layout.json; it is not
+ * a host backend plugin ABI.  Every multibyte field is stored little-endian
+ * and every structure is byte-aligned.  Consumers must use unaligned-safe
+ * little-endian loads and stores rather than directly dereferencing packed
+ * multibyte members.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define VIRTIO_ACCEL_PROTOCOL_MAJOR UINT16_C(1)
+#define VIRTIO_ACCEL_PROTOCOL_MINOR UINT16_C(0)
+
+#define VIRTIO_ACCEL_COMMAND_QUEUE UINT16_C(0)
+#define VIRTIO_ACCEL_BASELINE_COMMAND_QUEUES UINT16_C(1)
+#define VIRTIO_ACCEL_HARD_MAX_CHAIN_DESCRIPTORS UINT16_C(256)
+#define VIRTIO_ACCEL_MIN_MAX_REQUEST_BYTES UINT32_C(97)
+#define VIRTIO_ACCEL_MIN_MAX_RESPONSE_BYTES UINT32_C(92)
+#define VIRTIO_ACCEL_HARD_MAX_REQUEST_BYTES UINT32_C(16777216)
+#define VIRTIO_ACCEL_HARD_MAX_RESPONSE_BYTES UINT32_C(16777216)
+#define VIRTIO_ACCEL_HARD_MAX_BINDINGS UINT32_C(4096)
+
+/* Device-specific feature bit positions.  Protocol 1.0 advertises none. */
+#define VIRTIO_ACCEL_F_MULTI_QUEUE 0
+#define VIRTIO_ACCEL_F_EVENT_QUEUE 1
+#define VIRTIO_ACCEL_F_EXTERNAL_MEMORY 2
+#define VIRTIO_ACCEL_F_TIMELINE_FENCES 3
+#define VIRTIO_ACCEL_F_SECURE_CONTEXTS 4
+#define VIRTIO_ACCEL_BASELINE_FEATURES UINT64_C(0)
+#define VIRTIO_ACCEL_RESERVED_FEATURES UINT64_C(0x1f)
+
+/* Semantic capability masks returned by GET_DEVICE_INFO. */
+#define VIRTIO_ACCEL_CAP_HOST_VISIBLE_MEMORY (UINT64_C(1) << 0)
+#define VIRTIO_ACCEL_CAP_DEVICE_LOCAL_MEMORY (UINT64_C(1) << 1)
+#define VIRTIO_ACCEL_CAP_EVENT_CANCELLATION (UINT64_C(1) << 2)
+#define VIRTIO_ACCEL_CAP_EXTERNAL_MEMORY (UINT64_C(1) << 3) /* reserved */
+#define VIRTIO_ACCEL_CAP_SECURE_CONTEXTS (UINT64_C(1) << 4) /* reserved */
+#define VIRTIO_ACCEL_CAP_SHARED_MEMORY (UINT64_C(1) << 5)
+
+/* Accelerator classes.  Unknown uint16_t values remain representable. */
+#define VIRTIO_ACCEL_CLASS_OTHER UINT16_C(0)
+#define VIRTIO_ACCEL_CLASS_NPU UINT16_C(1)
+#define VIRTIO_ACCEL_CLASS_GPU UINT16_C(2)
+#define VIRTIO_ACCEL_CLASS_DSP UINT16_C(3)
+
+/* Buffer placement intent. */
+#define VIRTIO_ACCEL_MEMORY_HOST UINT8_C(1)
+#define VIRTIO_ACCEL_MEMORY_DEVICE UINT8_C(2)
+#define VIRTIO_ACCEL_MEMORY_SHARED UINT8_C(3)
+
+/* Buffer usage masks. */
+#define VIRTIO_ACCEL_BUFFER_TRANSFER_SOURCE (UINT32_C(1) << 0)
+#define VIRTIO_ACCEL_BUFFER_TRANSFER_DESTINATION (UINT32_C(1) << 1)
+#define VIRTIO_ACCEL_BUFFER_PROGRAM_INPUT (UINT32_C(1) << 2)
+#define VIRTIO_ACCEL_BUFFER_PROGRAM_OUTPUT (UINT32_C(1) << 3)
+#define VIRTIO_ACCEL_BUFFER_MUTABLE_STATE (UINT32_C(1) << 4)
+#define VIRTIO_ACCEL_KNOWN_BUFFER_USAGE_BITS UINT32_C(0x1f)
+
+/* Program binding access values. */
+#define VIRTIO_ACCEL_ACCESS_READ UINT8_C(1)
+#define VIRTIO_ACCEL_ACCESS_WRITE UINT8_C(2)
+#define VIRTIO_ACCEL_ACCESS_READ_WRITE UINT8_C(3)
+
+/* Request opcodes. */
+#define VIRTIO_ACCEL_OP_GET_DEVICE_INFO UINT16_C(0x0001)
+#define VIRTIO_ACCEL_OP_CREATE_CONTEXT UINT16_C(0x0100)
+#define VIRTIO_ACCEL_OP_DESTROY_CONTEXT UINT16_C(0x0101)
+#define VIRTIO_ACCEL_OP_ALLOCATE_BUFFER UINT16_C(0x0200)
+#define VIRTIO_ACCEL_OP_FREE_BUFFER UINT16_C(0x0201)
+#define VIRTIO_ACCEL_OP_WRITE_BUFFER UINT16_C(0x0202)
+#define VIRTIO_ACCEL_OP_READ_BUFFER UINT16_C(0x0203)
+#define VIRTIO_ACCEL_OP_LOAD_PROGRAM UINT16_C(0x0300)
+#define VIRTIO_ACCEL_OP_UNLOAD_PROGRAM UINT16_C(0x0301)
+#define VIRTIO_ACCEL_OP_CREATE_QUEUE UINT16_C(0x0400)
+#define VIRTIO_ACCEL_OP_DESTROY_QUEUE UINT16_C(0x0401)
+#define VIRTIO_ACCEL_OP_SUBMIT UINT16_C(0x0500)
+#define VIRTIO_ACCEL_OP_POLL_EVENT UINT16_C(0x0501)
+#define VIRTIO_ACCEL_OP_CANCEL_EVENT UINT16_C(0x0502)
+#define VIRTIO_ACCEL_OP_DESTROY_EVENT UINT16_C(0x0503)
+
+/* Response status values.  Unknown values are opaque non-success failures. */
+#define VIRTIO_ACCEL_STATUS_OK UINT16_C(0)
+#define VIRTIO_ACCEL_STATUS_UNSUPPORTED UINT16_C(1)
+#define VIRTIO_ACCEL_STATUS_INCOMPATIBLE UINT16_C(2)
+#define VIRTIO_ACCEL_STATUS_INVALID_ARGUMENT UINT16_C(3)
+#define VIRTIO_ACCEL_STATUS_OUT_OF_BOUNDS UINT16_C(4)
+#define VIRTIO_ACCEL_STATUS_BUSY UINT16_C(5)
+#define VIRTIO_ACCEL_STATUS_OUT_OF_MEMORY UINT16_C(6)
+#define VIRTIO_ACCEL_STATUS_RESOURCE_LIMIT UINT16_C(7)
+#define VIRTIO_ACCEL_STATUS_DEADLINE_EXPIRED UINT16_C(8)
+#define VIRTIO_ACCEL_STATUS_DEVICE_LOST UINT16_C(9)
+#define VIRTIO_ACCEL_STATUS_PERMISSION_DENIED UINT16_C(10)
+#define VIRTIO_ACCEL_STATUS_STALE_OBJECT UINT16_C(11)
+#define VIRTIO_ACCEL_STATUS_INTERNAL_ERROR UINT16_C(0xffff)
+
+/* Event state values returned by POLL_EVENT. */
+#define VIRTIO_ACCEL_EVENT_PENDING UINT16_C(0)
+#define VIRTIO_ACCEL_EVENT_COMPLETE UINT16_C(1)
+#define VIRTIO_ACCEL_EVENT_FAILED UINT16_C(2)
+#define VIRTIO_ACCEL_EVENT_CANCELLED UINT16_C(3)
+
+/* Protocol 1.0 accepts no request or object-specific flag bits. */
+#define VIRTIO_ACCEL_KNOWN_REQUEST_FLAGS UINT16_C(0)
+#define VIRTIO_ACCEL_KNOWN_CONTEXT_FLAGS UINT32_C(0)
+#define VIRTIO_ACCEL_KNOWN_PROGRAM_FLAGS UINT32_C(0)
+#define VIRTIO_ACCEL_KNOWN_QUEUE_FLAGS UINT32_C(0)
+#define VIRTIO_ACCEL_KNOWN_SUBMIT_FLAGS UINT32_C(0)
+
+/*
+ * C has no standard packed-structure spelling.  The compilers supported by
+ * this project all honor pack(push, 1); the assertions below fail compilation
+ * instead of silently exposing a differently aligned ABI.
+ */
+#pragma pack(push, 1)
+
+struct virtio_accel_config {
+    uint16_t protocol_major;
+    uint16_t protocol_minor;
+    uint16_t command_queue_count;
+    uint16_t max_chain_descriptors;
+    uint32_t max_request_bytes;
+    uint32_t max_response_bytes;
+};
+
+struct virtio_accel_request_header {
+    uint16_t opcode;
+    uint16_t flags;
+    uint32_t payload_bytes;
+    uint64_t request_id;
+};
+
+struct virtio_accel_response_header {
+    uint16_t status;
+    uint16_t flags;
+    uint32_t payload_bytes;
+    uint64_t request_id;
+};
+
+struct virtio_accel_device_info {
+    uint8_t uuid[16];
+    uint16_t accelerator_class;
+    uint16_t reserved;
+    uint32_t vendor_id;
+    uint32_t device_id;
+    uint64_t capabilities;
+    uint32_t max_contexts;
+    uint32_t max_buffers_per_context;
+    uint32_t max_programs_per_context;
+    uint32_t max_queues_per_context;
+    uint32_t max_events_per_context;
+    uint32_t max_bindings_per_submission;
+    uint64_t max_buffer_bytes;
+    uint64_t max_artifact_bytes;
+};
+
+struct virtio_accel_create_context_request {
+    uint32_t flags;
+    uint32_t reserved;
+};
+
+struct virtio_accel_object_payload {
+    uint64_t object_id;
+};
+
+struct virtio_accel_allocate_buffer_request {
+    uint64_t context_id;
+    uint64_t bytes;
+    uint64_t alignment;
+    uint8_t memory_domain;
+    uint8_t reserved0[7];
+    uint32_t usage;
+    uint32_t reserved1;
+};
+
+struct virtio_accel_transfer_buffer_request {
+    uint64_t buffer_id;
+    uint64_t offset;
+    uint64_t bytes;
+};
+
+struct virtio_accel_load_program_request {
+    uint64_t context_id;
+    uint32_t format;
+    uint32_t flags;
+    uint32_t target[12];
+    uint64_t payload_bytes;
+    uint64_t resident_bytes;
+};
+
+struct virtio_accel_create_queue_request {
+    uint64_t context_id;
+    uint32_t flags;
+    uint32_t reserved;
+};
+
+struct virtio_accel_submit_request {
+    uint64_t queue_id;
+    uint64_t program_id;
+    uint32_t binding_count;
+    uint32_t flags;
+    uint64_t timeout_ns;
+};
+
+struct virtio_accel_binding {
+    uint64_t buffer_id;
+    uint64_t offset;
+    uint64_t bytes;
+    uint32_t slot;
+    uint8_t access;
+    uint8_t reserved[3];
+};
+
+struct virtio_accel_submit_response {
+    uint64_t event_id;
+};
+
+struct virtio_accel_event_state {
+    uint16_t state;
+    uint16_t error;
+    uint32_t reserved;
+};
+
+#pragma pack(pop)
+
+#if defined(__cplusplus)
+#define VIRTIO_ACCEL_STATIC_ASSERT(condition, message) static_assert(condition, message)
+#define VIRTIO_ACCEL_ALIGNOF(type) alignof(type)
+#else
+#define VIRTIO_ACCEL_STATIC_ASSERT(condition, message) _Static_assert(condition, message)
+#define VIRTIO_ACCEL_ALIGNOF(type) _Alignof(type)
+#endif
+
+#define VIRTIO_ACCEL_ASSERT_LAYOUT(type, bytes)                                      \
+    VIRTIO_ACCEL_STATIC_ASSERT(sizeof(struct type) == (bytes), #type " size");       \
+    VIRTIO_ACCEL_STATIC_ASSERT(VIRTIO_ACCEL_ALIGNOF(struct type) == 1, #type " align")
+#define VIRTIO_ACCEL_ASSERT_OFFSET(type, field, offset)                              \
+    VIRTIO_ACCEL_STATIC_ASSERT(offsetof(struct type, field) == (offset),             \
+                               #type "." #field " offset")
+
+VIRTIO_ACCEL_ASSERT_LAYOUT(virtio_accel_config, 16);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_config, protocol_major, 0);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_config, protocol_minor, 2);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_config, command_queue_count, 4);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_config, max_chain_descriptors, 6);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_config, max_request_bytes, 8);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_config, max_response_bytes, 12);
+
+VIRTIO_ACCEL_ASSERT_LAYOUT(virtio_accel_request_header, 16);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_request_header, opcode, 0);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_request_header, flags, 2);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_request_header, payload_bytes, 4);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_request_header, request_id, 8);
+
+VIRTIO_ACCEL_ASSERT_LAYOUT(virtio_accel_response_header, 16);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_response_header, status, 0);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_response_header, flags, 2);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_response_header, payload_bytes, 4);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_response_header, request_id, 8);
+
+VIRTIO_ACCEL_ASSERT_LAYOUT(virtio_accel_device_info, 76);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_device_info, uuid, 0);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_device_info, accelerator_class, 16);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_device_info, reserved, 18);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_device_info, vendor_id, 20);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_device_info, device_id, 24);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_device_info, capabilities, 28);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_device_info, max_contexts, 36);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_device_info, max_buffers_per_context, 40);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_device_info, max_programs_per_context, 44);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_device_info, max_queues_per_context, 48);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_device_info, max_events_per_context, 52);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_device_info, max_bindings_per_submission, 56);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_device_info, max_buffer_bytes, 60);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_device_info, max_artifact_bytes, 68);
+
+VIRTIO_ACCEL_ASSERT_LAYOUT(virtio_accel_create_context_request, 8);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_create_context_request, flags, 0);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_create_context_request, reserved, 4);
+
+VIRTIO_ACCEL_ASSERT_LAYOUT(virtio_accel_object_payload, 8);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_object_payload, object_id, 0);
+
+VIRTIO_ACCEL_ASSERT_LAYOUT(virtio_accel_allocate_buffer_request, 40);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_allocate_buffer_request, context_id, 0);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_allocate_buffer_request, bytes, 8);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_allocate_buffer_request, alignment, 16);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_allocate_buffer_request, memory_domain, 24);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_allocate_buffer_request, reserved0, 25);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_allocate_buffer_request, usage, 32);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_allocate_buffer_request, reserved1, 36);
+
+VIRTIO_ACCEL_ASSERT_LAYOUT(virtio_accel_transfer_buffer_request, 24);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_transfer_buffer_request, buffer_id, 0);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_transfer_buffer_request, offset, 8);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_transfer_buffer_request, bytes, 16);
+
+VIRTIO_ACCEL_ASSERT_LAYOUT(virtio_accel_load_program_request, 80);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_load_program_request, context_id, 0);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_load_program_request, format, 8);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_load_program_request, flags, 12);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_load_program_request, target, 16);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_load_program_request, payload_bytes, 64);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_load_program_request, resident_bytes, 72);
+
+VIRTIO_ACCEL_ASSERT_LAYOUT(virtio_accel_create_queue_request, 16);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_create_queue_request, context_id, 0);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_create_queue_request, flags, 8);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_create_queue_request, reserved, 12);
+
+VIRTIO_ACCEL_ASSERT_LAYOUT(virtio_accel_submit_request, 32);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_submit_request, queue_id, 0);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_submit_request, program_id, 8);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_submit_request, binding_count, 16);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_submit_request, flags, 20);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_submit_request, timeout_ns, 24);
+
+VIRTIO_ACCEL_ASSERT_LAYOUT(virtio_accel_binding, 32);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_binding, buffer_id, 0);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_binding, offset, 8);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_binding, bytes, 16);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_binding, slot, 24);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_binding, access, 28);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_binding, reserved, 29);
+
+VIRTIO_ACCEL_ASSERT_LAYOUT(virtio_accel_submit_response, 8);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_submit_response, event_id, 0);
+
+VIRTIO_ACCEL_ASSERT_LAYOUT(virtio_accel_event_state, 8);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_event_state, state, 0);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_event_state, error, 2);
+VIRTIO_ACCEL_ASSERT_OFFSET(virtio_accel_event_state, reserved, 4);
+
+#undef VIRTIO_ACCEL_ASSERT_OFFSET
+#undef VIRTIO_ACCEL_ASSERT_LAYOUT
+#undef VIRTIO_ACCEL_ALIGNOF
+#undef VIRTIO_ACCEL_STATIC_ASSERT
+
+#endif /* VIRTIO_ACCEL_H */


### PR DESCRIPTION
## What changed

- add `include/virtio_accel.h` as a C11/C++11 projection of the frozen protocol 1.0 wire contract
- derive constant, size, alignment, and field-offset checks from `conformance/v1.0/layout.json`
- ship the header in the root crate and verify its presence during publication checks
- recognize canonical slot ordering during binding validation, avoiding quadratic revalidation on the normal submission path
- validate resolved buffer descriptors in place instead of allocating a parallel descriptor vector
- index split-queue logical descriptor spans so repeated segmented reads and writes skip untouched prefixes

## Why

QEMU and other non-Rust VMM/device implementations need a checked C representation of the wire ABI. The submission path also sorted binding slots during decode and then repeated quadratic duplicate detection, while retaining an unnecessary descriptor mirror allocation.

This keeps binding order semantically irrelevant, preserves the allocation-free arbitrary-order fallback, and does not modify any frozen protocol 1.0 byte or ownership semantics.

The split-queue indexing is built with caller-owned chain metadata before publication. Queue publication and byte access remain allocation-free; access improves from a descriptor-prefix scan to `O(log s + k + n)` for the concrete split-queue path.

## Validation

- `python3 ci/check-c-header.py`
- `python3 ci/check-release-policy.py`
- `python3 ci/check-normative-requirements.py --check`
- `python3 ci/check-performance-budgets.py --check`
- `cargo test -p virtio-accel-core`
- `cargo test -p virtio-accel-guest --lib`
- `cargo test -p virtio-accel-device --all-features`
- `cargo test -p virtio-accel-split-queue --all-features`
- `cargo test --test performance_budgets --all-features`
- strict clippy for core, guest, and device
- root package listing contains `include/virtio_accel.h`

The full workspace run reaches three pre-existing Core ML numerical failures around signed-zero/nonfinite edge preservation. The isolated publication walk verifies the first ten packages and then stops in Core ML native model loading with external error code 3 in that isolated environment.
