### PR TITLE
Reuse OpenVINO warm-path metadata safely

### DIFF
--- a/crates/virtio-accel-openvino/README.md
+++ b/crates/virtio-accel-openvino/README.md
@@ -59,6 +59,13 @@ submissions and host transfers with `Busy`, and are released before a terminal s
 published. Finite submission timeouts are enforced best-effort at poll time through
 `ov_infer_request_cancel`, surfacing as `DeadlineExpired`. Event cancellation is not advertised.
 
+Warm submissions reuse the queue's pointer-slot storage and one cleared high-water allocation for
+event backing metadata and bound-tensor metadata. The spare vectors contain capacity only: event
+completion drops all backing guards before recycling their vector, and event destruction frees the
+native request and tensor handles before recycling tensor metadata. Infer requests are never
+pooled because OpenVINO retains the tensor objects bound to a request and exposes no C reset API
+that can prove those guest-memory references detached.
+
 ## Devices
 
 One OpenVINO core is created per process and shared by every backend instance, because plugin

--- a/crates/virtio-accel-openvino/SAFETY.md
+++ b/crates/virtio-accel-openvino/SAFETY.md
@@ -38,6 +38,15 @@ joins the request, then frees the request and tensors, and only then releases th
 runtime threads can never touch freed Rust memory. The backend never creates public slices or
 raw-pointer accessors.
 
+The queue may retain one empty high-water vector allocation for backing metadata and one for
+bound-tensor metadata. Recycling clears and drops every element before the allocation enters the
+queue spare, so a spare owns no OpenVINO handle, `Arc`, backing guard, or buffer pointer. Events
+refer to the queue scratch weakly and therefore cannot extend queue lifetime. The separate
+pointer-slot scratch uses an RAII guard that clears its length on every return path, including a
+rejected submission. Native infer requests themselves are deliberately not pooled: OpenVINO
+retains copied tensor objects after `set_*_tensor_by_index`, and the C API supplies no operation
+that detaches all of those guest-backed tensors before reuse.
+
 OpenVINO receives tensors created from host pointers over Rust-owned memory. Submission
 validates range length and scalar alignment before exposing a bound pointer, and completion
 verifies the output tensor's data pointer before reporting success. A runtime that substitutes

--- a/crates/virtio-accel-openvino/src/native.rs
+++ b/crates/virtio-accel-openvino/src/native.rs
@@ -6,11 +6,13 @@
 //! owns Rust memory.
 
 use std::alloc::{Layout, alloc_zeroed, dealloc};
-use std::cell::{Cell, RefCell};
+use std::cell::{Cell, RefCell, RefMut};
 use std::ffi::{CStr, CString, c_void};
 use std::marker::PhantomData;
+use std::mem;
+use std::ops::{Deref, DerefMut};
 use std::ptr::{self, NonNull};
-use std::rc::Rc;
+use std::rc::{Rc, Weak};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
@@ -384,6 +386,139 @@ impl Drop for TensorHandle {
     }
 }
 
+/// One event-owned tensor plus the information needed to verify direct output backing.
+///
+/// Inputs use a null `expected_output`; output buffer pointers are always non-null because they
+/// originate in a live [`AlignedAllocation`]. Keeping the verification metadata beside the
+/// tensor removes a second per-event allocation.
+struct BoundTensor {
+    _tensor: TensorHandle,
+    output_io_index: usize,
+    expected_output: *mut c_void,
+}
+
+#[derive(Default)]
+struct EventMetadata {
+    tensors: Vec<BoundTensor>,
+    backings: Vec<EventBacking>,
+}
+
+/// Queue-owned warm-path metadata capacity.
+///
+/// Only one empty vector of each kind is retained. Returned vectors are cleared before entering
+/// the spare slots, so this object never owns an OpenVINO handle, a buffer backing guard, or a
+/// guest-memory pointer. Events hold a weak reference so outstanding work cannot keep a queue
+/// alive after its owner destroys it.
+#[derive(Default)]
+struct QueueScratch {
+    pointer_slots: RefCell<Vec<*mut c_void>>,
+    metadata_spare: RefCell<Option<EventMetadata>>,
+}
+
+impl QueueScratch {
+    fn take_pointer_slots(&self, count: usize) -> Result<PointerSlots<'_>, BackendError> {
+        let mut slots = self.pointer_slots.borrow_mut();
+        slots.clear();
+        slots
+            .try_reserve(count)
+            .map_err(|_| BackendError::OutOfMemory)?;
+        slots.resize(count, ptr::null_mut());
+        Ok(PointerSlots { slots })
+    }
+
+    fn take_metadata(
+        &self,
+        backing_count: usize,
+        tensor_count: usize,
+    ) -> Result<EventMetadata, BackendError> {
+        let mut metadata = self.metadata_spare.borrow_mut().take().unwrap_or_default();
+        debug_assert!(metadata.backings.is_empty());
+        debug_assert!(metadata.tensors.is_empty());
+        metadata
+            .backings
+            .try_reserve_exact(backing_count)
+            .map_err(|_| BackendError::OutOfMemory)?;
+        metadata
+            .tensors
+            .try_reserve_exact(tensor_count)
+            .map_err(|_| BackendError::OutOfMemory)?;
+        Ok(metadata)
+    }
+
+    fn recycle_metadata(&self, mut returned: EventMetadata) {
+        returned.tensors.clear();
+        returned.backings.clear();
+        let mut spare = self.metadata_spare.borrow_mut();
+        let returned_capacity = returned
+            .tensors
+            .capacity()
+            .saturating_add(returned.backings.capacity());
+        if spare.as_ref().is_none_or(|current| {
+            current
+                .tensors
+                .capacity()
+                .saturating_add(current.backings.capacity())
+                < returned_capacity
+        }) {
+            *spare = Some(returned);
+        }
+    }
+}
+
+impl std::fmt::Debug for QueueScratch {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("QueueScratch")
+            .field("pointer_capacity", &self.pointer_slots.borrow().capacity())
+            .field(
+                "backing_capacity",
+                &self
+                    .metadata_spare
+                    .borrow()
+                    .as_ref()
+                    .map_or(0, |metadata| metadata.backings.capacity()),
+            )
+            .field(
+                "tensor_capacity",
+                &self
+                    .metadata_spare
+                    .borrow()
+                    .as_ref()
+                    .map_or(0, |metadata| metadata.tensors.capacity()),
+            )
+            .finish()
+    }
+}
+
+/// Borrowed queue pointer slots that are scrubbed on every exit path.
+///
+/// Submission validation needs random slot lookup, but the queue must not retain guest pointers
+/// after `submit` returns, including on rejection. The guard makes that property independent of
+/// every `?` in the admission and native-binding phases.
+struct PointerSlots<'a> {
+    slots: RefMut<'a, Vec<*mut c_void>>,
+}
+
+impl Deref for PointerSlots<'_> {
+    type Target = Vec<*mut c_void>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.slots
+    }
+}
+
+impl DerefMut for PointerSlots<'_> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.slots
+    }
+}
+
+impl Drop for PointerSlots<'_> {
+    fn drop(&mut self) {
+        self.slots.clear();
+    }
+}
+
 /// Owned `ov_model_t`; a short-lived reader artifact freed right after compilation.
 struct ModelHandle {
     model: NonNull<ffi::ov_model_t>,
@@ -575,7 +710,7 @@ impl std::fmt::Debug for OpenVinoProgram {
 #[derive(Debug)]
 pub struct OpenVinoQueue {
     context_id: u64,
-    scratch: RefCell<Vec<*mut c_void>>,
+    scratch: Rc<QueueScratch>,
 }
 
 /// Asynchronous OpenVINO inference event.
@@ -585,9 +720,8 @@ pub struct OpenVinoQueue {
 /// published.
 pub struct OpenVinoEvent {
     request: NonNull<ffi::ov_infer_request_t>,
-    tensors: Vec<TensorHandle>,
-    output_checks: Vec<(usize, *mut c_void)>,
-    backings: RefCell<Vec<EventBacking>>,
+    metadata: RefCell<EventMetadata>,
+    scratch: Weak<QueueScratch>,
     latched: Cell<Option<EventState>>,
     deadline: Option<Instant>,
     cancel_issued: Cell<bool>,
@@ -607,20 +741,38 @@ impl OpenVinoEvent {
     /// Publish the first observed terminal state; guard release precedes latch publication so a
     /// caller observing a terminal state can immediately transfer buffer bytes.
     fn latch(&self, state: EventState) -> EventState {
-        self.backings.borrow_mut().clear();
+        self.metadata.borrow_mut().backings.clear();
         self.latched.set(Some(state));
         state
     }
 
+    fn recycle_metadata(&self) {
+        let mut metadata = self.metadata.borrow_mut();
+        if metadata.tensors.capacity() == 0 && metadata.backings.capacity() == 0 {
+            return;
+        }
+        metadata.tensors.clear();
+        metadata.backings.clear();
+        let returned = mem::take(&mut *metadata);
+        drop(metadata);
+        if let Some(scratch) = self.scratch.upgrade() {
+            scratch.recycle_metadata(returned);
+        }
+    }
+
     /// Verify the runtime executed into the caller's own output allocations.
     fn outputs_are_directly_backed(&self) -> Result<bool, BackendError> {
-        for (io_index, expected) in &self.output_checks {
+        let metadata = self.metadata.borrow();
+        for bound in &metadata.tensors {
+            if bound.expected_output.is_null() {
+                continue;
+            }
             let mut tensor = ptr::null_mut();
             // SAFETY: the request is live; the runtime returns one owned tensor reference.
             check_status(unsafe {
                 ffi::ov_infer_request_get_output_tensor_by_index(
                     self.request.as_ptr(),
-                    *io_index,
+                    bound.output_io_index,
                     &mut tensor,
                 )
             })?;
@@ -632,7 +784,7 @@ impl OpenVinoEvent {
             let mut data = ptr::null_mut();
             // SAFETY: the probe tensor is live and `data` is a valid out-pointer.
             check_status(unsafe { ffi::ov_tensor_data(probe.as_const_ptr(), &mut data) })?;
-            if data != *expected {
+            if data != bound.expected_output {
                 return Ok(false);
             }
         }
@@ -654,8 +806,10 @@ impl Drop for OpenVinoEvent {
             }
         }
         // SAFETY: this handle owns the request reference and frees it exactly once; the bound
-        // tensor handles and backing guards drop afterwards in field order.
+        // tensors are dropped only after this call, then the already-terminal backing guards are
+        // released. This ordering also applies to a pre-start rejection.
         unsafe { ffi::ov_infer_request_free(self.request.as_ptr()) };
+        self.recycle_metadata();
     }
 }
 
@@ -1100,7 +1254,7 @@ impl Accelerator for OpenVinoAccelerator {
         self.info.validate_queue_desc(desc)?;
         Ok(OpenVinoQueue {
             context_id: context.id,
-            scratch: RefCell::new(Vec::new()),
+            scratch: Rc::new(QueueScratch::default()),
         })
     }
 
@@ -1123,16 +1277,14 @@ impl Accelerator for OpenVinoAccelerator {
         if queue.context_id != program.context_id {
             return Err(SubmitFailure::Rejected(BackendError::InvalidArgument));
         }
-        let mut pointers = queue.scratch.borrow_mut();
-        pointers.clear();
-        pointers
-            .try_reserve(program.slots.len())
-            .map_err(|_| SubmitFailure::Rejected(BackendError::OutOfMemory))?;
-        pointers.resize(program.slots.len(), ptr::null_mut());
-        let mut event_backings = Vec::new();
-        event_backings
-            .try_reserve_exact(bindings.len())
-            .map_err(|_| SubmitFailure::Rejected(BackendError::OutOfMemory))?;
+        let mut pointers = queue
+            .scratch
+            .take_pointer_slots(program.slots.len())
+            .map_err(SubmitFailure::Rejected)?;
+        let mut event_metadata = queue
+            .scratch
+            .take_metadata(bindings.len(), program.slots.len())
+            .map_err(SubmitFailure::Rejected)?;
         let mut seen = [0_u64; 4];
         for binding in bindings {
             if binding.buffer.context_id != queue.context_id {
@@ -1163,7 +1315,7 @@ impl Accelerator for OpenVinoAccelerator {
                 return Err(SubmitFailure::Rejected(BackendError::Incompatible));
             }
             pointers[index] = binding.buffer.allocation.pointer_at(start).cast();
-            event_backings.push(EventBacking::new(
+            event_metadata.backings.push(EventBacking::new(
                 Arc::clone(&binding.buffer.allocation),
                 binding.access,
             ));
@@ -1172,7 +1324,7 @@ impl Accelerator for OpenVinoAccelerator {
             return Err(SubmitFailure::Rejected(BackendError::Incompatible));
         }
 
-        prepare_event_backings(&mut event_backings).map_err(SubmitFailure::Rejected)?;
+        prepare_event_backings(&mut event_metadata.backings).map_err(SubmitFailure::Rejected)?;
 
         // Native phase. Failures below free every created handle and reject: nothing observable
         // was started until `start_async` succeeds, so `SubmitFailure::Indeterminate` is never
@@ -1192,11 +1344,10 @@ impl Accelerator for OpenVinoAccelerator {
                 code: 0,
             }));
         };
-        let mut event = OpenVinoEvent {
+        let event = OpenVinoEvent {
             request,
-            tensors: Vec::new(),
-            output_checks: Vec::new(),
-            backings: RefCell::new(event_backings),
+            metadata: RefCell::new(event_metadata),
+            scratch: Rc::downgrade(&queue.scratch),
             // A pre-latched event never re-enters the runtime: on rejection below, `Drop` frees
             // the never-started request and tensors immediately.
             latched: Cell::new(Some(EventState::Failed(BackendError::InvalidArgument))),
@@ -1209,15 +1360,8 @@ impl Accelerator for OpenVinoAccelerator {
             cancel_issued: Cell::new(false),
             _not_send_sync: PhantomData,
         };
-        event
-            .tensors
-            .try_reserve_exact(program.slots.len())
-            .map_err(|_| SubmitFailure::Rejected(BackendError::OutOfMemory))?;
-        event
-            .output_checks
-            .try_reserve_exact(program.slots.len())
-            .map_err(|_| SubmitFailure::Rejected(BackendError::OutOfMemory))?;
 
+        let mut metadata = event.metadata.borrow_mut();
         for (plan, data) in program.slots.iter().zip(pointers.iter()) {
             let tensor = TensorHandle::from_host_ptr(plan.element, plan.shape.as_value(), *data)
                 .map_err(SubmitFailure::Rejected)?;
@@ -1237,11 +1381,17 @@ impl Accelerator for OpenVinoAccelerator {
                 }
             };
             check_status(status).map_err(SubmitFailure::Rejected)?;
-            if plan.role == LoweredFeatureRole::Output {
-                event.output_checks.push((plan.io_index, *data));
-            }
-            event.tensors.push(tensor);
+            metadata.tensors.push(BoundTensor {
+                _tensor: tensor,
+                output_io_index: plan.io_index,
+                expected_output: if plan.role == LoweredFeatureRole::Output {
+                    *data
+                } else {
+                    ptr::null_mut()
+                },
+            });
         }
+        drop(metadata);
 
         // SAFETY: the request is live with every boundary tensor bound.
         let status = unsafe { ffi::ov_infer_request_start_async(event.request.as_ptr()) };
@@ -1413,6 +1563,39 @@ mod tests {
         assert_eq!(pending[0].access, BackingAccess::Exclusive);
     }
 
+    #[test]
+    fn queue_scratch_reuses_only_cleared_metadata_capacity() {
+        let scratch = QueueScratch::default();
+        let allocation = Arc::new(AlignedAllocation::new(32, 16).unwrap());
+
+        let mut metadata = scratch.take_metadata(2, 2).unwrap();
+        let backing_storage = metadata.backings.as_ptr();
+        let tensor_storage = metadata.tensors.as_ptr();
+        metadata
+            .backings
+            .push(EventBacking::new(Arc::clone(&allocation), AccessMode::Read));
+        assert_eq!(Arc::strong_count(&allocation), 2);
+        scratch.recycle_metadata(metadata);
+        assert_eq!(Arc::strong_count(&allocation), 1);
+
+        let reused = scratch.take_metadata(2, 2).unwrap();
+        assert_eq!(reused.backings.as_ptr(), backing_storage);
+        assert_eq!(reused.tensors.as_ptr(), tensor_storage);
+        assert!(reused.backings.is_empty());
+        assert!(reused.tensors.is_empty());
+    }
+
+    #[test]
+    fn pointer_scratch_is_scrubbed_on_every_exit() {
+        let scratch = QueueScratch::default();
+        {
+            let mut slots = scratch.take_pointer_slots(2).unwrap();
+            slots[0] = NonNull::<u8>::dangling().as_ptr().cast();
+            slots[1] = NonNull::<u16>::dangling().as_ptr().cast();
+        }
+        assert!(scratch.pointer_slots.borrow().is_empty());
+    }
+
     /// Pins the runtime facts the lowering design depends on: in-memory IR v11 acceptance with a
     /// null weights tensor, a direct parameter-to-result edge, the variadic property convention
     /// of `ov_core_compile_model`, and index-stable I/O sizes — via the production load path.
@@ -1495,6 +1678,8 @@ mod tests {
                 }
             });
         assert_eq!(wait_for_terminal(&backend, &event), EventState::Complete);
+        assert!(event.metadata.borrow().backings.is_empty());
+        assert!(queue.scratch.metadata_spare.borrow().is_none());
 
         let mut result = vec![0u8; bytes as usize];
         backend
@@ -1504,6 +1689,19 @@ mod tests {
         assert_eq!(backend.direct_binding_admissions(), 2);
 
         backend.destroy_event(event).unwrap();
+        assert!(
+            queue
+                .scratch
+                .metadata_spare
+                .borrow()
+                .as_ref()
+                .is_some_and(|metadata| {
+                    metadata.backings.is_empty()
+                        && metadata.backings.capacity() >= bindings.len()
+                        && metadata.tensors.is_empty()
+                        && metadata.tensors.capacity() >= bindings.len()
+                })
+        );
         backend.destroy_queue(queue).unwrap();
         backend.unload_program(program).unwrap();
         backend.free_buffer(input).unwrap();

--- a/crates/virtio-accel-openvino/tests/openvino.rs
+++ b/crates/virtio-accel-openvino/tests/openvino.rs
@@ -716,6 +716,7 @@ fn measure_warm_latency_on(device: &str) {
         let event = backend
             .submit(&queue, &program, &bindings, Timeout::Infinite)
             .unwrap_or_else(|_| panic!("warm submission rejected"));
+        let admission = started.elapsed();
         let deadline = started + Duration::from_secs(15);
         loop {
             match backend.poll_event(&event).unwrap() {
@@ -727,22 +728,26 @@ fn measure_warm_latency_on(device: &str) {
                 state => panic!("unexpected terminal state {state:?}"),
             }
         }
-        let elapsed = started.elapsed();
+        let completion = started.elapsed();
         backend.destroy_event(event).unwrap();
-        elapsed
+        (admission, completion)
     };
 
     for _ in 0..20 {
         submit_once();
     }
-    let mut samples = (0..200).map(|_| submit_once()).collect::<Vec<_>>();
-    samples.sort_unstable();
+    let (mut admission, mut completion): (Vec<_>, Vec<_>) = (0..200).map(|_| submit_once()).unzip();
+    admission.sort_unstable();
+    completion.sort_unstable();
     eprintln!(
-        "device {}: warm submit-to-complete p50 {:?} p95 {:?} p99 {:?}",
+        "device {}: warm admission p50 {:?} p95 {:?} p99 {:?}; submit-to-complete p50 {:?} p95 {:?} p99 {:?}",
         backend.device_name(),
-        samples[samples.len() / 2],
-        samples[samples.len() * 95 / 100],
-        samples[samples.len() * 99 / 100],
+        admission[admission.len() / 2],
+        admission[admission.len() * 95 / 100],
+        admission[admission.len() * 99 / 100],
+        completion[completion.len() / 2],
+        completion[completion.len() * 95 / 100],
+        completion[completion.len() * 99 / 100],
     );
 
     backend.destroy_queue(queue).unwrap();

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -109,3 +109,31 @@ microseconds admission and 98.46 microseconds completion. The optimization there
 submission allocation/scan work without claiming a timing improvement below the noise floor of this
 micro-model. This is evidence for host and Core ML fixed overhead, not representative ANE
 throughput, and remains non-gating wall-clock data.
+
+## OpenVINO provider evidence
+
+`virtio-accel-openvino` builds the sorted slot/access/shape plan once at program load. Warm
+submission reuses the queue's pointer-slot storage plus one empty high-water vector allocation for
+backing guards and one for tensor/check metadata. Each spare is cleared before the queue can retain
+it; therefore reuse removes Rust metadata allocations without retaining buffer pointers, backing
+guards, tensor handles, or native requests. Concurrent events remain supported: when the one spare
+is occupied, another event allocates independently, and completion retains at most the larger
+returned allocation.
+
+The native infer request remains event-owned and is created for every submission. Pooling it would
+be an unsafe optimization because OpenVINO copies bound tensor objects into the request and its C
+API has no reset operation that detaches all input and output tensors. Submission still copies no
+tensor bytes.
+
+The crate includes an ignored release-mode measurement that reports admission separately from
+submit-to-complete latency:
+
+```sh
+cargo test --release -p virtio-accel-openvino \
+  measures_warm_submission_and_completion_latency -- --ignored --nocapture
+```
+
+Wall-clock results must be recorded on a pinned OpenVINO runtime and identified device before a
+timing claim is made; the deterministic regression tests instead pin capacity reuse, pointer
+scrubbing, guard release at terminal observation, and tensor-metadata release after request
+destruction.


### PR DESCRIPTION
## Summary

- reuse queue pointer-slot storage and one cleared high-water event-metadata spare on sequential warm submissions
- co-locate tensor handles with direct-output checks, removing the separate output-check allocation
- scrub transient guest pointers on every submission exit path with an RAII guard
- keep native infer requests event-owned and recycle tensor metadata only after request destruction
- report OpenVINO admission latency separately from submit-to-complete latency in the manual benchmark
- document the lifecycle, allocation boundary, and safety argument

## Why

The existing OpenVINO path allocated event backing, tensor, and output-check vectors for every submission. This change removes the repeat Rust metadata allocations without weakening direct-binding ownership or concurrent-event behavior.

Native request pooling is intentionally excluded. OpenVINO's C wrapper copies each tensor object into the request in [`ov_infer_request_set_*_tensor_by_index`](https://github.com/openvinotoolkit/openvino/blob/63e3152/src/bindings/c/src/ov_infer_request.cpp), while the [C infer-request API](https://docs.openvino.ai/nightly/api/c_cpp_api/group__ov__infer__request__c__api.html) exposes no reset operation that detaches all input and output tensors. Reusing such a request could retain stale guest-backed memory.

## Validation

- `RUSTFLAGS='--cfg va_openvino' cargo check -p virtio-accel-openvino --all-targets`
- `RUSTFLAGS='--cfg va_openvino' cargo clippy -p virtio-accel-openvino --all-targets -- -D warnings`
- `cargo test -p virtio-accel-openvino`
- `cargo test --workspace --all-features --exclude virtio-accel-coreml`
- `python3 ci/check-performance-budgets.py --check`
- `cargo fmt --all -- --check`
- `git diff --check`

Pinned native OpenVINO execution and the new lifecycle assertions are left to this PR's runtime CI job. A local full-workspace run reached the unrelated Core ML native suite and failed three existing numerical/concurrency cases; this branch does not touch Core ML.