### PR TITLE
Add Qualcomm Hexagon QNN HTP backend

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -37,6 +37,7 @@ cargo run --example backend_conformance
 cargo run --example reference_execution
 cargo run -p virtio-accel-coreml --example tosa_coreml
 cargo run -p virtio-accel-openvino --example tosa_openvino
+cargo run -p virtio-accel-hexagon --example tosa_hexagon
 python3 ci/publish-dry-run.py
 ```
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -38,6 +38,7 @@ cargo run --example reference_execution
 cargo run -p virtio-accel-coreml --example tosa_coreml
 cargo run -p virtio-accel-openvino --example tosa_openvino
 cargo run -p virtio-accel-hexagon --example tosa_hexagon
+cargo run -p virtio-accel-hexagon --example mock_classifier
 python3 ci/publish-dry-run.py
 ```
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,9 @@ jobs:
       - name: Run SDK-free TOSA-to-Hexagon example
         run: cargo run -p virtio-accel-hexagon --example tosa_hexagon
 
+      - name: Run SDK-free Hexagon mock-classifier example
+        run: cargo run -p virtio-accel-hexagon --example mock_classifier
+
       - name: Check release profile
         run: cargo check --workspace --release --all-features
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,9 @@ jobs:
       - name: Run TOSA-to-OpenVINO example
         run: cargo run -p virtio-accel-openvino --example tosa_openvino
 
+      - name: Run SDK-free TOSA-to-Hexagon example
+        run: cargo run -p virtio-accel-hexagon --example tosa_hexagon
+
       - name: Check release profile
         run: cargo check --workspace --release --all-features
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,7 @@
 /fuzz/corpus/
 /fuzz/target/
 
+__pycache__/
+*.py[cod]
+
 .DS_Store

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,7 @@ cargo run --example reference_execution
 cargo run -p virtio-accel-coreml --example tosa_coreml
 cargo run -p virtio-accel-openvino --example tosa_openvino
 cargo run -p virtio-accel-hexagon --example tosa_hexagon
+cargo run -p virtio-accel-hexagon --example mock_classifier
 python3 ci/publish-dry-run.py
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,7 @@ cargo run --example backend_conformance
 cargo run --example reference_execution
 cargo run -p virtio-accel-coreml --example tosa_coreml
 cargo run -p virtio-accel-openvino --example tosa_openvino
+cargo run -p virtio-accel-hexagon --example tosa_hexagon
 python3 ci/publish-dry-run.py
 ```
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,6 +224,7 @@ dependencies = [
 name = "virtio-accel-hexagon"
 version = "0.2.1"
 dependencies = [
+ "cc",
  "virtio-accel-conformance",
  "virtio-accel-core",
  "virtio-accel-tosa",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,6 +221,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "virtio-accel-hexagon"
+version = "0.2.1"
+dependencies = [
+ "virtio-accel-conformance",
+ "virtio-accel-core",
+ "virtio-accel-tosa",
+]
+
+[[package]]
 name = "virtio-accel-mock"
 version = "0.2.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ members = [
     "crates/virtio-accel-coreml",
     "crates/virtio-accel-device",
     "crates/virtio-accel-guest",
+    "crates/virtio-accel-hexagon",
     "crates/virtio-accel-mock",
     "crates/virtio-accel-openvino",
     "crates/virtio-accel-proto",
@@ -63,6 +64,7 @@ virtio-accel-cleanroom = { path = "conformance/rust-clean-room", version = "0.2.
 virtio-accel-conformance = { path = "crates/virtio-accel-conformance", version = "0.2.1" }
 virtio-accel-device = { path = "crates/virtio-accel-device", version = "0.2.1" }
 virtio-accel-guest = { path = "crates/virtio-accel-guest", version = "0.2.1" }
+virtio-accel-hexagon = { path = "crates/virtio-accel-hexagon", version = "0.2.1" }
 virtio-accel-mock = { path = "crates/virtio-accel-mock", version = "0.2.1" }
 virtio-accel-proto = { path = "crates/virtio-accel-proto", version = "0.2.1" }
 virtio-accel-split-queue = { path = "crates/virtio-accel-split-queue", version = "0.2.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ categories = ["no-std", "hardware-support", "virtualization"]
 
 [workspace.dependencies]
 bitflags = { version = "2.13.1", default-features = false }
+cc = "1.2"
 flatbuffers = { version = "=25.2.10", default-features = false }
 serde_json = "1.0.151"
 zerocopy = { version = "0.8.56", default-features = false, features = [

--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ fallback:
 
 ```sh
 cargo run -p virtio-accel-hexagon --example tosa_hexagon
+cargo run -p virtio-accel-hexagon --example mock_classifier
 ```
 
 The portable facade, device engine, transport, and guest layers see only the TOSA artifact format,
@@ -355,6 +356,7 @@ cargo run --example reference_execution
 cargo run -p virtio-accel-coreml --example tosa_coreml # macOS 14+ with ANE
 cargo run -p virtio-accel-openvino --example tosa_openvino # Linux with OpenVINO 2026.x
 cargo run -p virtio-accel-hexagon --example tosa_hexagon # Windows ARM64 with the documented QAIRT setup
+cargo run -p virtio-accel-hexagon --example mock_classifier # FP16 linear classifier on Hexagon HTP
 python3 ci/publish-dry-run.py
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ submissions, and events. The workspace also contains two real host backends: a m
 backend that lowers device-neutral TOSA into Core ML and submits ANE-capable predictions with
 direct buffer bindings, and an Intel OpenVINO backend that lowers the same TOSA artifacts to
 in-memory OpenVINO IR and executes them on NPU, GPU, or CPU inference devices with direct
-host-pointer tensors. The first target is NPU execution, while the object model deliberately
+host-pointer tensors. A separate Qualcomm Hexagon adapter now carries SDK-free strict TOSA-to-QNN
+planning for the initial FP16 subset, while its native HTP execution path remains gated on the full
+QAIRT/QNN C development package and hardware conformance. The first target is NPU execution, while the object model deliberately
 leaves room for GPUs, DSPs, and other program-driven accelerators.
 
 This is no longer a specification-only repository: the frozen protocol review input is developed
@@ -39,7 +41,7 @@ execution. “Not implemented” describes this repository, not necessarily the 
 | Apple Core ML / ANE (`virtio-accel-coreml`) | Implemented; macOS 14+ | Static TOSA 1.0 FP; INT8 tier on macOS 26+ | Supported       | Supported       | Not implemented | Identity + MATMUL | Not implemented | Direct host/shared bindings |
 | Intel OpenVINO (`virtio-accel-openvino`)    | Implemented; OpenVINO 2026.x | Static TOSA 1.0 FP + INT8 tier | Supported       | Supported       | Not implemented | Identity + MATMUL | Not implemented | Direct host/shared bindings |
 | AMD XDNA                                    | Planned                | Not implemented                       | Not implemented | Not implemented | Not implemented | Not implemented | Not implemented | Not implemented             |
-| Qualcomm Hexagon                            | Planned                | Not implemented                       | Not implemented | Not implemented | Not implemented | Not implemented | Not implemented | Not implemented             |
+| Qualcomm Hexagon (`virtio-accel-hexagon`)  | Planned; portable planner implemented | FP16 admission only; native execution pending | Not implemented | Not implemented | Not implemented | Not implemented | Not implemented | Not implemented             |
 
 The Core ML row describes model-boundary support; restricted INT32 outputs are also available.
 Core ML chooses ANE or CPU placement per operation. Direct INT8 boundaries require macOS 26+, and
@@ -57,6 +59,12 @@ the Core ML backend it rejects unsupported FP8, unsupported INT8 operators, and 
 of silently dequantizing. See the
 [`virtio-accel-openvino` support boundary](crates/virtio-accel-openvino/README.md#low-precision-boundary).
 
+The Hexagon row remains `Planned` because portable graph planning is not hardware execution. The
+adapter rejects FP32 and every unadvertised low-precision tier, recognizes only FP16 identity,
+MATMUL, and MAX_POOL2D, and reports `RuntimeUnavailable` until an audited QNN HTP path passes
+conformance on Snapdragon hardware. See the
+[`virtio-accel-hexagon` support boundary](crates/virtio-accel-hexagon/README.md#initial-support-boundary).
+
 Independently of backend execution, `virtio-accel-tosa` validates the TOSA 1.0 profiles and
 extensions for all five dtype columns, and `virtio-accel-conformance` ships shared fixtures and
 oracles for them. The byte-oriented `virtio-accel-mock` backend remains test infrastructure rather
@@ -73,6 +81,7 @@ than a typed hardware implementation.
 | `virtio-accel-tosa`        | `core + alloc` | Bounded zero-copy TOSA 1.0 validation, lowering analysis, specialization, and packed low-precision utilities |
 | `virtio-accel-coreml`      | macOS `std`    | TOSA-to-Core ML lowering, direct buffers, and asynchronous ANE-capable prediction                            |
 | `virtio-accel-openvino`    | Linux `std` (probed) | TOSA-to-OpenVINO IR lowering, direct host-pointer tensors, and asynchronous NPU/GPU/CPU inference      |
+| `virtio-accel-hexagon`     | Windows ARM64 `std` (probed) | Strict FP16 TOSA-to-QNN planning and an SDK-gated Hexagon NPU adapter; native execution remains planned |
 | `virtio-accel-split-queue` | `core + alloc` | Bounded in-memory split-ring reference model                                                                 |
 | `virtio-accel-guest`       | `core + alloc` | Typed reference client with bounded request tracking                                                         |
 | `virtio-accel-device`      | `core + alloc` | Device-owned state, including bounded generational IDs                                                       |
@@ -102,6 +111,9 @@ virtio-accel-coreml ----------+--------------> virtio-accel-core
 virtio-accel-openvino --------+--------------> virtio-accel-core
                               |
                               +--------------> virtio-accel-tosa
+virtio-accel-hexagon ---------+--------------> virtio-accel-core
+                              |
+                              +--------------> virtio-accel-tosa
 other provider adapters --------------------> virtio-accel-core
 ```
 
@@ -127,6 +139,10 @@ On an ANE-capable Mac, add `virtio-accel-coreml = "0.1"` separately for the host
 On a Linux host with an OpenVINO 2026.x runtime, add `virtio-accel-openvino = "0.1"` instead. Both
 adapters accept the production TOSA 1.0 program format; validation, analysis, and native model
 generation all happen inside the adapter. Neither is re-exported by the portable facade.
+
+`virtio-accel-hexagon = "0.2"` exposes the separate Qualcomm adapter scaffold. It is not yet a
+hardware-supported backend: SDK-free builds validate and unit-test its strict FP16 graph planner,
+while constructors return `RuntimeUnavailable` until the audited QNN HTP bridge is completed.
 
 Add `virtio-accel-tosa = "0.1"` separately to validate TOSA 1.0 artifacts, inspect safe borrowed
 graph and typed-attribute views, enforce complete stable-op semantics for a declared target, and
@@ -157,6 +173,13 @@ cargo run -p virtio-accel-openvino --example tosa_openvino
 
 ```text
 TOSA -> OpenVINO -> CPU result: 3.25
+```
+
+The Qualcomm adapter's SDK-free example verifies that unavailable hosts fail explicitly without a
+CPU/GPU fallback:
+
+```sh
+cargo run -p virtio-accel-hexagon --example tosa_hexagon
 ```
 
 The portable facade, device engine, transport, and guest layers see only the TOSA artifact format,
@@ -312,6 +335,7 @@ tier, including compile-only checks of the adapter's unsupported-platform surfac
 | `core + alloc` | `core + alloc`; no OS, filesystem, sockets, threads, or host synchronization |
 | `std`          | Portable `std`; no host-OS or vendor-specific API                            |
 | macOS `std`    | Host-native Core ML/Foundation adapter; never a portable default dependency  |
+| Windows ARM64 `std` | SDK-probed Qualcomm adapter; native HTP execution remains unadvertised until conformance |
 
 Concrete VMM, kernel, OS, and vendor adapters do not change the portable v1 protocol and must not
 become default dependencies of a portable crate. Cargo features must be additive: disabling default
@@ -330,6 +354,7 @@ cargo run --example backend_conformance
 cargo run --example reference_execution
 cargo run -p virtio-accel-coreml --example tosa_coreml # macOS 14+ with ANE
 cargo run -p virtio-accel-openvino --example tosa_openvino # Linux with OpenVINO 2026.x
+cargo run -p virtio-accel-hexagon --example tosa_hexagon # SDK-free probe; HTP path still planned
 python3 ci/publish-dry-run.py
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,13 +12,12 @@ An experimental virtual-accelerator protocol plus production-oriented Rust imple
 
 `virtio-accel` defines a protocol and ships executable `no_std` guest, device, transport, queue, and
 TOSA layers for exposing an accelerator to a guest: contexts, buffers, programs, execution queues,
-submissions, and events. The workspace also contains two real host backends: a macOS Core ML
+submissions, and events. The workspace also contains three real host backends: a macOS Core ML
 backend that lowers device-neutral TOSA into Core ML and submits ANE-capable predictions with
 direct buffer bindings, and an Intel OpenVINO backend that lowers the same TOSA artifacts to
 in-memory OpenVINO IR and executes them on NPU, GPU, or CPU inference devices with direct
-host-pointer tensors. A separate Qualcomm Hexagon adapter now carries SDK-free strict TOSA-to-QNN
-planning for the initial FP16 subset, while its native HTP execution path remains gated on the full
-QAIRT/QNN C development package and hardware conformance. The first target is NPU execution, while the object model deliberately
+host-pointer tensors, and a Qualcomm backend that lowers a strict FP16 TOSA subset to QNN and
+executes it on Hexagon HTP with direct client buffers. The first target is NPU execution, while the object model deliberately
 leaves room for GPUs, DSPs, and other program-driven accelerators.
 
 This is no longer a specification-only repository: the frozen protocol review input is developed
@@ -41,7 +40,7 @@ execution. “Not implemented” describes this repository, not necessarily the 
 | Apple Core ML / ANE (`virtio-accel-coreml`) | Implemented; macOS 14+ | Static TOSA 1.0 FP; INT8 tier on macOS 26+ | Supported       | Supported       | Not implemented | Identity + MATMUL | Not implemented | Direct host/shared bindings |
 | Intel OpenVINO (`virtio-accel-openvino`)    | Implemented; OpenVINO 2026.x | Static TOSA 1.0 FP + INT8 tier | Supported       | Supported       | Not implemented | Identity + MATMUL | Not implemented | Direct host/shared bindings |
 | AMD XDNA                                    | Planned                | Not implemented                       | Not implemented | Not implemented | Not implemented | Not implemented | Not implemented | Not implemented             |
-| Qualcomm Hexagon (`virtio-accel-hexagon`)  | Planned; portable planner implemented | FP16 admission only; native execution pending | Not implemented | Not implemented | Not implemented | Not implemented | Not implemented | Not implemented             |
+| Qualcomm Hexagon (`virtio-accel-hexagon`)  | Experimental; QAIRT 2.49 on Windows ARM64 | Static TOSA 1.0 FP16 subset | Not implemented | Identity + MATMUL + MAX_POOL2D | Not implemented | Not implemented | Not implemented | Direct host/shared bindings |
 
 The Core ML row describes model-boundary support; restricted INT32 outputs are also available.
 Core ML chooses ANE or CPU placement per operation. Direct INT8 boundaries require macOS 26+, and
@@ -59,11 +58,11 @@ the Core ML backend it rejects unsupported FP8, unsupported INT8 operators, and 
 of silently dequantizing. See the
 [`virtio-accel-openvino` support boundary](crates/virtio-accel-openvino/README.md#low-precision-boundary).
 
-The Hexagon row remains `Planned` because portable graph planning is not hardware execution. The
+The Hexagon row is limited to the pinned Snapdragon X126100/QAIRT 2.49 hardware evidence. The
 adapter rejects FP32 and every unadvertised low-precision tier, recognizes only FP16 identity,
-MATMUL, and MAX_POOL2D, and reports `RuntimeUnavailable` until an audited QNN HTP path passes
-conformance on Snapdragon hardware. See the
-[`virtio-accel-hexagon` support boundary](crates/virtio-accel-hexagon/README.md#initial-support-boundary).
+MATMUL, and MAX_POOL2D, and reports `RuntimeUnavailable` when a complete SDK is not selected at
+build time. See the
+[`virtio-accel-hexagon` support boundary](crates/virtio-accel-hexagon/README.md#validated-baseline).
 
 Independently of backend execution, `virtio-accel-tosa` validates the TOSA 1.0 profiles and
 extensions for all five dtype columns, and `virtio-accel-conformance` ships shared fixtures and
@@ -81,7 +80,7 @@ than a typed hardware implementation.
 | `virtio-accel-tosa`        | `core + alloc` | Bounded zero-copy TOSA 1.0 validation, lowering analysis, specialization, and packed low-precision utilities |
 | `virtio-accel-coreml`      | macOS `std`    | TOSA-to-Core ML lowering, direct buffers, and asynchronous ANE-capable prediction                            |
 | `virtio-accel-openvino`    | Linux `std` (probed) | TOSA-to-OpenVINO IR lowering, direct host-pointer tensors, and asynchronous NPU/GPU/CPU inference      |
-| `virtio-accel-hexagon`     | Windows ARM64 `std` (probed) | Strict FP16 TOSA-to-QNN planning and an SDK-gated Hexagon NPU adapter; native execution remains planned |
+| `virtio-accel-hexagon`     | Windows ARM64 `std` (probed) | Strict FP16 TOSA-to-QNN lowering, direct buffers, and asynchronous Hexagon HTP execution |
 | `virtio-accel-split-queue` | `core + alloc` | Bounded in-memory split-ring reference model                                                                 |
 | `virtio-accel-guest`       | `core + alloc` | Typed reference client with bounded request tracking                                                         |
 | `virtio-accel-device`      | `core + alloc` | Device-owned state, including bounded generational IDs                                                       |
@@ -140,9 +139,9 @@ On a Linux host with an OpenVINO 2026.x runtime, add `virtio-accel-openvino = "0
 adapters accept the production TOSA 1.0 program format; validation, analysis, and native model
 generation all happen inside the adapter. Neither is re-exported by the portable facade.
 
-`virtio-accel-hexagon = "0.2"` exposes the separate Qualcomm adapter scaffold. It is not yet a
-hardware-supported backend: SDK-free builds validate and unit-test its strict FP16 graph planner,
-while constructors return `RuntimeUnavailable` until the audited QNN HTP bridge is completed.
+`virtio-accel-hexagon = "0.2"` exposes the separate Qualcomm adapter. A complete QAIRT/QNN SDK on
+Windows ARM64 enables its HTP backend; SDK-free builds validate its strict FP16 graph planner and
+constructors return `RuntimeUnavailable`.
 
 Add `virtio-accel-tosa = "0.1"` separately to validate TOSA 1.0 artifacts, inspect safe borrowed
 graph and typed-attribute views, enforce complete stable-op semantics for a declared target, and
@@ -175,8 +174,9 @@ cargo run -p virtio-accel-openvino --example tosa_openvino
 TOSA -> OpenVINO -> CPU result: 3.25
 ```
 
-The Qualcomm adapter's SDK-free example verifies that unavailable hosts fail explicitly without a
-CPU/GPU fallback:
+With the documented QAIRT environment, the Qualcomm adapter's example executes FP16 identity on
+HTP and verifies the shared numerical oracle. SDK-free builds fail explicitly without a CPU/GPU
+fallback:
 
 ```sh
 cargo run -p virtio-accel-hexagon --example tosa_hexagon
@@ -335,7 +335,7 @@ tier, including compile-only checks of the adapter's unsupported-platform surfac
 | `core + alloc` | `core + alloc`; no OS, filesystem, sockets, threads, or host synchronization |
 | `std`          | Portable `std`; no host-OS or vendor-specific API                            |
 | macOS `std`    | Host-native Core ML/Foundation adapter; never a portable default dependency  |
-| Windows ARM64 `std` | SDK-probed Qualcomm adapter; native HTP execution remains unadvertised until conformance |
+| Windows ARM64 `std` | SDK-probed Qualcomm QNN adapter with a pinned experimental HTP execution tier |
 
 Concrete VMM, kernel, OS, and vendor adapters do not change the portable v1 protocol and must not
 become default dependencies of a portable crate. Cargo features must be additive: disabling default
@@ -354,7 +354,7 @@ cargo run --example backend_conformance
 cargo run --example reference_execution
 cargo run -p virtio-accel-coreml --example tosa_coreml # macOS 14+ with ANE
 cargo run -p virtio-accel-openvino --example tosa_openvino # Linux with OpenVINO 2026.x
-cargo run -p virtio-accel-hexagon --example tosa_hexagon # SDK-free probe; HTP path still planned
+cargo run -p virtio-accel-hexagon --example tosa_hexagon # Windows ARM64 with the documented QAIRT setup
 python3 ci/publish-dry-run.py
 ```
 

--- a/ci/check-release-policy.py
+++ b/ci/check-release-policy.py
@@ -83,6 +83,11 @@ UNSAFE_AUDITS = {
         "cfg_attr(not(va_openvino), forbid(unsafe_code))",
         ("OpenVINO C API", "AlignedAllocation", "poll-latch"),
     ),
+    ROOT / "crates" / "virtio-accel-hexagon" / "src" / "lib.rs": (
+        ROOT / "crates" / "virtio-accel-hexagon" / "SAFETY.md",
+        "cfg_attr(not(va_hexagon), forbid(unsafe_code))",
+        ("public QNN C interface", "AlignedAllocation", "`poll_event`"),
+    ),
     ROOT / "crates" / "virtio-accel-tosa" / "src" / "lib.rs": (
         ROOT / "crates" / "virtio-accel-tosa" / "SAFETY.md",
         "#![deny(unsafe_code)]",

--- a/ci/check-release-policy.py
+++ b/ci/check-release-policy.py
@@ -30,6 +30,7 @@ PUBLISHED_PACKAGES = {
     "crates/virtio-accel-coreml": "virtio-accel-coreml",
     "crates/virtio-accel-device": "virtio-accel-device",
     "crates/virtio-accel-guest": "virtio-accel-guest",
+    "crates/virtio-accel-hexagon": "virtio-accel-hexagon",
     "crates/virtio-accel-mock": "virtio-accel-mock",
     "crates/virtio-accel-openvino": "virtio-accel-openvino",
     "crates/virtio-accel-proto": "virtio-accel-proto",
@@ -116,12 +117,14 @@ def fail(message: str) -> None:
 
 
 def rel(path: pathlib.Path) -> str:
-    return str(path.relative_to(ROOT))
+    # Policy keys and package paths use Cargo's portable forward-slash spelling. Normalizing here
+    # also lets contributors run the release gate directly on Windows.
+    return path.relative_to(ROOT).as_posix()
 
 
 def check_workspace_metadata() -> None:
     """The workspace is the single source of truth for every inherited publish field."""
-    data = tomllib.loads((ROOT / "Cargo.toml").read_text())
+    data = tomllib.loads((ROOT / "Cargo.toml").read_text(encoding="utf-8"))
     workspace_package = data.get("workspace", {}).get("package", {})
 
     for key, expected in INHERITED_PACKAGE_KEYS.items():
@@ -154,7 +157,7 @@ def check_workspace_metadata() -> None:
 
 
 def check_manifest(path: pathlib.Path) -> None:
-    data = tomllib.loads(path.read_text())
+    data = tomllib.loads(path.read_text(encoding="utf-8"))
     package = data.get("package")
     if not isinstance(package, dict):
         fail(f"{rel(path)} has no [package] table")
@@ -214,7 +217,7 @@ def check_published_set() -> None:
 def check_crate_root(path: pathlib.Path) -> None:
     if not path.exists():
         fail(f"missing crate root {rel(path)}")
-    text = path.read_text()
+    text = path.read_text(encoding="utf-8")
     if "#![forbid(unsafe_code)]" in text:
         return
     audit_spec = UNSAFE_AUDITS.get(path)
@@ -225,7 +228,7 @@ def check_crate_root(path: pathlib.Path) -> None:
         fail(f"{rel(path)} unsafe exception is missing {rel(audit)}")
     if root_marker not in text:
         fail(f"{rel(path)} unsafe exception must keep its confinement marker {root_marker!r}")
-    audit_text = audit.read_text()
+    audit_text = audit.read_text(encoding="utf-8")
     for required in required_markers:
         if required not in audit_text:
             fail(f"{rel(audit)} must document the {required!r} unsafe invariant")
@@ -233,7 +236,7 @@ def check_crate_root(path: pathlib.Path) -> None:
 
 def check_links() -> None:
     for path, required in REQUIRED_LINKS.items():
-        text = path.read_text()
+        text = path.read_text(encoding="utf-8")
         for needle in required:
             if needle not in text:
                 fail(f"{rel(path)} must link {needle}")
@@ -261,7 +264,7 @@ def check_publish_workflow() -> None:
     """Keep the token-bearing workflow narrow and coupled to the repository gates."""
     if not PUBLISH_WORKFLOW.is_file():
         fail(f"missing {rel(PUBLISH_WORKFLOW)}")
-    text = PUBLISH_WORKFLOW.read_text()
+    text = PUBLISH_WORKFLOW.read_text(encoding="utf-8")
     required = (
         '"on":\n  release:\n    types:\n      - published',
         "permissions:\n  contents: read",
@@ -295,7 +298,7 @@ def check_publish_workflow() -> None:
         if stripped.startswith("uses:") and not re.search(r"@[0-9a-f]{40}(?:\s|$)", stripped):
             fail(f"{rel(PUBLISH_WORKFLOW)} action is not pinned to a full commit: {stripped}")
 
-    publisher = (ROOT / "ci" / "publish.py").read_text()
+    publisher = (ROOT / "ci" / "publish.py").read_text(encoding="utf-8")
     for fragment in ('"--no-verify"', '"--registry",\n            "crates-io"'):
         if fragment not in publisher:
             fail(
@@ -307,7 +310,7 @@ def check_publish_workflow() -> None:
 def check_fuzz_stays_unpublished() -> None:
     """The fuzz harness is a separate workspace and is deliberately not published."""
     manifest = ROOT / "fuzz" / "Cargo.toml"
-    package = tomllib.loads(manifest.read_text()).get("package", {})
+    package = tomllib.loads(manifest.read_text(encoding="utf-8")).get("package", {})
     if package.get("publish") is not False:
         fail(f"{rel(manifest)} package.publish must remain false")
 

--- a/ci/publication.py
+++ b/ci/publication.py
@@ -29,6 +29,7 @@ PUBLISH_ORDER = (
     "virtio-accel-conformance",
     "virtio-accel-coreml",
     "virtio-accel-openvino",
+    "virtio-accel-hexagon",
     "virtio-accel",
 )
 

--- a/crates/virtio-accel-conformance/src/numerics.rs
+++ b/crates/virtio-accel-conformance/src/numerics.rs
@@ -313,6 +313,42 @@ pub const MATMUL_FP16: TosaFloat16Case = TosaFloat16Case {
     outputs: MATMUL_OUTPUTS_FP16,
 };
 
+const MOCK_CLASSIFIER_FEATURES_FP16_BITS: &[u16] = &[
+    0x3c00, 0x4000, 0x4200, // [1.0, 2.0, 3.0]
+    0xbc00, 0x3800, 0x4000, // [-1.0, 0.5, 2.0]
+];
+const MOCK_CLASSIFIER_WEIGHTS_FP16_BITS: &[u16] = &[
+    0x3c00, 0x0000, // feature 0 -> [1.0, 0.0]
+    0x0000, 0x3c00, // feature 1 -> [0.0, 1.0]
+    0x3c00, 0xbc00, // feature 2 -> [1.0, -1.0]
+];
+const MOCK_CLASSIFIER_LOGITS_FP16_BITS: &[u16] = &[
+    0x4400, 0xbc00, // [4.0, -1.0]
+    0x3c00, 0xbe00, // [1.0, -1.5]
+];
+const MOCK_CLASSIFIER_INPUTS_FP16: &[Float16Tensor] = &[
+    Float16Tensor {
+        shape: &[1, 2, 3],
+        bits: MOCK_CLASSIFIER_FEATURES_FP16_BITS,
+    },
+    Float16Tensor {
+        shape: &[1, 3, 2],
+        bits: MOCK_CLASSIFIER_WEIGHTS_FP16_BITS,
+    },
+];
+const MOCK_CLASSIFIER_OUTPUTS_FP16: &[Float16Tensor] = &[Float16Tensor {
+    shape: &[1, 2, 2],
+    bits: MOCK_CLASSIFIER_LOGITS_FP16_BITS,
+}];
+
+/// Two-sample, three-feature FP16 linear classifier with a direct-bound 3x2 weight matrix.
+pub const MOCK_LINEAR_CLASSIFIER_FP16: TosaFloat16Case = TosaFloat16Case {
+    name: "mock-linear-classifier-fp16",
+    artifact: MATMUL_FP16.artifact,
+    inputs: MOCK_CLASSIFIER_INPUTS_FP16,
+    outputs: MOCK_CLASSIFIER_OUTPUTS_FP16,
+};
+
 const MAX_POOL2D_INPUT_FP16_BITS: &[u16] = &[
     0x3c00, 0x5650, 0x4000, 0x5660, 0x4200, 0x5670, 0x4400, 0x5680, 0x4500, 0x5690, 0x4600, 0x56a0,
     0x4700, 0x56b0, 0x4800, 0x56c0, 0x4880, 0x56d0, 0x4900, 0x56e0, 0x4980, 0x56f0, 0x4a00, 0x5700,
@@ -486,6 +522,7 @@ mod tests {
     #[test]
     fn fp16_oracle_is_exact_except_for_nan_payloads() {
         assert!(MATMUL_FP16.output_matches(0, MATMUL_OUTPUT_FP16_BITS));
+        assert!(MOCK_LINEAR_CLASSIFIER_FP16.output_matches(0, MOCK_CLASSIFIER_LOGITS_FP16_BITS));
         assert!(!MATMUL_FP16.output_matches(0, &[0x5340, 0x5400]));
         assert!(!MATMUL_FP16.output_matches(1, MATMUL_OUTPUT_FP16_BITS));
 

--- a/crates/virtio-accel-coreml/Cargo.toml
+++ b/crates/virtio-accel-coreml/Cargo.toml
@@ -19,4 +19,4 @@ virtio-accel-tosa.workspace = true
 virtio-accel-conformance.workspace = true
 
 [build-dependencies]
-cc = "1.2"
+cc.workspace = true

--- a/crates/virtio-accel-hexagon/Cargo.toml
+++ b/crates/virtio-accel-hexagon/Cargo.toml
@@ -17,3 +17,6 @@ virtio-accel-tosa.workspace = true
 
 [dev-dependencies]
 virtio-accel-conformance.workspace = true
+
+[build-dependencies]
+cc = "1"

--- a/crates/virtio-accel-hexagon/Cargo.toml
+++ b/crates/virtio-accel-hexagon/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "virtio-accel-hexagon"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Qualcomm Hexagon NPU host backend for virtio-accel"
+readme = "README.md"
+
+[dependencies]
+virtio-accel-core.workspace = true
+virtio-accel-tosa.workspace = true
+
+[dev-dependencies]
+virtio-accel-conformance.workspace = true

--- a/crates/virtio-accel-hexagon/Cargo.toml
+++ b/crates/virtio-accel-hexagon/Cargo.toml
@@ -19,4 +19,4 @@ virtio-accel-tosa.workspace = true
 virtio-accel-conformance.workspace = true
 
 [build-dependencies]
-cc = "1"
+cc.workspace = true

--- a/crates/virtio-accel-hexagon/LICENSE-APACHE
+++ b/crates/virtio-accel-hexagon/LICENSE-APACHE
@@ -1,0 +1,176 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/crates/virtio-accel-hexagon/LICENSE-MIT
+++ b/crates/virtio-accel-hexagon/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2026 MicroPerceptron contributors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/crates/virtio-accel-hexagon/README.md
+++ b/crates/virtio-accel-hexagon/README.md
@@ -1,0 +1,68 @@
+# virtio-accel-hexagon
+
+An in-progress Qualcomm Hexagon NPU host backend for `virtio-accel`. The portable portion already
+validates device-neutral TOSA 1.0 artifacts and creates an owned, fixed-slot graph plan for the
+initial FP16 identity, non-square batched MATMUL, and NHWC MAX_POOL2D tier.
+
+**Current status:** portable lowering and build/runtime detection are implemented. Native QNN HTP
+graph construction and execution remain unavailable until the full public QAIRT/QNN C development
+package is supplied. The smaller public QAIRT AppBuilder/Genie bundle does not include the QNN C
+headers or Windows ARM64 `QnnHtp` application import library and is not treated as sufficient.
+
+**Portability tier:** `host-native` when completed; an explicit compile-only unavailable-runtime
+placeholder on SDK-free hosts. This crate is not a dependency of the facade or any portable crate.
+
+## Initial support boundary
+
+The first target is Windows 11 ARM64 on Snapdragon X Series using QAIRT/QNN's HTP backend. The
+portable admission layer currently accepts:
+
+- TOSA 1.0, floating-point profile, level 8K, no extensions;
+- static, positive-shape FP16 tensor boundaries;
+- one region and one basic block with no runtime obligations;
+- identity;
+- non-square batched MATMUL with serialized FP16 zero points equal to positive or negative zero;
+- NHWC MAX_POOL2D with propagating NaNs, a two-dimensional positive kernel/stride, and zero padding.
+
+FP32 is rejected until HTP hardware evidence proves that the selected runtime preserves FP32
+semantics without relaxed or forced FP16 computation. INT8, INT4, FP8, dynamic shapes, additional
+operators, profiles, extensions, layouts, and attributes are also rejected during program
+admission. The backend must never substitute CPU or GPU execution.
+
+## SDK detection
+
+The build script recognizes the following variables:
+
+- `VIRTIO_ACCEL_HEXAGON=0` forces the portable placeholder;
+- `VIRTIO_ACCEL_HEXAGON=1` requires a complete supported SDK and fails loudly otherwise;
+- `VIRTIO_ACCEL_QNN_SDK_ROOT` selects the QAIRT/QNN SDK root;
+- `QNN_SDK_ROOT` is accepted as the conventional fallback root;
+- `VIRTIO_ACCEL_QNN_LIB_DIR` overrides the Windows ARM64 QNN import-library directory.
+
+Autodetection requires Windows ARM64, a public `QnnInterface.h`, and a `QnnHtp` import library. A
+driver-only or inference-only installation does not enable native modules.
+
+## Running
+
+```sh
+cargo test -p virtio-accel-hexagon
+cargo run -p virtio-accel-hexagon --example tosa_hexagon
+```
+
+Without the full QNN development runtime, the example reports why native execution is unavailable
+and exits successfully.
+
+## Hardware baseline discovered during bring-up
+
+The initial development host is a Snapdragon X126100 Windows ARM64 system. Windows enumerates
+`Snapdragon(R) X - X126100 - Qualcomm(R) Hexagon(TM) NPU` in the `ComputeAccelerator` class with
+Qualcomm driver `30.0.222.0` dated 2026-04-01. The driver package includes the V73 HTP stub/skel and
+prepare components, but not the public application-facing QNN C development surface.
+
+No runtime/device row in the repository support matrix should change from `Planned` until the
+native path passes semantic conformance and the advertised numerical corpus on that NPU.
+
+## License
+
+Licensed under either of [Apache License, Version 2.0](LICENSE-APACHE) or
+[MIT license](LICENSE-MIT) at your option.

--- a/crates/virtio-accel-hexagon/README.md
+++ b/crates/virtio-accel-hexagon/README.md
@@ -64,16 +64,19 @@ From the repository root in the configured PowerShell session:
 cargo check -p virtio-accel-hexagon
 cargo test -p virtio-accel-hexagon --all-targets -- --test-threads=1
 cargo run -p virtio-accel-hexagon --example tosa_hexagon
+cargo run -p virtio-accel-hexagon --example mock_classifier
 ```
 
 The integration tests initialize the pinned HTP provider, validate device identity, execute the
-shared FP16 identity, batched non-square MATMUL, and NHWC MAX_POOL2D corpora, compare every result
-with its numerical oracle, reject duplicate slots, wrong access, short bindings, and finite
-timeouts, check stable terminal polling/output visibility, and verify that a live event keeps its
-graph busy. The example prints the actual provider/build/API versions and ends with:
+shared FP16 identity, batched non-square MATMUL, mock linear classifier, and NHWC MAX_POOL2D cases,
+compare every result with its numerical oracle, reject duplicate slots, wrong access, short
+bindings, and finite timeouts, check stable terminal polling/output visibility, and verify that a
+live event keeps its graph busy. The examples print the actual provider/build/API versions and end
+with results such as:
 
 ```text
 TOSA FP16 identity -> QNN HTP v73: passed
+mock FP16 linear classifier -> QNN HTP v73: passed; output=[4400, bc00, 3c00, be00]
 ```
 
 To verify SDK-free portability in a fresh shell:

--- a/crates/virtio-accel-hexagon/README.md
+++ b/crates/virtio-accel-hexagon/README.md
@@ -1,66 +1,87 @@
 # virtio-accel-hexagon
 
-An in-progress Qualcomm Hexagon NPU host backend for `virtio-accel`. The portable portion already
-validates device-neutral TOSA 1.0 artifacts and creates an owned, fixed-slot graph plan for the
-initial FP16 identity, non-square batched MATMUL, and NHWC MAX_POOL2D tier.
+Qualcomm Hexagon NPU host backend for `virtio-accel`. On Windows ARM64, a complete QAIRT/QNN SDK
+enables direct QNN HTP graph execution. Other builds retain the portable TOSA admission tests and
+an explicit `RuntimeUnavailable` placeholder. This crate is not a dependency of the facade or any
+portable crate.
 
-**Current status:** portable lowering and build/runtime detection are implemented. Native QNN HTP
-graph construction and execution remain unavailable until the full public QAIRT/QNN C development
-package is supplied. The smaller public QAIRT AppBuilder/Genie bundle does not include the QNN C
-headers or Windows ARM64 `QnnHtp` application import library and is not treated as sufficient.
+## Validated baseline
 
-**Portability tier:** `host-native` when completed; an explicit compile-only unavailable-runtime
-placeholder on SDK-free hosts. This crate is not a dependency of the facade or any portable crate.
+The initial hardware baseline is:
 
-## Initial support boundary
+- Snapdragon X126100, Hexagon HTP v73;
+- Windows 11 ARM64, Qualcomm NPU driver `30.0.222.0`;
+- QAIRT `2.49.0.260730`;
+- QNN core API `2.38.0`, HTP backend API `5.49.0`.
 
-The first target is Windows 11 ARM64 on Snapdragon X Series using QAIRT/QNN's HTP backend. The
-portable admission layer currently accepts:
+The backend accepts static, positive-shape FP16 TOSA 1.0 graphs containing identity, non-square
+batched MATMUL, and zero-padded NHWC MAX_POOL2D. MAX_POOL2D is expressed as QNN Gather plus
+ElementWiseMaximum nodes because this QAIRT Windows HTP build rejects its documented native
+PoolMax2d tensor parameters at graph finalization. All resulting nodes still execute through the
+HTP backend; there is no CPU or GPU fallback.
 
-- TOSA 1.0, floating-point profile, level 8K, no extensions;
-- static, positive-shape FP16 tensor boundaries;
-- one region and one basic block with no runtime obligations;
-- identity;
-- non-square batched MATMUL with serialized FP16 zero points equal to positive or negative zero;
-- NHWC MAX_POOL2D with propagating NaNs, a two-dimensional positive kernel/stride, and zero padding.
+FP32, quantized types, dynamic shapes, additional operators, profiles, extensions, layouts, and
+attributes are rejected during program admission. The initial execution lane permits one native
+submission at a time. Finite submission timeouts and cancellation are not advertised because the
+validated QNN HTP interface does not provide a working bounded asynchronous execution primitive.
 
-FP32 is rejected until HTP hardware evidence proves that the selected runtime preserves FP32
-semantics without relaxed or forced FP16 computation. INT8, INT4, FP8, dynamic shapes, additional
-operators, profiles, extensions, layouts, and attributes are also rejected during program
-admission. The backend must never substitute CPU or GPU execution.
+## Install and configure QAIRT
 
-## SDK detection
+Download the complete Qualcomm AI Runtime Community SDK, not an AppBuilder/Genie-only bundle. The
+SDK root must contain both:
 
-The build script recognizes the following variables:
+```text
+include\QNN\QnnInterface.h
+lib\aarch64-windows-msvc\QnnHtp.lib
+```
 
-- `VIRTIO_ACCEL_HEXAGON=0` forces the portable placeholder;
-- `VIRTIO_ACCEL_HEXAGON=1` requires a complete supported SDK and fails loudly otherwise;
-- `VIRTIO_ACCEL_QNN_SDK_ROOT` selects the QAIRT/QNN SDK root;
-- `QNN_SDK_ROOT` is accepted as the conventional fallback root;
-- `VIRTIO_ACCEL_QNN_LIB_DIR` overrides the Windows ARM64 QNN import-library directory.
+For the validated archive, extraction to `C:\Qualcomm\AIStack\QAIRT\2.49.0.260730` gives the
+following PowerShell setup:
 
-Autodetection requires Windows ARM64, a public `QnnInterface.h`, and a `QnnHtp` import library. A
-driver-only or inference-only installation does not enable native modules.
+```powershell
+$sdk = 'C:\Qualcomm\AIStack\QAIRT\2.49.0.260730'
+$env:VIRTIO_ACCEL_HEXAGON = '1'
+$env:VIRTIO_ACCEL_QNN_SDK_ROOT = $sdk
+$env:ADSP_LIBRARY_PATH = "$sdk\lib\hexagon-v73\unsigned"
+```
 
-## Running
+`ADSP_LIBRARY_PATH` lets the Windows HTP stub locate the matching v73 DSP libraries. Do not commit
+or redistribute Qualcomm SDK files from this repository.
 
-```sh
-cargo test -p virtio-accel-hexagon
+The build probe also supports:
+
+- `VIRTIO_ACCEL_HEXAGON=0` to force the portable placeholder;
+- `QNN_SDK_ROOT` as a conventional SDK-root fallback;
+- `VIRTIO_ACCEL_QNN_LIB_DIR` to override the Windows ARM64 import-library directory.
+
+Forced-on mode fails immediately when the target is not Windows ARM64 or the SDK is incomplete.
+
+## Manual hardware test
+
+From the repository root in the configured PowerShell session:
+
+```powershell
+cargo check -p virtio-accel-hexagon
+cargo test -p virtio-accel-hexagon --all-targets -- --test-threads=1
 cargo run -p virtio-accel-hexagon --example tosa_hexagon
 ```
 
-Without the full QNN development runtime, the example reports why native execution is unavailable
-and exits successfully.
+The integration tests initialize the pinned HTP provider, validate device identity, execute the
+shared FP16 identity, batched non-square MATMUL, and NHWC MAX_POOL2D corpora, compare every result
+with its numerical oracle, reject duplicate slots, wrong access, short bindings, and finite
+timeouts, check stable terminal polling/output visibility, and verify that a live event keeps its
+graph busy. The example prints the actual provider/build/API versions and ends with:
 
-## Hardware baseline discovered during bring-up
+```text
+TOSA FP16 identity -> QNN HTP v73: passed
+```
 
-The initial development host is a Snapdragon X126100 Windows ARM64 system. Windows enumerates
-`Snapdragon(R) X - X126100 - Qualcomm(R) Hexagon(TM) NPU` in the `ComputeAccelerator` class with
-Qualcomm driver `30.0.222.0` dated 2026-04-01. The driver package includes the V73 HTP stub/skel and
-prepare components, but not the public application-facing QNN C development surface.
+To verify SDK-free portability in a fresh shell:
 
-No runtime/device row in the repository support matrix should change from `Planned` until the
-native path passes semantic conformance and the advertised numerical corpus on that NPU.
+```powershell
+$env:VIRTIO_ACCEL_HEXAGON = '0'
+cargo test -p virtio-accel-hexagon --all-targets
+```
 
 ## License
 

--- a/crates/virtio-accel-hexagon/SAFETY.md
+++ b/crates/virtio-accel-hexagon/SAFETY.md
@@ -1,78 +1,56 @@
-# Qualcomm QNN native-boundary safety plan
+# Qualcomm QNN native-boundary safety argument
 
-The currently compiled SDK-free crate forbids unsafe code. This document defines the review gates
-that must be satisfied before enabling the native QNN modules; it is not evidence that the native
-backend is complete.
+The native backend is compiled only when `build.rs` finds the public QAIRT/QNN headers and Windows
+ARM64 HTP import library. Safe TOSA parsing, semantic admission, shape arithmetic, slot planning,
+and resource-policy checks remain in `lower.rs`. Rust FFI calls are confined to `ffi.rs` and
+`native.rs`; the C++ implementation is confined to `native/qnn_bridge.cpp` and uses only the
+public QNN C interface.
 
-## Boundary
+## ABI and runtime lifetime
 
-Only `ffi.rs` and `native.rs` may eventually contain unsafe code. TOSA parsing, semantic analysis,
-operator admission, graph planning, binding-slot construction, size arithmetic, and test fixtures
-remain safe Rust in `lower.rs`. No Qualcomm type may appear in `virtio-accel-core`,
-`virtio-accel-tosa`, the facade, or another portable crate.
+The bridge loads the SDK's `QnnHtp.dll`, resolves `QnnInterface_getProviders`, selects only the HTP
+backend with the expected core API major and a compatible minor, and verifies every required
+function pointer before use. `RuntimeHandle` owns the loaded DLL, backend, and device. Graphs retain
+that handle through `Rc`, and events retain their graph, so the provider table and DLL necessarily
+outlive every native call.
 
-The bridge must use the public QNN C API obtained from the selected QAIRT SDK. Internal driver APIs,
-the Windows `QnnHtp*Drv` libraries, sample-only interfaces, and layout guesses reconstructed without
-the matching public headers are outside the boundary.
+Each QNN backend, device, context/graph, and event has one native owner. Construction stores each
+handle before the next fallible step and releases the initialized prefix on error. Explicit graph
+or event release changes the stored pointer only after QNN reports success. `ReleaseFailure`
+returns still-live Rust resources on `Busy`; indeterminate native failures do not fabricate
+successful ownership transfer.
 
-## Required native invariants
+## Descriptors and buffers
 
-### Interface and ABI
+`VaQnnGraph` owns tensor names, dimensions, constants, node parameters, and operation configs until
+the graph context is destroyed. Its tensor vector is capacity-checked and reserved before raw
+pointers into those records are retained. Pool-window index and tensor-count arithmetic is checked
+before graph construction.
 
-- Load `QnnInterface_getProviders` from the selected HTP backend and copy only a provider whose
-  core API major/minor range is validated against the headers used at build time.
-- Treat the provider table and every function pointer as live only while the backend DLL remains
-  loaded. The DLL owner must outlive backend, device, context, graph, signal, and tensor use.
-- Reject missing functions and incompatible versions before creating native state. Never call a
-  function pointer merely because a newer table is large enough to contain its slot.
+Every `HexagonBuffer` owns one zero-initialized `AlignedAllocation` with at least 4096-byte
+alignment.
+Submission validates the context, slot, access mode, exact byte length, and checked range before
+passing the allocation's range pointer directly as a QNN raw client buffer. It creates only QNN
+descriptor vectors, never a tensor-content bounce buffer. Events retain `Rc` references and
+shared/exclusive access guards for all allocations until native execution is observed terminal;
+the event retains its graph until release. Host transfers reject an allocation while it is in
+flight.
 
-### Handle ownership and teardown
+## Asynchronous execution
 
-Every QNN backend, device, context, graph, signal, and registered-memory handle has one Rust owner.
-Drop order is the reverse of successful construction. Partial construction stores each new owner
-immediately so an error releases exactly the initialized prefix. Explicit release transfers or
-returns ownership according to `ReleaseFailure`; no handle is released twice.
+QAIRT 2.49's HTP asynchronous graph entry point returns `QNN_COMMON_ERROR_NOT_SUPPORTED` on the
+validated Windows target. The bridge therefore admits at most one request and moves blocking
+`graphExecute` to one owned `std::thread`. `submit` returns after thread creation; `poll_event`
+reads atomic state only and never calls QNN. The worker writes the QNN result, clears the runtime's
+in-flight gate, and then publishes a terminal event with release ordering. Event destruction joins
+the terminal worker before releasing its descriptors, graph, or allocation guards.
 
-An unrecoverable HTP result poisons the backend. The process does not try to reconstruct unknown
-native ownership by reusing a context, graph, signal, or buffer registration after device loss.
+Finite deadlines are rejected before admission. Cancellation is not advertised. Consequently no
+timeout or cancellation path can release memory while HTP may still access it.
 
-### Tensor descriptors and direct buffers
+## Audited unsafe operations
 
-- A program owns all QNN tensor names, dimensions, scalar/quantization descriptors, operation
-  configs, and parameter storage until the documented QNN copy point. Anything documented as
-  retained remains program-owned through graph destruction.
-- A buffer owns one aligned, zero-initialized allocation. The exact pointer and bound range passed
-  by the caller become the QNN client buffer or registered-memory view used at dispatch.
-- Submission may create small descriptor metadata but never an input/output allocation or content
-  copy. The program and every bound allocation remain strongly owned until the event is terminal
-  and released.
-- Explicit read/write operations perform any required QNN/HTP synchronization around the existing
-  allocation. They are the only provider content-copy boundaries.
-
-### Worker and event synchronization
-
-The initial backend has one bounded serialized lane per device. `submit` reserves access guards and
-enqueues owned work without waiting for QNN execution. The worker may call blocking QNN execution;
-`poll_event` reads only an atomic/locked Rust latch and never enters QNN.
-
-The worker releases output synchronization and buffer guards before publishing a terminal state.
-The event retains its program, descriptor storage, allocations, and native completion state until
-release. No callback receives a pointer to stack storage. If a QNN callback is used, its context is
-an `Arc` raw pointer with an audited exactly-once foreign/Rust reference transfer.
-
-### Cancellation and timeouts
-
-Cancellation is advertised only if the selected QNN signal API proves bounded, race-safe
-cancellation. Otherwise a finite timeout may reject before admission, but accepted native work
-retains its event and allocation ownership until the worker observes completion. A timeout never
-causes early descriptor or buffer destruction.
-
-## Audit evidence required before native enablement
-
-- Build the native boundary against the exact pinned QAIRT headers and Windows ARM64 libraries.
-- Run malformed-input, lifecycle, concurrency, timeout, device-loss, and exact-once teardown tests.
-- Pass the reusable semantic suite and every advertised FP16 numerical fixture on HTP.
-- Demonstrate exact pointer/range binding and zero provider-staged submissions through conformance
-  diagnostics.
-- Record runtime logs proving HTP placement and no CPU/GPU partition.
-- Add local `SAFETY:` comments to every unsafe block naming the invariant above that makes it valid.
+Every Rust unsafe block has a local `SAFETY:` comment covering its pointer validity, allocation
+layout, ownership, and call duration. The native integration tests exercise numerical execution,
+stable terminal polling, pre-admission timeout rejection, live-event graph retention, and ordered
+teardown on the pinned HTP runtime. Unsupported hosts compile without either native module.

--- a/crates/virtio-accel-hexagon/SAFETY.md
+++ b/crates/virtio-accel-hexagon/SAFETY.md
@@ -1,0 +1,78 @@
+# Qualcomm QNN native-boundary safety plan
+
+The currently compiled SDK-free crate forbids unsafe code. This document defines the review gates
+that must be satisfied before enabling the native QNN modules; it is not evidence that the native
+backend is complete.
+
+## Boundary
+
+Only `ffi.rs` and `native.rs` may eventually contain unsafe code. TOSA parsing, semantic analysis,
+operator admission, graph planning, binding-slot construction, size arithmetic, and test fixtures
+remain safe Rust in `lower.rs`. No Qualcomm type may appear in `virtio-accel-core`,
+`virtio-accel-tosa`, the facade, or another portable crate.
+
+The bridge must use the public QNN C API obtained from the selected QAIRT SDK. Internal driver APIs,
+the Windows `QnnHtp*Drv` libraries, sample-only interfaces, and layout guesses reconstructed without
+the matching public headers are outside the boundary.
+
+## Required native invariants
+
+### Interface and ABI
+
+- Load `QnnInterface_getProviders` from the selected HTP backend and copy only a provider whose
+  core API major/minor range is validated against the headers used at build time.
+- Treat the provider table and every function pointer as live only while the backend DLL remains
+  loaded. The DLL owner must outlive backend, device, context, graph, signal, and tensor use.
+- Reject missing functions and incompatible versions before creating native state. Never call a
+  function pointer merely because a newer table is large enough to contain its slot.
+
+### Handle ownership and teardown
+
+Every QNN backend, device, context, graph, signal, and registered-memory handle has one Rust owner.
+Drop order is the reverse of successful construction. Partial construction stores each new owner
+immediately so an error releases exactly the initialized prefix. Explicit release transfers or
+returns ownership according to `ReleaseFailure`; no handle is released twice.
+
+An unrecoverable HTP result poisons the backend. The process does not try to reconstruct unknown
+native ownership by reusing a context, graph, signal, or buffer registration after device loss.
+
+### Tensor descriptors and direct buffers
+
+- A program owns all QNN tensor names, dimensions, scalar/quantization descriptors, operation
+  configs, and parameter storage until the documented QNN copy point. Anything documented as
+  retained remains program-owned through graph destruction.
+- A buffer owns one aligned, zero-initialized allocation. The exact pointer and bound range passed
+  by the caller become the QNN client buffer or registered-memory view used at dispatch.
+- Submission may create small descriptor metadata but never an input/output allocation or content
+  copy. The program and every bound allocation remain strongly owned until the event is terminal
+  and released.
+- Explicit read/write operations perform any required QNN/HTP synchronization around the existing
+  allocation. They are the only provider content-copy boundaries.
+
+### Worker and event synchronization
+
+The initial backend has one bounded serialized lane per device. `submit` reserves access guards and
+enqueues owned work without waiting for QNN execution. The worker may call blocking QNN execution;
+`poll_event` reads only an atomic/locked Rust latch and never enters QNN.
+
+The worker releases output synchronization and buffer guards before publishing a terminal state.
+The event retains its program, descriptor storage, allocations, and native completion state until
+release. No callback receives a pointer to stack storage. If a QNN callback is used, its context is
+an `Arc` raw pointer with an audited exactly-once foreign/Rust reference transfer.
+
+### Cancellation and timeouts
+
+Cancellation is advertised only if the selected QNN signal API proves bounded, race-safe
+cancellation. Otherwise a finite timeout may reject before admission, but accepted native work
+retains its event and allocation ownership until the worker observes completion. A timeout never
+causes early descriptor or buffer destruction.
+
+## Audit evidence required before native enablement
+
+- Build the native boundary against the exact pinned QAIRT headers and Windows ARM64 libraries.
+- Run malformed-input, lifecycle, concurrency, timeout, device-loss, and exact-once teardown tests.
+- Pass the reusable semantic suite and every advertised FP16 numerical fixture on HTP.
+- Demonstrate exact pointer/range binding and zero provider-staged submissions through conformance
+  diagnostics.
+- Record runtime logs proving HTP placement and no CPU/GPU partition.
+- Add local `SAFETY:` comments to every unsafe block naming the invariant above that makes it valid.

--- a/crates/virtio-accel-hexagon/build.rs
+++ b/crates/virtio-accel-hexagon/build.rs
@@ -44,16 +44,18 @@ fn main() {
         return;
     };
 
-    let header = [
-        root.join("include/QNN/QnnInterface.h"),
-        root.join("include/QnnInterface.h"),
-    ]
-    .into_iter()
-    .find(|candidate| candidate.is_file());
-    let Some(header) = header else {
+    let required_headers = ["QnnInterface.h", "QnnOpDef.h", "HTP/QnnHtpCommon.h"];
+    let include_dir = [root.join("include/QNN"), root.join("include")]
+        .into_iter()
+        .find(|directory| {
+            required_headers
+                .iter()
+                .all(|header| directory.join(header).is_file())
+        });
+    let Some(include_dir) = include_dir else {
         assert!(
             !forced,
-            "{FORCE_ENV}=1 but {root:?} contains no public QnnInterface.h"
+            "{FORCE_ENV}=1 but {root:?} contains no complete public QNN/HTP header set"
         );
         return;
     };
@@ -69,13 +71,18 @@ fn main() {
         return;
     }
 
-    println!("cargo:rerun-if-changed={}", header.display());
+    for header in required_headers {
+        println!(
+            "cargo:rerun-if-changed={}",
+            include_dir.join(header).display()
+        );
+    }
     println!("cargo:rerun-if-changed=native/qnn_bridge.cpp");
     println!("cargo:rerun-if-changed=native/qnn_bridge.h");
     cc::Build::new()
         .cpp(true)
         .file("native/qnn_bridge.cpp")
-        .include(root.join("include/QNN"))
+        .include(include_dir)
         .flag_if_supported("/std:c++17")
         .flag_if_supported("/EHsc")
         .flag_if_supported("-std=c++17")

--- a/crates/virtio-accel-hexagon/build.rs
+++ b/crates/virtio-accel-hexagon/build.rs
@@ -70,12 +70,21 @@ fn main() {
     }
 
     println!("cargo:rerun-if-changed={}", header.display());
+    println!("cargo:rerun-if-changed=native/qnn_bridge.cpp");
+    println!("cargo:rerun-if-changed=native/qnn_bridge.h");
+    cc::Build::new()
+        .cpp(true)
+        .file("native/qnn_bridge.cpp")
+        .include(root.join("include/QNN"))
+        .flag_if_supported("/std:c++17")
+        .flag_if_supported("/EHsc")
+        .flag_if_supported("-std=c++17")
+        .warnings(true)
+        .compile("virtio_accel_qnn_bridge");
     println!(
         "cargo:rustc-env=VIRTIO_ACCEL_QNN_SDK_ROOT={}",
         root.display()
     );
-    println!("cargo:rustc-link-search=native={}", lib_dir.display());
-    println!("cargo:rustc-link-lib=dylib=QnnHtp");
     println!("cargo::rustc-cfg=va_hexagon");
 }
 

--- a/crates/virtio-accel-hexagon/build.rs
+++ b/crates/virtio-accel-hexagon/build.rs
@@ -1,0 +1,86 @@
+//! Detect a complete QAIRT/QNN SDK and gate the native Hexagon backend on it.
+//!
+//! Driver packages and inference-only bundles can contain HTP support libraries without the
+//! public QNN C development surface. Native compilation is enabled only when the SDK root has the
+//! interface header and the Windows ARM64 HTP import library. All other builds retain the portable
+//! TOSA admission/lowering code and an unsupported-runtime placeholder.
+
+#![forbid(unsafe_code)]
+
+use std::path::{Path, PathBuf};
+
+const FORCE_ENV: &str = "VIRTIO_ACCEL_HEXAGON";
+const ROOT_ENV: &str = "VIRTIO_ACCEL_QNN_SDK_ROOT";
+const LIB_ENV: &str = "VIRTIO_ACCEL_QNN_LIB_DIR";
+
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(va_hexagon)");
+    for variable in [FORCE_ENV, ROOT_ENV, LIB_ENV, "QNN_SDK_ROOT"] {
+        println!("cargo:rerun-if-env-changed={variable}");
+    }
+
+    let forced = match std::env::var(FORCE_ENV) {
+        Ok(value) if value == "0" => return,
+        Ok(value) if value == "1" => true,
+        Ok(other) => panic!("{FORCE_ENV} must be \"0\" or \"1\", not {other:?}"),
+        Err(_) => false,
+    };
+
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+    if target_os != "windows" || target_arch != "aarch64" {
+        assert!(
+            !forced,
+            "{FORCE_ENV}=1 requires the initial windows/aarch64 Snapdragon target, found {target_os}/{target_arch}"
+        );
+        return;
+    }
+
+    let root = std::env::var_os(ROOT_ENV)
+        .or_else(|| std::env::var_os("QNN_SDK_ROOT"))
+        .map(PathBuf::from);
+    let Some(root) = root else {
+        assert!(!forced, "{FORCE_ENV}=1 requires {ROOT_ENV} or QNN_SDK_ROOT");
+        return;
+    };
+
+    let header = [
+        root.join("include/QNN/QnnInterface.h"),
+        root.join("include/QnnInterface.h"),
+    ]
+    .into_iter()
+    .find(|candidate| candidate.is_file());
+    let Some(header) = header else {
+        assert!(
+            !forced,
+            "{FORCE_ENV}=1 but {root:?} contains no public QnnInterface.h"
+        );
+        return;
+    };
+
+    let lib_dir = std::env::var_os(LIB_ENV)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| root.join("lib/aarch64-windows-msvc"));
+    if !has_import_library(&lib_dir, "QnnHtp") {
+        assert!(
+            !forced,
+            "{FORCE_ENV}=1 but {lib_dir:?} contains no QnnHtp import library"
+        );
+        return;
+    }
+
+    println!("cargo:rerun-if-changed={}", header.display());
+    println!(
+        "cargo:rustc-env=VIRTIO_ACCEL_QNN_SDK_ROOT={}",
+        root.display()
+    );
+    println!("cargo:rustc-link-search=native={}", lib_dir.display());
+    println!("cargo:rustc-link-lib=dylib=QnnHtp");
+    println!("cargo::rustc-cfg=va_hexagon");
+}
+
+fn has_import_library(directory: &Path, stem: &str) -> bool {
+    [format!("{stem}.lib"), format!("lib{stem}.a")]
+        .iter()
+        .any(|name| directory.join(name).is_file())
+}

--- a/crates/virtio-accel-hexagon/examples/mock_classifier.rs
+++ b/crates/virtio-accel-hexagon/examples/mock_classifier.rs
@@ -1,0 +1,30 @@
+//! Run a tiny FP16 linear classifier on Qualcomm Hexagon HTP.
+//!
+//! The graph computes two sets of class logits from three input features using a learned 3x2
+//! weight matrix. The weights are direct-bound inputs because embedded model constants are outside
+//! the initial Hexagon tier.
+
+#[cfg(va_hexagon)]
+mod support;
+
+#[cfg(va_hexagon)]
+fn main() {
+    use virtio_accel_conformance::numerics::MOCK_LINEAR_CLASSIFIER_FP16;
+
+    support::run_fp16_model(
+        "mock FP16 linear classifier",
+        MOCK_LINEAR_CLASSIFIER_FP16.artifact,
+        &[
+            MOCK_LINEAR_CLASSIFIER_FP16.inputs[0].bits,
+            MOCK_LINEAR_CLASSIFIER_FP16.inputs[1].bits,
+        ],
+        MOCK_LINEAR_CLASSIFIER_FP16.outputs[0].bits,
+    );
+}
+
+#[cfg(not(va_hexagon))]
+fn main() {
+    println!(
+        "Qualcomm Hexagon HTP unavailable: build on Windows ARM64 with a complete QAIRT/QNN SDK"
+    );
+}

--- a/crates/virtio-accel-hexagon/examples/support/mod.rs
+++ b/crates/virtio-accel-hexagon/examples/support/mod.rs
@@ -1,0 +1,182 @@
+use std::time::{Duration, Instant};
+use virtio_accel_core::{
+    Accelerator, AccessMode, BackendError, BindingRef, BufferDesc, BufferRange, BufferUsage,
+    ByteSink, ByteSource, ContextDesc, EventState, MemoryDomain, QueueDesc, SubmitFailure, Timeout,
+};
+use virtio_accel_hexagon::{
+    HEXAGON_TOSA_TARGET, HexagonAccelerator, REQUIRED_RESIDENT_BYTES, TESTED_QAIRT_RELEASE,
+};
+use virtio_accel_tosa::parse;
+
+#[derive(Debug)]
+struct SliceSource<'a>(&'a [u8]);
+
+impl ByteSource for SliceSource<'_> {
+    fn len(&self) -> u64 {
+        self.0.len() as u64
+    }
+
+    fn read_at(&self, offset: u64, target: &mut [u8]) -> Result<(), BackendError> {
+        ByteSource::read_at(self.0, offset, target)
+    }
+
+    fn as_contiguous(&self) -> Option<&[u8]> {
+        Some(self.0)
+    }
+}
+
+#[derive(Debug)]
+struct SliceSink<'a>(&'a mut [u8]);
+
+impl ByteSink for SliceSink<'_> {
+    fn len(&self) -> u64 {
+        self.0.len() as u64
+    }
+
+    fn write_at(&mut self, offset: u64, source: &[u8]) -> Result<(), BackendError> {
+        ByteSink::write_at(self.0, offset, source)
+    }
+
+    fn as_contiguous_mut(&mut self) -> Option<&mut [u8]> {
+        Some(self.0)
+    }
+}
+
+fn fp16_bytes(values: &[u16]) -> Vec<u8> {
+    values
+        .iter()
+        .flat_map(|value| value.to_le_bytes())
+        .collect()
+}
+
+fn fp16_matches(expected: &[u16], actual: &[u16]) -> bool {
+    expected.len() == actual.len()
+        && expected.iter().zip(actual).all(|(expected, actual)| {
+            let expected_is_nan = expected & 0x7c00 == 0x7c00 && expected & 0x03ff != 0;
+            let actual_is_nan = actual & 0x7c00 == 0x7c00 && actual & 0x03ff != 0;
+            expected == actual || expected_is_nan && actual_is_nan
+        })
+}
+
+pub fn run_fp16_model(name: &str, artifact: &[u8], input_bits: &[&[u16]], expected: &[u16]) {
+    let backend = HexagonAccelerator::new().expect("initialize the QNN HTP backend");
+    println!(
+        "QAIRT {TESTED_QAIRT_RELEASE}: provider={} build={} core={:?} backend={:?}",
+        backend.runtime_info().provider_name,
+        backend.runtime_info().build_id,
+        backend.runtime_info().core_version,
+        backend.runtime_info().backend_version,
+    );
+    let context = backend
+        .create_context(ContextDesc::default())
+        .expect("create context");
+    let model = parse(artifact).expect("parse model TOSA");
+    let program = backend
+        .load_program(
+            &context,
+            model
+                .artifact_ref(HEXAGON_TOSA_TARGET, REQUIRED_RESIDENT_BYTES)
+                .expect("build artifact envelope"),
+        )
+        .expect("lower and finalize model graph on HTP");
+
+    let input_bytes = input_bits
+        .iter()
+        .map(|values| fp16_bytes(values))
+        .collect::<Vec<_>>();
+    let mut inputs = Vec::with_capacity(input_bytes.len());
+    for bytes in &input_bytes {
+        let (mut buffer, _) = backend
+            .allocate_buffer(
+                &context,
+                BufferDesc::new(
+                    bytes.len() as u64,
+                    4096,
+                    MemoryDomain::Shared,
+                    BufferUsage::TRANSFER_DESTINATION | BufferUsage::PROGRAM_INPUT,
+                )
+                .expect("input descriptor"),
+            )
+            .expect("allocate input")
+            .into_parts();
+        backend
+            .write_buffer(&mut buffer, 0, &SliceSource(bytes))
+            .expect("write model input");
+        inputs.push(buffer);
+    }
+
+    let output_len = expected.len() * 2;
+    let (output, _) = backend
+        .allocate_buffer(
+            &context,
+            BufferDesc::new(
+                output_len as u64,
+                4096,
+                MemoryDomain::Shared,
+                BufferUsage::TRANSFER_SOURCE | BufferUsage::PROGRAM_OUTPUT,
+            )
+            .expect("output descriptor"),
+        )
+        .expect("allocate output")
+        .into_parts();
+    let queue = backend
+        .create_queue(&context, QueueDesc::default())
+        .expect("create queue");
+    let mut bindings = inputs
+        .iter()
+        .enumerate()
+        .map(|(slot, buffer)| BindingRef {
+            slot: slot as u32,
+            buffer,
+            range: BufferRange::new(0, input_bytes[slot].len() as u64).expect("input range"),
+            access: AccessMode::Read,
+        })
+        .collect::<Vec<_>>();
+    bindings.push(BindingRef {
+        slot: inputs.len() as u32,
+        buffer: &output,
+        range: BufferRange::new(0, output_len as u64).expect("output range"),
+        access: AccessMode::Write,
+    });
+
+    let event = backend
+        .submit(&queue, &program, &bindings, Timeout::Infinite)
+        .unwrap_or_else(|failure| match failure {
+            SubmitFailure::Rejected(error) => panic!("HTP submission rejected: {error:?}"),
+            SubmitFailure::Indeterminate { error, .. } => {
+                panic!("HTP submission indeterminate: {error:?}")
+            }
+        });
+    let deadline = Instant::now() + Duration::from_secs(15);
+    loop {
+        match backend.poll_event(&event).expect("poll HTP event") {
+            EventState::Pending if Instant::now() < deadline => std::thread::yield_now(),
+            EventState::Pending => panic!("HTP execution timed out"),
+            EventState::Complete => break,
+            terminal => panic!("HTP execution failed: {terminal:?}"),
+        }
+    }
+
+    let mut actual_bytes = vec![0; output_len];
+    backend
+        .read_buffer(&output, 0, &mut SliceSink(&mut actual_bytes))
+        .expect("read HTP output");
+    let actual = actual_bytes
+        .chunks_exact(2)
+        .map(|bytes| u16::from_le_bytes([bytes[0], bytes[1]]))
+        .collect::<Vec<_>>();
+    assert!(
+        fp16_matches(expected, &actual),
+        "{name} result differs from the expected FP16 output: {actual:04x?}"
+    );
+
+    backend.destroy_event(event).expect("destroy event");
+    backend.destroy_queue(queue).expect("destroy queue");
+    backend.unload_program(program).expect("unload program");
+    backend.free_buffer(output).expect("free output");
+    for input in inputs {
+        backend.free_buffer(input).expect("free input");
+    }
+    backend.destroy_context(context).expect("destroy context");
+    println!("{name} -> QNN HTP v73: passed; output={actual:04x?}");
+}

--- a/crates/virtio-accel-hexagon/examples/tosa_hexagon.rs
+++ b/crates/virtio-accel-hexagon/examples/tosa_hexagon.rs
@@ -1,18 +1,175 @@
-//! Backend-local entry point for the Qualcomm Hexagon TOSA path.
+//! Execute the shared FP16 identity corpus through QNN on Qualcomm Hexagon HTP.
 
-use virtio_accel_hexagon::{HexagonAccelerator, TESTED_QAIRT_RELEASE};
+#[cfg(va_hexagon)]
+mod enabled {
+    use std::time::{Duration, Instant};
+    use virtio_accel_conformance::numerics::IDENTITY_EDGES_FP16;
+    use virtio_accel_core::{
+        Accelerator, AccessMode, BackendError, BindingRef, BufferDesc, BufferRange, BufferUsage,
+        ByteSink, ByteSource, ContextDesc, EventState, MemoryDomain, QueueDesc, SubmitFailure,
+        Timeout,
+    };
+    use virtio_accel_hexagon::{
+        HEXAGON_TOSA_TARGET, HexagonAccelerator, REQUIRED_RESIDENT_BYTES, TESTED_QAIRT_RELEASE,
+    };
+    use virtio_accel_tosa::parse;
 
-fn main() {
-    match HexagonAccelerator::new() {
-        Ok(_) => {
-            println!(
-                "QAIRT {TESTED_QAIRT_RELEASE} was detected, but native TOSA execution is not enabled in this revision"
-            );
+    #[derive(Debug)]
+    struct SliceSource<'a>(&'a [u8]);
+
+    impl ByteSource for SliceSource<'_> {
+        fn len(&self) -> u64 {
+            self.0.len() as u64
         }
-        Err(error) => {
-            println!(
-                "Qualcomm Hexagon backend unavailable ({error}); install the complete QAIRT/QNN C SDK to enable native development"
-            );
+
+        fn read_at(&self, offset: u64, target: &mut [u8]) -> Result<(), BackendError> {
+            ByteSource::read_at(self.0, offset, target)
+        }
+
+        fn as_contiguous(&self) -> Option<&[u8]> {
+            Some(self.0)
         }
     }
+
+    #[derive(Debug)]
+    struct SliceSink<'a>(&'a mut [u8]);
+
+    impl ByteSink for SliceSink<'_> {
+        fn len(&self) -> u64 {
+            self.0.len() as u64
+        }
+
+        fn write_at(&mut self, offset: u64, source: &[u8]) -> Result<(), BackendError> {
+            ByteSink::write_at(self.0, offset, source)
+        }
+
+        fn as_contiguous_mut(&mut self) -> Option<&mut [u8]> {
+            Some(self.0)
+        }
+    }
+
+    pub fn run() {
+        let backend = HexagonAccelerator::new().expect("initialize the QNN HTP backend");
+        println!(
+            "QAIRT {TESTED_QAIRT_RELEASE}: provider={} build={} core={:?} backend={:?}",
+            backend.runtime_info().provider_name,
+            backend.runtime_info().build_id,
+            backend.runtime_info().core_version,
+            backend.runtime_info().backend_version,
+        );
+        let context = backend
+            .create_context(ContextDesc::default())
+            .expect("create context");
+        let model = parse(IDENTITY_EDGES_FP16.artifact).expect("parse identity TOSA");
+        let program = backend
+            .load_program(
+                &context,
+                model
+                    .artifact_ref(HEXAGON_TOSA_TARGET, REQUIRED_RESIDENT_BYTES)
+                    .expect("build artifact envelope"),
+            )
+            .expect("lower and finalize identity graph on HTP");
+        let input_bytes = IDENTITY_EDGES_FP16.inputs[0]
+            .bits
+            .iter()
+            .flat_map(|bits| bits.to_le_bytes())
+            .collect::<Vec<_>>();
+        let output_bytes = IDENTITY_EDGES_FP16.outputs[0].bits.len() * 2;
+        let (mut input, _) = backend
+            .allocate_buffer(
+                &context,
+                BufferDesc::new(
+                    input_bytes.len() as u64,
+                    4096,
+                    MemoryDomain::Shared,
+                    BufferUsage::TRANSFER_DESTINATION | BufferUsage::PROGRAM_INPUT,
+                )
+                .expect("input descriptor"),
+            )
+            .expect("allocate input")
+            .into_parts();
+        let (output, _) = backend
+            .allocate_buffer(
+                &context,
+                BufferDesc::new(
+                    output_bytes as u64,
+                    4096,
+                    MemoryDomain::Shared,
+                    BufferUsage::TRANSFER_SOURCE | BufferUsage::PROGRAM_OUTPUT,
+                )
+                .expect("output descriptor"),
+            )
+            .expect("allocate output")
+            .into_parts();
+        backend
+            .write_buffer(&mut input, 0, &SliceSource(&input_bytes))
+            .expect("write identity input");
+        let queue = backend
+            .create_queue(&context, QueueDesc::default())
+            .expect("create queue");
+        let bindings = [
+            BindingRef {
+                slot: 0,
+                buffer: &input,
+                range: BufferRange::new(0, input_bytes.len() as u64).expect("input range"),
+                access: AccessMode::Read,
+            },
+            BindingRef {
+                slot: 1,
+                buffer: &output,
+                range: BufferRange::new(0, output_bytes as u64).expect("output range"),
+                access: AccessMode::Write,
+            },
+        ];
+        let event = backend
+            .submit(&queue, &program, &bindings, Timeout::Infinite)
+            .unwrap_or_else(|failure| match failure {
+                SubmitFailure::Rejected(error) => panic!("HTP submission rejected: {error:?}"),
+                SubmitFailure::Indeterminate { error, .. } => {
+                    panic!("HTP submission indeterminate: {error:?}")
+                }
+            });
+        let deadline = Instant::now() + Duration::from_secs(15);
+        loop {
+            match backend.poll_event(&event).expect("poll HTP event") {
+                EventState::Pending if Instant::now() < deadline => std::thread::yield_now(),
+                EventState::Pending => panic!("HTP execution timed out"),
+                EventState::Complete => break,
+                terminal => panic!("HTP execution failed: {terminal:?}"),
+            }
+        }
+        backend.destroy_event(event).expect("destroy event");
+
+        let mut actual_bytes = vec![0; output_bytes];
+        backend
+            .read_buffer(&output, 0, &mut SliceSink(&mut actual_bytes))
+            .expect("read HTP output");
+        let actual = actual_bytes
+            .chunks_exact(2)
+            .map(|bytes| u16::from_le_bytes([bytes[0], bytes[1]]))
+            .collect::<Vec<_>>();
+        assert!(
+            IDENTITY_EDGES_FP16.output_matches(0, &actual),
+            "HTP identity result differs from the shared FP16 oracle"
+        );
+
+        backend.destroy_queue(queue).expect("destroy queue");
+        backend.unload_program(program).expect("unload program");
+        backend.free_buffer(output).expect("free output");
+        backend.free_buffer(input).expect("free input");
+        backend.destroy_context(context).expect("destroy context");
+        println!("TOSA FP16 identity -> QNN HTP v73: passed");
+    }
+}
+
+#[cfg(va_hexagon)]
+fn main() {
+    enabled::run();
+}
+
+#[cfg(not(va_hexagon))]
+fn main() {
+    println!(
+        "Qualcomm Hexagon HTP unavailable: build on Windows ARM64 with a complete QAIRT/QNN SDK"
+    );
 }

--- a/crates/virtio-accel-hexagon/examples/tosa_hexagon.rs
+++ b/crates/virtio-accel-hexagon/examples/tosa_hexagon.rs
@@ -1,170 +1,18 @@
 //! Execute the shared FP16 identity corpus through QNN on Qualcomm Hexagon HTP.
 
 #[cfg(va_hexagon)]
-mod enabled {
-    use std::time::{Duration, Instant};
-    use virtio_accel_conformance::numerics::IDENTITY_EDGES_FP16;
-    use virtio_accel_core::{
-        Accelerator, AccessMode, BackendError, BindingRef, BufferDesc, BufferRange, BufferUsage,
-        ByteSink, ByteSource, ContextDesc, EventState, MemoryDomain, QueueDesc, SubmitFailure,
-        Timeout,
-    };
-    use virtio_accel_hexagon::{
-        HEXAGON_TOSA_TARGET, HexagonAccelerator, REQUIRED_RESIDENT_BYTES, TESTED_QAIRT_RELEASE,
-    };
-    use virtio_accel_tosa::parse;
-
-    #[derive(Debug)]
-    struct SliceSource<'a>(&'a [u8]);
-
-    impl ByteSource for SliceSource<'_> {
-        fn len(&self) -> u64 {
-            self.0.len() as u64
-        }
-
-        fn read_at(&self, offset: u64, target: &mut [u8]) -> Result<(), BackendError> {
-            ByteSource::read_at(self.0, offset, target)
-        }
-
-        fn as_contiguous(&self) -> Option<&[u8]> {
-            Some(self.0)
-        }
-    }
-
-    #[derive(Debug)]
-    struct SliceSink<'a>(&'a mut [u8]);
-
-    impl ByteSink for SliceSink<'_> {
-        fn len(&self) -> u64 {
-            self.0.len() as u64
-        }
-
-        fn write_at(&mut self, offset: u64, source: &[u8]) -> Result<(), BackendError> {
-            ByteSink::write_at(self.0, offset, source)
-        }
-
-        fn as_contiguous_mut(&mut self) -> Option<&mut [u8]> {
-            Some(self.0)
-        }
-    }
-
-    pub fn run() {
-        let backend = HexagonAccelerator::new().expect("initialize the QNN HTP backend");
-        println!(
-            "QAIRT {TESTED_QAIRT_RELEASE}: provider={} build={} core={:?} backend={:?}",
-            backend.runtime_info().provider_name,
-            backend.runtime_info().build_id,
-            backend.runtime_info().core_version,
-            backend.runtime_info().backend_version,
-        );
-        let context = backend
-            .create_context(ContextDesc::default())
-            .expect("create context");
-        let model = parse(IDENTITY_EDGES_FP16.artifact).expect("parse identity TOSA");
-        let program = backend
-            .load_program(
-                &context,
-                model
-                    .artifact_ref(HEXAGON_TOSA_TARGET, REQUIRED_RESIDENT_BYTES)
-                    .expect("build artifact envelope"),
-            )
-            .expect("lower and finalize identity graph on HTP");
-        let input_bytes = IDENTITY_EDGES_FP16.inputs[0]
-            .bits
-            .iter()
-            .flat_map(|bits| bits.to_le_bytes())
-            .collect::<Vec<_>>();
-        let output_bytes = IDENTITY_EDGES_FP16.outputs[0].bits.len() * 2;
-        let (mut input, _) = backend
-            .allocate_buffer(
-                &context,
-                BufferDesc::new(
-                    input_bytes.len() as u64,
-                    4096,
-                    MemoryDomain::Shared,
-                    BufferUsage::TRANSFER_DESTINATION | BufferUsage::PROGRAM_INPUT,
-                )
-                .expect("input descriptor"),
-            )
-            .expect("allocate input")
-            .into_parts();
-        let (output, _) = backend
-            .allocate_buffer(
-                &context,
-                BufferDesc::new(
-                    output_bytes as u64,
-                    4096,
-                    MemoryDomain::Shared,
-                    BufferUsage::TRANSFER_SOURCE | BufferUsage::PROGRAM_OUTPUT,
-                )
-                .expect("output descriptor"),
-            )
-            .expect("allocate output")
-            .into_parts();
-        backend
-            .write_buffer(&mut input, 0, &SliceSource(&input_bytes))
-            .expect("write identity input");
-        let queue = backend
-            .create_queue(&context, QueueDesc::default())
-            .expect("create queue");
-        let bindings = [
-            BindingRef {
-                slot: 0,
-                buffer: &input,
-                range: BufferRange::new(0, input_bytes.len() as u64).expect("input range"),
-                access: AccessMode::Read,
-            },
-            BindingRef {
-                slot: 1,
-                buffer: &output,
-                range: BufferRange::new(0, output_bytes as u64).expect("output range"),
-                access: AccessMode::Write,
-            },
-        ];
-        let event = backend
-            .submit(&queue, &program, &bindings, Timeout::Infinite)
-            .unwrap_or_else(|failure| match failure {
-                SubmitFailure::Rejected(error) => panic!("HTP submission rejected: {error:?}"),
-                SubmitFailure::Indeterminate { error, .. } => {
-                    panic!("HTP submission indeterminate: {error:?}")
-                }
-            });
-        let deadline = Instant::now() + Duration::from_secs(15);
-        loop {
-            match backend.poll_event(&event).expect("poll HTP event") {
-                EventState::Pending if Instant::now() < deadline => std::thread::yield_now(),
-                EventState::Pending => panic!("HTP execution timed out"),
-                EventState::Complete => break,
-                terminal => panic!("HTP execution failed: {terminal:?}"),
-            }
-        }
-        backend.destroy_event(event).expect("destroy event");
-
-        let mut actual_bytes = vec![0; output_bytes];
-        backend
-            .read_buffer(&output, 0, &mut SliceSink(&mut actual_bytes))
-            .expect("read HTP output");
-        let actual = actual_bytes
-            .chunks_exact(2)
-            .map(|bytes| u16::from_le_bytes([bytes[0], bytes[1]]))
-            .collect::<Vec<_>>();
-        assert!(
-            IDENTITY_EDGES_FP16.output_matches(0, &actual),
-            "HTP identity result differs from the shared FP16 oracle"
-        );
-
-        backend.destroy_queue(queue).expect("destroy queue");
-        backend.unload_program(program).expect("unload program");
-        backend.free_buffer(output).expect("free output");
-        backend.free_buffer(input).expect("free input");
-        backend.destroy_context(context).expect("destroy context");
-        println!("TOSA FP16 identity -> QNN HTP v73: passed");
-    }
-}
+mod support;
 
 #[cfg(va_hexagon)]
 fn main() {
-    enabled::run();
+    use virtio_accel_conformance::numerics::IDENTITY_EDGES_FP16;
+
+    support::run_fp16_model(
+        "TOSA FP16 identity",
+        IDENTITY_EDGES_FP16.artifact,
+        &[IDENTITY_EDGES_FP16.inputs[0].bits],
+        IDENTITY_EDGES_FP16.outputs[0].bits,
+    );
 }
 
 #[cfg(not(va_hexagon))]

--- a/crates/virtio-accel-hexagon/examples/tosa_hexagon.rs
+++ b/crates/virtio-accel-hexagon/examples/tosa_hexagon.rs
@@ -1,0 +1,18 @@
+//! Backend-local entry point for the Qualcomm Hexagon TOSA path.
+
+use virtio_accel_hexagon::{HexagonAccelerator, TESTED_QAIRT_RELEASE};
+
+fn main() {
+    match HexagonAccelerator::new() {
+        Ok(_) => {
+            println!(
+                "QAIRT {TESTED_QAIRT_RELEASE} was detected, but native TOSA execution is not enabled in this revision"
+            );
+        }
+        Err(error) => {
+            println!(
+                "Qualcomm Hexagon backend unavailable ({error}); install the complete QAIRT/QNN C SDK to enable native development"
+            );
+        }
+    }
+}

--- a/crates/virtio-accel-hexagon/native/qnn_bridge.cpp
+++ b/crates/virtio-accel-hexagon/native/qnn_bridge.cpp
@@ -1,0 +1,825 @@
+#define _CRT_SECURE_NO_WARNINGS
+#define NOMINMAX
+
+#include "qnn_bridge.h"
+
+#include <HTP/QnnHtpCommon.h>
+#include <QnnInterface.h>
+#include <QnnOpDef.h>
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+#include <atomic>
+#include <cstring>
+#include <limits>
+#include <memory>
+#include <new>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace {
+
+void set_message(char *output, size_t size, const char *message) {
+  if (output == nullptr || size == 0) {
+    return;
+  }
+  const char *source = message == nullptr ? "" : message;
+  std::strncpy(output, source, size - 1);
+  output[size - 1] = '\0';
+}
+
+template <size_t N> void copy_text(char (&output)[N], const char *source) {
+  const char *text = source == nullptr ? "" : source;
+  std::strncpy(output, text, N - 1);
+  output[N - 1] = '\0';
+}
+
+struct TensorStorage {
+  uint32_t value = 0;
+  std::string name;
+  std::vector<uint32_t> dimensions;
+  std::vector<uint32_t> constant_values;
+  Qnn_Tensor_t tensor = []() {
+    Qnn_Tensor_t value{};
+    value.version = QNN_TENSOR_VERSION_2;
+    value.v2 = QNN_TENSOR_V2_INIT;
+    return value;
+  }();
+};
+
+struct NodeStorage {
+  std::string name;
+  std::string type;
+  std::vector<Qnn_Tensor_t> inputs;
+  std::vector<Qnn_Tensor_t> outputs;
+  std::vector<Qnn_Param_t> params;
+  Qnn_OpConfig_t config = QNN_OPCONFIG_INIT;
+
+  void finish() {
+    config.v1.name = name.c_str();
+    config.v1.packageName = QNN_OP_PACKAGE_NAME_QTI_AISW;
+    config.v1.typeName = type.c_str();
+    config.v1.numOfParams = static_cast<uint32_t>(params.size());
+    config.v1.params = params.empty() ? nullptr : params.data();
+    config.v1.numOfInputs = static_cast<uint32_t>(inputs.size());
+    config.v1.inputTensors = inputs.data();
+    config.v1.numOfOutputs = static_cast<uint32_t>(outputs.size());
+    config.v1.outputTensors = outputs.data();
+  }
+};
+
+} // namespace
+
+struct VaQnnRuntime {
+  HMODULE library = nullptr;
+  QNN_INTERFACE_VER_TYPE api = QNN_INTERFACE_VER_TYPE_INIT;
+  Qnn_BackendHandle_t backend = nullptr;
+  Qnn_DeviceHandle_t device = nullptr;
+  std::atomic<uint32_t> in_flight{0};
+};
+
+struct VaQnnGraph {
+  VaQnnRuntime *runtime = nullptr;
+  Qnn_ContextHandle_t context = nullptr;
+  Qnn_GraphHandle_t graph = nullptr;
+  std::vector<TensorStorage> tensors;
+  std::unordered_map<uint32_t, size_t> by_value;
+  std::vector<size_t> inputs;
+  std::vector<size_t> outputs;
+  std::vector<std::unique_ptr<NodeStorage>> nodes;
+};
+
+struct VaQnnEvent {
+  VaQnnRuntime *runtime = nullptr;
+  std::atomic<uint32_t> state{VA_QNN_EVENT_PENDING};
+  std::atomic<uint64_t> error{QNN_SUCCESS};
+  std::vector<Qnn_Tensor_t> inputs;
+  std::vector<Qnn_Tensor_t> outputs;
+  std::thread worker;
+};
+
+namespace {
+
+const QnnInterface_t *select_provider(const QnnInterface_t **providers,
+                                      uint32_t count) {
+  for (uint32_t index = 0; index < count; ++index) {
+    const QnnInterface_t *provider = providers[index];
+    if (provider != nullptr && provider->backendId == QNN_BACKEND_ID_HTP &&
+        provider->apiVersion.coreApiVersion.major == QNN_API_VERSION_MAJOR &&
+        provider->apiVersion.coreApiVersion.minor >= QNN_API_VERSION_MINOR) {
+      return provider;
+    }
+  }
+  return nullptr;
+}
+
+bool required_api_present(const QNN_INTERFACE_VER_TYPE &api) {
+  return api.backendCreate != nullptr && api.backendGetApiVersion != nullptr &&
+         api.backendGetBuildId != nullptr && api.backendFree != nullptr &&
+         api.deviceCreate != nullptr && api.deviceFree != nullptr &&
+         api.contextCreate != nullptr && api.contextFree != nullptr &&
+         api.graphCreate != nullptr && api.graphAddNode != nullptr &&
+         api.graphFinalize != nullptr && api.graphExecute != nullptr &&
+         api.tensorCreateGraphTensor != nullptr;
+}
+
+Qnn_TensorType_t tensor_type(uint32_t role) {
+  switch (role) {
+  case VA_QNN_TENSOR_INPUT:
+    return QNN_TENSOR_TYPE_APP_WRITE;
+  case VA_QNN_TENSOR_OUTPUT:
+    return QNN_TENSOR_TYPE_APP_READ;
+  default:
+    return QNN_TENSOR_TYPE_NATIVE;
+  }
+}
+
+uint64_t append_scalar_bool(NodeStorage &node, const char *name,
+                            uint8_t value) {
+  Qnn_Param_t parameter = QNN_PARAM_INIT;
+  parameter.paramType = QNN_PARAMTYPE_SCALAR;
+  parameter.name = name;
+  parameter.scalarParam.dataType = QNN_DATATYPE_BOOL_8;
+  parameter.scalarParam.bool8Value = value;
+  node.params.push_back(parameter);
+  return QNN_SUCCESS;
+}
+
+void append_scalar_i32(NodeStorage &node, const char *name, int32_t value) {
+  Qnn_Param_t parameter = QNN_PARAM_INIT;
+  parameter.paramType = QNN_PARAMTYPE_SCALAR;
+  parameter.name = name;
+  parameter.scalarParam.dataType = QNN_DATATYPE_INT_32;
+  parameter.scalarParam.int32Value = value;
+  node.params.push_back(parameter);
+}
+
+uint64_t commit_node(VaQnnGraph &graph, std::unique_ptr<NodeStorage> node,
+                     char *message, size_t message_size) {
+  node->finish();
+  const uint64_t status =
+      graph.runtime->api.graphAddNode(graph.graph, node->config);
+  if (status != QNN_SUCCESS) {
+    set_message(message, message_size, "QNN rejected a graph node");
+    return status;
+  }
+  graph.nodes.push_back(std::move(node));
+  return QNN_SUCCESS;
+}
+
+uint64_t create_internal_tensor(VaQnnGraph &graph, std::string name,
+                                std::vector<uint32_t> dimensions,
+                                Qnn_TensorType_t type, Qnn_DataType_t data_type,
+                                std::vector<uint32_t> constant_values,
+                                TensorStorage **output, char *message,
+                                size_t message_size) {
+  TensorStorage storage;
+  storage.name = std::move(name);
+  storage.dimensions = std::move(dimensions);
+  storage.constant_values = std::move(constant_values);
+  storage.tensor.v2.name = storage.name.c_str();
+  storage.tensor.v2.type = type;
+  storage.tensor.v2.dataFormat = QNN_TENSOR_DATA_FORMAT_FLAT_BUFFER;
+  storage.tensor.v2.dataType = data_type;
+  storage.tensor.v2.rank = static_cast<uint32_t>(storage.dimensions.size());
+  storage.tensor.v2.dimensions = storage.dimensions.data();
+  storage.tensor.v2.memType = QNN_TENSORMEMTYPE_RAW;
+  if (type == QNN_TENSOR_TYPE_STATIC) {
+    storage.tensor.v2.clientBuf.data = storage.constant_values.data();
+    storage.tensor.v2.clientBuf.dataSize = static_cast<uint32_t>(
+        storage.constant_values.size() * sizeof(uint32_t));
+  }
+  graph.tensors.push_back(std::move(storage));
+  TensorStorage &retained = graph.tensors.back();
+  retained.tensor.v2.name = retained.name.c_str();
+  retained.tensor.v2.dimensions = retained.dimensions.data();
+  if (type == QNN_TENSOR_TYPE_STATIC) {
+    retained.tensor.v2.clientBuf.data = retained.constant_values.data();
+  }
+  const uint64_t status =
+      graph.runtime->api.tensorCreateGraphTensor(graph.graph, &retained.tensor);
+  if (status != QNN_SUCCESS) {
+    set_message(message, message_size, "QNN rejected an internal tensor");
+    return status;
+  }
+  *output = &retained;
+  return QNN_SUCCESS;
+}
+
+uint64_t add_gather(VaQnnGraph &graph, const std::string &name,
+                    TensorStorage &data, TensorStorage &indices,
+                    TensorStorage &output, int32_t axis, char *message,
+                    size_t message_size) {
+  auto node = std::make_unique<NodeStorage>();
+  node->name = name;
+  node->type = QNN_OP_GATHER;
+  node->inputs = {data.tensor, indices.tensor};
+  node->outputs = {output.tensor};
+  node->params.reserve(1);
+  append_scalar_i32(*node, QNN_OP_GATHER_PARAM_AXIS, axis);
+  return commit_node(graph, std::move(node), message, message_size);
+}
+
+uint64_t add_binary_maximum(VaQnnGraph &graph, const std::string &name,
+                            TensorStorage &left, TensorStorage &right,
+                            TensorStorage &output, char *message,
+                            size_t message_size) {
+  auto node = std::make_unique<NodeStorage>();
+  node->name = name;
+  node->type = QNN_OP_ELEMENT_WISE_MAXIMUM;
+  node->inputs = {left.tensor, right.tensor};
+  node->outputs = {output.tensor};
+  return commit_node(graph, std::move(node), message, message_size);
+}
+
+uint64_t add_max_pool(VaQnnGraph &graph, const VaQnnNodeDesc &description,
+                      uint32_t index, TensorStorage &input,
+                      TensorStorage &output, char *message,
+                      size_t message_size) {
+  // QNN's Windows HTP backend rejects the documented PoolMax2d tensor
+  // parameters during graph finalization in QAIRT 2.49. Lowering the same
+  // zero-padding semantics to Gather and ElementWiseMaximum keeps every
+  // operation on HTP and avoids a host fallback.
+  if (input.dimensions.size() != 4 || output.dimensions.size() != 4 ||
+      description.kernel[0] == 0 || description.kernel[1] == 0 ||
+      description.stride[0] == 0 || description.stride[1] == 0) {
+    set_message(message, message_size, "invalid max-pool shape or attributes");
+    return VA_QNN_ERROR_INVALID_ARGUMENT;
+  }
+  const uint32_t input_height = input.dimensions[1];
+  const uint32_t input_width = input.dimensions[2];
+  const uint32_t output_height = output.dimensions[1];
+  const uint32_t output_width = output.dimensions[2];
+  if (input.dimensions[0] != output.dimensions[0] ||
+      input.dimensions[3] != output.dimensions[3] ||
+      description.kernel[0] > input_height ||
+      description.kernel[1] > input_width ||
+      (input_height - description.kernel[0]) / description.stride[0] + 1 !=
+          output_height ||
+      (input_width - description.kernel[1]) / description.stride[1] + 1 !=
+          output_width) {
+    set_message(message, message_size,
+                "max-pool output shape does not match its attributes");
+    return VA_QNN_ERROR_INVALID_ARGUMENT;
+  }
+
+  const std::string prefix = "virtio_accel_pool_" + std::to_string(index) + "_";
+  std::vector<TensorStorage *> row_indices;
+  std::vector<TensorStorage *> column_indices;
+  std::vector<TensorStorage *> row_views;
+  std::vector<TensorStorage *> windows;
+  row_indices.reserve(description.kernel[0]);
+  column_indices.reserve(description.kernel[1]);
+  row_views.reserve(description.kernel[0]);
+  windows.reserve(static_cast<size_t>(description.kernel[0]) *
+                  description.kernel[1]);
+
+  for (uint32_t kernel_row = 0; kernel_row < description.kernel[0];
+       ++kernel_row) {
+    std::vector<uint32_t> values;
+    values.reserve(output_height);
+    for (uint32_t row = 0; row < output_height; ++row) {
+      const uint64_t position =
+          kernel_row + static_cast<uint64_t>(row) * description.stride[0];
+      if (position >= input_height) {
+        set_message(message, message_size,
+                    "max-pool row index exceeds the input");
+        return VA_QNN_ERROR_INVALID_ARGUMENT;
+      }
+      values.push_back(static_cast<uint32_t>(position));
+    }
+    TensorStorage *tensor = nullptr;
+    uint64_t status = create_internal_tensor(
+        graph, prefix + "rows_" + std::to_string(kernel_row), {output_height},
+        QNN_TENSOR_TYPE_STATIC, QNN_DATATYPE_UINT_32, std::move(values),
+        &tensor, message, message_size);
+    if (status != QNN_SUCCESS)
+      return status;
+    row_indices.push_back(tensor);
+  }
+  for (uint32_t kernel_column = 0; kernel_column < description.kernel[1];
+       ++kernel_column) {
+    std::vector<uint32_t> values;
+    values.reserve(output_width);
+    for (uint32_t column = 0; column < output_width; ++column) {
+      const uint64_t position =
+          kernel_column + static_cast<uint64_t>(column) * description.stride[1];
+      if (position >= input_width) {
+        set_message(message, message_size,
+                    "max-pool column index exceeds the input");
+        return VA_QNN_ERROR_INVALID_ARGUMENT;
+      }
+      values.push_back(static_cast<uint32_t>(position));
+    }
+    TensorStorage *tensor = nullptr;
+    uint64_t status = create_internal_tensor(
+        graph, prefix + "columns_" + std::to_string(kernel_column),
+        {output_width}, QNN_TENSOR_TYPE_STATIC, QNN_DATATYPE_UINT_32,
+        std::move(values), &tensor, message, message_size);
+    if (status != QNN_SUCCESS)
+      return status;
+    column_indices.push_back(tensor);
+  }
+
+  for (uint32_t kernel_row = 0; kernel_row < description.kernel[0];
+       ++kernel_row) {
+    TensorStorage *row_view = nullptr;
+    uint64_t status = create_internal_tensor(
+        graph, prefix + "row_view_" + std::to_string(kernel_row),
+        {input.dimensions[0], output_height, input_width, input.dimensions[3]},
+        QNN_TENSOR_TYPE_NATIVE, QNN_DATATYPE_FLOAT_16, {}, &row_view, message,
+        message_size);
+    if (status != QNN_SUCCESS)
+      return status;
+    row_views.push_back(row_view);
+    status = add_gather(
+        graph, prefix + "gather_rows_" + std::to_string(kernel_row), input,
+        *row_indices[kernel_row], *row_view, 1, message, message_size);
+    if (status != QNN_SUCCESS)
+      return status;
+  }
+
+  for (uint32_t kernel_row = 0; kernel_row < description.kernel[0];
+       ++kernel_row) {
+    for (uint32_t kernel_column = 0; kernel_column < description.kernel[1];
+         ++kernel_column) {
+      TensorStorage *window = nullptr;
+      const std::string suffix =
+          std::to_string(kernel_row) + "_" + std::to_string(kernel_column);
+      uint64_t status = create_internal_tensor(
+          graph, prefix + "window_" + suffix, output.dimensions,
+          QNN_TENSOR_TYPE_NATIVE, QNN_DATATYPE_FLOAT_16, {}, &window, message,
+          message_size);
+      if (status != QNN_SUCCESS)
+        return status;
+      windows.push_back(window);
+      status = add_gather(
+          graph, prefix + "gather_columns_" + suffix, *row_views[kernel_row],
+          *column_indices[kernel_column], *window, 2, message, message_size);
+      if (status != QNN_SUCCESS)
+        return status;
+    }
+  }
+
+  if (windows.size() == 1) {
+    auto node = std::make_unique<NodeStorage>();
+    node->name = prefix + "identity";
+    node->type = QNN_OP_RESHAPE;
+    node->inputs = {windows[0]->tensor};
+    node->outputs = {output.tensor};
+    return commit_node(graph, std::move(node), message, message_size);
+  }
+  TensorStorage *accumulator = windows[0];
+  for (size_t window_index = 1; window_index < windows.size(); ++window_index) {
+    TensorStorage *maximum = &output;
+    if (window_index + 1 != windows.size()) {
+      uint64_t status = create_internal_tensor(
+          graph, prefix + "maximum_" + std::to_string(window_index),
+          output.dimensions, QNN_TENSOR_TYPE_NATIVE, QNN_DATATYPE_FLOAT_16, {},
+          &maximum, message, message_size);
+      if (status != QNN_SUCCESS)
+        return status;
+    }
+    const uint64_t status = add_binary_maximum(
+        graph, prefix + "max_" + std::to_string(window_index), *accumulator,
+        *windows[window_index], *maximum, message, message_size);
+    if (status != QNN_SUCCESS)
+      return status;
+    accumulator = maximum;
+  }
+  return QNN_SUCCESS;
+}
+
+uint64_t add_node(VaQnnGraph &graph, const VaQnnNodeDesc &description,
+                  uint32_t index, char *message, size_t message_size) {
+  auto find_tensor = [&](uint32_t value) -> TensorStorage * {
+    const auto found = graph.by_value.find(value);
+    return found == graph.by_value.end() ? nullptr
+                                         : &graph.tensors[found->second];
+  };
+
+  TensorStorage *input0 = find_tensor(description.input0);
+  TensorStorage *output = find_tensor(description.output);
+  if (input0 == nullptr || output == nullptr) {
+    set_message(message, message_size, "node references an unknown tensor");
+    return VA_QNN_ERROR_INVALID_ARGUMENT;
+  }
+
+  if (description.kind == VA_QNN_NODE_MAX_POOL_2D) {
+    return add_max_pool(graph, description, index, *input0, *output, message,
+                        message_size);
+  }
+
+  auto node = std::make_unique<NodeStorage>();
+  node->name = "virtio_accel_node_" + std::to_string(index);
+  node->inputs.push_back(input0->tensor);
+  node->outputs.push_back(output->tensor);
+
+  switch (description.kind) {
+  case VA_QNN_NODE_RESHAPE:
+    node->type = QNN_OP_RESHAPE;
+    break;
+  case VA_QNN_NODE_MATMUL: {
+    TensorStorage *input1 = find_tensor(description.input1);
+    if (input1 == nullptr) {
+      set_message(message, message_size,
+                  "matmul references an unknown right tensor");
+      return VA_QNN_ERROR_INVALID_ARGUMENT;
+    }
+    node->type = QNN_OP_MAT_MUL;
+    node->inputs.push_back(input1->tensor);
+    node->params.reserve(2);
+    append_scalar_bool(*node, QNN_OP_MAT_MUL_PARAM_TRANSPOSE_IN0, 0);
+    append_scalar_bool(*node, QNN_OP_MAT_MUL_PARAM_TRANSPOSE_IN1, 0);
+    break;
+  }
+  default:
+    set_message(message, message_size, "unknown QNN node kind");
+    return VA_QNN_ERROR_INVALID_ARGUMENT;
+  }
+
+  return commit_node(graph, std::move(node), message, message_size);
+}
+
+} // namespace
+
+extern "C" uint64_t va_qnn_runtime_create(const char *library_path,
+                                          VaQnnRuntime **output,
+                                          VaQnnRuntimeInfo *info, char *message,
+                                          size_t message_size) {
+  if (output == nullptr || info == nullptr) {
+    return VA_QNN_ERROR_INVALID_ARGUMENT;
+  }
+  *output = nullptr;
+  *info = {};
+  try {
+    auto runtime = std::make_unique<VaQnnRuntime>();
+    runtime->library = LoadLibraryExA(
+        library_path == nullptr ? "QnnHtp.dll" : library_path, nullptr,
+        library_path == nullptr ? 0 : LOAD_WITH_ALTERED_SEARCH_PATH);
+    if (runtime->library == nullptr) {
+      set_message(message, message_size, "QnnHtp.dll could not be loaded");
+      return VA_QNN_ERROR_INCOMPATIBLE;
+    }
+    using GetProviders = Qnn_ErrorHandle_t (*)(
+        const QnnInterface_t ***providerList, uint32_t *numProviders);
+    auto get_providers = reinterpret_cast<GetProviders>(
+        GetProcAddress(runtime->library, "QnnInterface_getProviders"));
+    if (get_providers == nullptr) {
+      FreeLibrary(runtime->library);
+      runtime->library = nullptr;
+      set_message(message, message_size,
+                  "QnnHtp.dll exports no QnnInterface_getProviders");
+      return VA_QNN_ERROR_INCOMPATIBLE;
+    }
+    const QnnInterface_t **providers = nullptr;
+    uint32_t provider_count = 0;
+    uint64_t status = get_providers(&providers, &provider_count);
+    if (status != QNN_SUCCESS) {
+      FreeLibrary(runtime->library);
+      runtime->library = nullptr;
+      set_message(message, message_size, "QnnInterface_getProviders failed");
+      return status;
+    }
+    const QnnInterface_t *provider = select_provider(providers, provider_count);
+    if (provider == nullptr) {
+      FreeLibrary(runtime->library);
+      runtime->library = nullptr;
+      set_message(message, message_size,
+                  "no compatible QNN HTP interface provider");
+      return VA_QNN_ERROR_INCOMPATIBLE;
+    }
+
+    runtime->api = provider->QNN_INTERFACE_VER_NAME;
+    if (!required_api_present(runtime->api)) {
+      FreeLibrary(runtime->library);
+      runtime->library = nullptr;
+      set_message(message, message_size,
+                  "QNN HTP provider lacks a required API function");
+      return VA_QNN_ERROR_INCOMPATIBLE;
+    }
+    status = runtime->api.backendCreate(nullptr, nullptr, &runtime->backend);
+    if (status != QNN_SUCCESS) {
+      FreeLibrary(runtime->library);
+      runtime->library = nullptr;
+      set_message(message, message_size, "QNN HTP backend creation failed");
+      return status;
+    }
+    status = runtime->api.deviceCreate(nullptr, nullptr, &runtime->device);
+    if (status != QNN_SUCCESS) {
+      runtime->api.backendFree(runtime->backend);
+      runtime->backend = nullptr;
+      FreeLibrary(runtime->library);
+      runtime->library = nullptr;
+      set_message(message, message_size, "QNN HTP device creation failed");
+      return status;
+    }
+
+    Qnn_ApiVersion_t version = QNN_API_VERSION_INIT;
+    status = runtime->api.backendGetApiVersion(&version);
+    if (status != QNN_SUCCESS) {
+      runtime->api.deviceFree(runtime->device);
+      runtime->api.backendFree(runtime->backend);
+      FreeLibrary(runtime->library);
+      runtime->library = nullptr;
+      set_message(message, message_size, "QNN HTP API version query failed");
+      return status;
+    }
+    const char *build_id = nullptr;
+    status = runtime->api.backendGetBuildId(&build_id);
+    if (status != QNN_SUCCESS) {
+      runtime->api.deviceFree(runtime->device);
+      runtime->api.backendFree(runtime->backend);
+      FreeLibrary(runtime->library);
+      runtime->library = nullptr;
+      set_message(message, message_size,
+                  "QNN HTP build identifier query failed");
+      return status;
+    }
+
+    info->backend_id = provider->backendId;
+    info->core_major = version.coreApiVersion.major;
+    info->core_minor = version.coreApiVersion.minor;
+    info->core_patch = version.coreApiVersion.patch;
+    info->backend_major = version.backendApiVersion.major;
+    info->backend_minor = version.backendApiVersion.minor;
+    info->backend_patch = version.backendApiVersion.patch;
+    copy_text(info->provider_name, provider->providerName);
+    copy_text(info->build_id, build_id);
+    *output = runtime.release();
+    return QNN_SUCCESS;
+  } catch (const std::bad_alloc &) {
+    set_message(message, message_size, "native QNN bridge allocation failed");
+    return VA_QNN_ERROR_OUT_OF_MEMORY;
+  } catch (...) {
+    set_message(message, message_size, "unexpected native QNN bridge failure");
+    return VA_QNN_ERROR_INTERNAL;
+  }
+}
+
+extern "C" uint64_t va_qnn_runtime_free(VaQnnRuntime *runtime) {
+  if (runtime == nullptr) {
+    return VA_QNN_ERROR_INVALID_ARGUMENT;
+  }
+  if (runtime->in_flight.load(std::memory_order_acquire) != 0) {
+    return VA_QNN_ERROR_BUSY;
+  }
+  uint64_t first_error = QNN_SUCCESS;
+  if (runtime->device != nullptr) {
+    first_error = runtime->api.deviceFree(runtime->device);
+  }
+  if (runtime->backend != nullptr) {
+    const uint64_t status = runtime->api.backendFree(runtime->backend);
+    if (first_error == QNN_SUCCESS) {
+      first_error = status;
+    }
+  }
+  if (runtime->library != nullptr) {
+    FreeLibrary(runtime->library);
+    runtime->library = nullptr;
+  }
+  delete runtime;
+  return first_error;
+}
+
+extern "C" uint64_t
+va_qnn_graph_create(VaQnnRuntime *runtime,
+                    const VaQnnTensorDesc *tensor_descriptions,
+                    uint32_t tensor_count,
+                    const VaQnnNodeDesc *node_descriptions, uint32_t node_count,
+                    VaQnnGraph **output, char *message, size_t message_size) {
+  if (runtime == nullptr || tensor_descriptions == nullptr ||
+      tensor_count == 0 || node_descriptions == nullptr || node_count == 0 ||
+      output == nullptr) {
+    return VA_QNN_ERROR_INVALID_ARGUMENT;
+  }
+  *output = nullptr;
+  try {
+    auto graph = std::make_unique<VaQnnGraph>();
+    graph->runtime = runtime;
+    uint64_t status = runtime->api.contextCreate(
+        runtime->backend, runtime->device, nullptr, &graph->context);
+    if (status != QNN_SUCCESS) {
+      set_message(message, message_size, "QNN context creation failed");
+      return status;
+    }
+    status = runtime->api.graphCreate(graph->context, "virtio_accel_graph",
+                                      nullptr, &graph->graph);
+    if (status != QNN_SUCCESS) {
+      runtime->api.contextFree(graph->context, nullptr);
+      graph->context = nullptr;
+      set_message(message, message_size, "QNN graph creation failed");
+      return status;
+    }
+
+    size_t retained_tensor_count = tensor_count;
+    for (uint32_t index = 0; index < node_count; ++index) {
+      const VaQnnNodeDesc &description = node_descriptions[index];
+      if (description.kind != VA_QNN_NODE_MAX_POOL_2D)
+        continue;
+      const size_t rows = description.kernel[0];
+      const size_t columns = description.kernel[1];
+      if (rows == 0 || columns == 0 || rows > 256 || columns > 256 ||
+          rows > std::numeric_limits<size_t>::max() / columns) {
+        runtime->api.contextFree(graph->context, nullptr);
+        graph->context = nullptr;
+        set_message(message, message_size,
+                    "max-pool kernel exceeds the native resource limit");
+        return VA_QNN_ERROR_INVALID_ARGUMENT;
+      }
+      const size_t windows = rows * columns;
+      const size_t maximums = windows > 1 ? windows - 2 : 0;
+      const size_t extra = rows + columns + rows + windows + maximums;
+      if (retained_tensor_count > std::numeric_limits<size_t>::max() - extra) {
+        runtime->api.contextFree(graph->context, nullptr);
+        graph->context = nullptr;
+        return VA_QNN_ERROR_OUT_OF_MEMORY;
+      }
+      retained_tensor_count += extra;
+    }
+    graph->tensors.reserve(retained_tensor_count);
+    graph->by_value.reserve(tensor_count);
+    for (uint32_t index = 0; index < tensor_count; ++index) {
+      const VaQnnTensorDesc &description = tensor_descriptions[index];
+      if ((description.rank != 0 && description.dimensions == nullptr) ||
+          graph->by_value.find(description.value) != graph->by_value.end()) {
+        runtime->api.contextFree(graph->context, nullptr);
+        set_message(message, message_size,
+                    "invalid or duplicate QNN tensor description");
+        return VA_QNN_ERROR_INVALID_ARGUMENT;
+      }
+      TensorStorage storage;
+      storage.value = description.value;
+      storage.name = "virtio_accel_tensor_" + std::to_string(description.value);
+      storage.dimensions.assign(description.dimensions,
+                                description.dimensions + description.rank);
+      storage.tensor.v2.name = storage.name.c_str();
+      storage.tensor.v2.type = tensor_type(description.role);
+      storage.tensor.v2.dataFormat = QNN_TENSOR_DATA_FORMAT_FLAT_BUFFER;
+      storage.tensor.v2.dataType = QNN_DATATYPE_FLOAT_16;
+      storage.tensor.v2.rank = description.rank;
+      storage.tensor.v2.dimensions = storage.dimensions.data();
+      storage.tensor.v2.memType = QNN_TENSORMEMTYPE_RAW;
+      graph->tensors.push_back(std::move(storage));
+      TensorStorage &retained = graph->tensors.back();
+      retained.tensor.v2.name = retained.name.c_str();
+      retained.tensor.v2.dimensions = retained.dimensions.data();
+      status =
+          runtime->api.tensorCreateGraphTensor(graph->graph, &retained.tensor);
+      if (status != QNN_SUCCESS) {
+        runtime->api.contextFree(graph->context, nullptr);
+        set_message(message, message_size, "QNN graph tensor creation failed");
+        return status;
+      }
+      graph->by_value.emplace(description.value, index);
+      if (description.role == VA_QNN_TENSOR_INPUT) {
+        graph->inputs.push_back(index);
+      } else if (description.role == VA_QNN_TENSOR_OUTPUT) {
+        graph->outputs.push_back(index);
+      }
+    }
+
+    graph->nodes.reserve(node_count);
+    for (uint32_t index = 0; index < node_count; ++index) {
+      status = add_node(*graph, node_descriptions[index], index, message,
+                        message_size);
+      if (status != QNN_SUCCESS) {
+        runtime->api.contextFree(graph->context, nullptr);
+        graph->context = nullptr;
+        return status;
+      }
+    }
+    status = runtime->api.graphFinalize(graph->graph, nullptr, nullptr);
+    if (status != QNN_SUCCESS) {
+      runtime->api.contextFree(graph->context, nullptr);
+      graph->context = nullptr;
+      set_message(message, message_size, "QNN HTP graph finalization failed");
+      return status;
+    }
+    *output = graph.release();
+    return QNN_SUCCESS;
+  } catch (const std::bad_alloc &) {
+    set_message(message, message_size, "native QNN graph allocation failed");
+    return VA_QNN_ERROR_OUT_OF_MEMORY;
+  } catch (...) {
+    set_message(message, message_size, "unexpected native QNN graph failure");
+    return VA_QNN_ERROR_INTERNAL;
+  }
+}
+
+extern "C" uint64_t va_qnn_graph_free(VaQnnGraph *graph) {
+  if (graph == nullptr) {
+    return VA_QNN_ERROR_INVALID_ARGUMENT;
+  }
+  if (graph->runtime->in_flight.load(std::memory_order_acquire) != 0) {
+    return VA_QNN_ERROR_BUSY;
+  }
+  const uint64_t status =
+      graph->runtime->api.contextFree(graph->context, nullptr);
+  delete graph;
+  return status;
+}
+
+extern "C" uint64_t va_qnn_graph_execute_async(
+    VaQnnGraph *graph, const VaQnnBinding *input_bindings, uint32_t input_count,
+    const VaQnnBinding *output_bindings, uint32_t output_count,
+    VaQnnEvent **output, char *message, size_t message_size) {
+  if (graph == nullptr || output == nullptr ||
+      input_count != graph->inputs.size() ||
+      output_count != graph->outputs.size() ||
+      (input_count != 0 && input_bindings == nullptr) ||
+      (output_count != 0 && output_bindings == nullptr)) {
+    return VA_QNN_ERROR_INVALID_ARGUMENT;
+  }
+  *output = nullptr;
+  uint32_t expected = 0;
+  if (!graph->runtime->in_flight.compare_exchange_strong(
+          expected, 1, std::memory_order_acq_rel, std::memory_order_acquire)) {
+    return VA_QNN_ERROR_BUSY;
+  }
+  try {
+    auto event = std::make_unique<VaQnnEvent>();
+    event->runtime = graph->runtime;
+    event->inputs.reserve(input_count);
+    event->outputs.reserve(output_count);
+    for (uint32_t index = 0; index < input_count; ++index) {
+      if (input_bindings[index].data == nullptr ||
+          input_bindings[index].size > std::numeric_limits<uint32_t>::max()) {
+        graph->runtime->in_flight.store(0, std::memory_order_release);
+        return VA_QNN_ERROR_INVALID_ARGUMENT;
+      }
+      Qnn_Tensor_t tensor = graph->tensors[graph->inputs[index]].tensor;
+      tensor.v2.clientBuf.data = input_bindings[index].data;
+      tensor.v2.clientBuf.dataSize =
+          static_cast<uint32_t>(input_bindings[index].size);
+      event->inputs.push_back(tensor);
+    }
+    for (uint32_t index = 0; index < output_count; ++index) {
+      if (output_bindings[index].data == nullptr ||
+          output_bindings[index].size > std::numeric_limits<uint32_t>::max()) {
+        graph->runtime->in_flight.store(0, std::memory_order_release);
+        return VA_QNN_ERROR_INVALID_ARGUMENT;
+      }
+      Qnn_Tensor_t tensor = graph->tensors[graph->outputs[index]].tensor;
+      tensor.v2.clientBuf.data = output_bindings[index].data;
+      tensor.v2.clientBuf.dataSize =
+          static_cast<uint32_t>(output_bindings[index].size);
+      event->outputs.push_back(tensor);
+    }
+
+    VaQnnEvent *accepted = event.get();
+    accepted->worker = std::thread([graph, accepted]() {
+      const uint64_t status = graph->runtime->api.graphExecute(
+          graph->graph, accepted->inputs.data(),
+          static_cast<uint32_t>(accepted->inputs.size()),
+          accepted->outputs.data(),
+          static_cast<uint32_t>(accepted->outputs.size()), nullptr, nullptr);
+      accepted->error.store(status, std::memory_order_relaxed);
+      accepted->runtime->in_flight.store(0, std::memory_order_release);
+      accepted->state.store(status == QNN_SUCCESS ? VA_QNN_EVENT_COMPLETE
+                                                  : VA_QNN_EVENT_FAILED,
+                            std::memory_order_release);
+    });
+    *output = event.release();
+    return QNN_SUCCESS;
+  } catch (const std::bad_alloc &) {
+    graph->runtime->in_flight.store(0, std::memory_order_release);
+    return VA_QNN_ERROR_OUT_OF_MEMORY;
+  } catch (...) {
+    graph->runtime->in_flight.store(0, std::memory_order_release);
+    return VA_QNN_ERROR_INTERNAL;
+  }
+}
+
+extern "C" uint32_t va_qnn_event_poll(const VaQnnEvent *event,
+                                      uint64_t *qnn_error) {
+  if (event == nullptr) {
+    if (qnn_error != nullptr) {
+      *qnn_error = VA_QNN_ERROR_INVALID_ARGUMENT;
+    }
+    return VA_QNN_EVENT_FAILED;
+  }
+  const uint32_t state = event->state.load(std::memory_order_acquire);
+  if (qnn_error != nullptr) {
+    *qnn_error = event->error.load(std::memory_order_relaxed);
+  }
+  return state;
+}
+
+extern "C" uint64_t va_qnn_event_free(VaQnnEvent *event) {
+  if (event == nullptr) {
+    return VA_QNN_ERROR_INVALID_ARGUMENT;
+  }
+  if (event->state.load(std::memory_order_acquire) == VA_QNN_EVENT_PENDING) {
+    return VA_QNN_ERROR_BUSY;
+  }
+  if (event->worker.joinable()) {
+    event->worker.join();
+  }
+  delete event;
+  return QNN_SUCCESS;
+}

--- a/crates/virtio-accel-hexagon/native/qnn_bridge.cpp
+++ b/crates/virtio-accel-hexagon/native/qnn_bridge.cpp
@@ -616,6 +616,37 @@ va_qnn_graph_create(VaQnnRuntime *runtime,
       return status;
     }
 
+    size_t input_count = 0;
+    size_t output_count = 0;
+    for (uint32_t index = 0; index < tensor_count; ++index) {
+      const VaQnnTensorDesc &description = tensor_descriptions[index];
+      switch (description.role) {
+      case VA_QNN_TENSOR_NATIVE:
+        if (description.io_index != UINT32_MAX) {
+          runtime->api.contextFree(graph->context, nullptr);
+          graph->context = nullptr;
+          set_message(message, message_size,
+                      "native QNN tensor has a model I/O index");
+          return VA_QNN_ERROR_INVALID_ARGUMENT;
+        }
+        break;
+      case VA_QNN_TENSOR_INPUT:
+        ++input_count;
+        break;
+      case VA_QNN_TENSOR_OUTPUT:
+        ++output_count;
+        break;
+      default:
+        runtime->api.contextFree(graph->context, nullptr);
+        graph->context = nullptr;
+        set_message(message, message_size, "invalid QNN tensor role");
+        return VA_QNN_ERROR_INVALID_ARGUMENT;
+      }
+    }
+    const size_t unbound = std::numeric_limits<size_t>::max();
+    graph->inputs.assign(input_count, unbound);
+    graph->outputs.assign(output_count, unbound);
+
     size_t retained_tensor_count = tensor_count;
     for (uint32_t index = 0; index < node_count; ++index) {
       const VaQnnNodeDesc &description = node_descriptions[index];
@@ -677,9 +708,25 @@ va_qnn_graph_create(VaQnnRuntime *runtime,
       }
       graph->by_value.emplace(description.value, index);
       if (description.role == VA_QNN_TENSOR_INPUT) {
-        graph->inputs.push_back(index);
+        if (description.io_index >= graph->inputs.size() ||
+            graph->inputs[description.io_index] != unbound) {
+          runtime->api.contextFree(graph->context, nullptr);
+          graph->context = nullptr;
+          set_message(message, message_size,
+                      "duplicate or invalid QNN input index");
+          return VA_QNN_ERROR_INVALID_ARGUMENT;
+        }
+        graph->inputs[description.io_index] = index;
       } else if (description.role == VA_QNN_TENSOR_OUTPUT) {
-        graph->outputs.push_back(index);
+        if (description.io_index >= graph->outputs.size() ||
+            graph->outputs[description.io_index] != unbound) {
+          runtime->api.contextFree(graph->context, nullptr);
+          graph->context = nullptr;
+          set_message(message, message_size,
+                      "duplicate or invalid QNN output index");
+          return VA_QNN_ERROR_INVALID_ARGUMENT;
+        }
+        graph->outputs[description.io_index] = index;
       }
     }
 

--- a/crates/virtio-accel-hexagon/native/qnn_bridge.h
+++ b/crates/virtio-accel-hexagon/native/qnn_bridge.h
@@ -51,6 +51,7 @@ typedef struct VaQnnRuntimeInfo {
 typedef struct VaQnnTensorDesc {
   uint32_t value;
   uint32_t role;
+  uint32_t io_index;
   const uint32_t *dimensions;
   uint32_t rank;
 } VaQnnTensorDesc;

--- a/crates/virtio-accel-hexagon/native/qnn_bridge.h
+++ b/crates/virtio-accel-hexagon/native/qnn_bridge.h
@@ -1,0 +1,97 @@
+#ifndef VIRTIO_ACCEL_QNN_BRIDGE_H
+#define VIRTIO_ACCEL_QNN_BRIDGE_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct VaQnnRuntime VaQnnRuntime;
+typedef struct VaQnnGraph VaQnnGraph;
+typedef struct VaQnnEvent VaQnnEvent;
+
+enum VaQnnNodeKind {
+  VA_QNN_NODE_RESHAPE = 1,
+  VA_QNN_NODE_MATMUL = 2,
+  VA_QNN_NODE_MAX_POOL_2D = 3,
+};
+
+enum VaQnnTensorRole {
+  VA_QNN_TENSOR_NATIVE = 0,
+  VA_QNN_TENSOR_INPUT = 1,
+  VA_QNN_TENSOR_OUTPUT = 2,
+};
+
+enum VaQnnEventState {
+  VA_QNN_EVENT_PENDING = 0,
+  VA_QNN_EVENT_COMPLETE = 1,
+  VA_QNN_EVENT_FAILED = 2,
+};
+
+#define VA_QNN_ERROR_INTERNAL UINT64_MAX
+#define VA_QNN_ERROR_INCOMPATIBLE (UINT64_MAX - UINT64_C(1))
+#define VA_QNN_ERROR_BUSY (UINT64_MAX - UINT64_C(2))
+#define VA_QNN_ERROR_INVALID_ARGUMENT (UINT64_MAX - UINT64_C(3))
+#define VA_QNN_ERROR_OUT_OF_MEMORY (UINT64_MAX - UINT64_C(4))
+
+typedef struct VaQnnRuntimeInfo {
+  uint32_t backend_id;
+  uint32_t core_major;
+  uint32_t core_minor;
+  uint32_t core_patch;
+  uint32_t backend_major;
+  uint32_t backend_minor;
+  uint32_t backend_patch;
+  char provider_name[128];
+  char build_id[256];
+} VaQnnRuntimeInfo;
+
+typedef struct VaQnnTensorDesc {
+  uint32_t value;
+  uint32_t role;
+  const uint32_t *dimensions;
+  uint32_t rank;
+} VaQnnTensorDesc;
+
+typedef struct VaQnnNodeDesc {
+  uint32_t kind;
+  uint32_t input0;
+  uint32_t input1;
+  uint32_t output;
+  uint32_t kernel[2];
+  uint32_t stride[2];
+} VaQnnNodeDesc;
+
+typedef struct VaQnnBinding {
+  void *data;
+  uint64_t size;
+} VaQnnBinding;
+
+uint64_t va_qnn_runtime_create(const char *library_path, VaQnnRuntime **runtime,
+                               VaQnnRuntimeInfo *info, char *message,
+                               size_t message_size);
+uint64_t va_qnn_runtime_free(VaQnnRuntime *runtime);
+
+uint64_t va_qnn_graph_create(VaQnnRuntime *runtime,
+                             const VaQnnTensorDesc *tensors,
+                             uint32_t tensor_count, const VaQnnNodeDesc *nodes,
+                             uint32_t node_count, VaQnnGraph **graph,
+                             char *message, size_t message_size);
+uint64_t va_qnn_graph_free(VaQnnGraph *graph);
+
+uint64_t va_qnn_graph_execute_async(VaQnnGraph *graph,
+                                    const VaQnnBinding *inputs,
+                                    uint32_t input_count,
+                                    const VaQnnBinding *outputs,
+                                    uint32_t output_count, VaQnnEvent **event,
+                                    char *message, size_t message_size);
+uint32_t va_qnn_event_poll(const VaQnnEvent *event, uint64_t *qnn_error);
+uint64_t va_qnn_event_free(VaQnnEvent *event);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/crates/virtio-accel-hexagon/src/ffi.rs
+++ b/crates/virtio-accel-hexagon/src/ffi.rs
@@ -1,9 +1,130 @@
-//! Reserved native QNN C ABI boundary.
-//!
-//! This module is compiled only after the build probe finds the public QNN development surface.
-//! The initial repository integration intentionally contains no guessed ABI declarations: the
-//! complete matching QAIRT headers are required before this boundary can be implemented safely.
+//! Narrow C ABI implemented by `native/qnn_bridge.cpp` against the detected QAIRT headers.
 
-#![forbid(unsafe_code)]
+use core::ffi::{c_char, c_void};
 
-pub(crate) const NATIVE_BRIDGE_IMPLEMENTED: bool = false;
+pub(crate) const SUCCESS: u64 = 0;
+pub(crate) const ERROR_INTERNAL: u64 = u64::MAX;
+pub(crate) const ERROR_INCOMPATIBLE: u64 = u64::MAX - 1;
+pub(crate) const ERROR_BUSY: u64 = u64::MAX - 2;
+pub(crate) const ERROR_INVALID_ARGUMENT: u64 = u64::MAX - 3;
+pub(crate) const ERROR_OUT_OF_MEMORY: u64 = u64::MAX - 4;
+
+pub(crate) const TENSOR_NATIVE: u32 = 0;
+pub(crate) const TENSOR_INPUT: u32 = 1;
+pub(crate) const TENSOR_OUTPUT: u32 = 2;
+
+pub(crate) const NODE_RESHAPE: u32 = 1;
+pub(crate) const NODE_MATMUL: u32 = 2;
+pub(crate) const NODE_MAX_POOL_2D: u32 = 3;
+
+pub(crate) const EVENT_PENDING: u32 = 0;
+pub(crate) const EVENT_COMPLETE: u32 = 1;
+pub(crate) const EVENT_FAILED: u32 = 2;
+
+#[repr(C)]
+pub(crate) struct Runtime {
+    _private: [u8; 0],
+}
+
+#[repr(C)]
+pub(crate) struct Graph {
+    _private: [u8; 0],
+}
+
+#[repr(C)]
+pub(crate) struct Event {
+    _private: [u8; 0],
+}
+
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub(crate) struct RuntimeInfo {
+    pub backend_id: u32,
+    pub core_major: u32,
+    pub core_minor: u32,
+    pub core_patch: u32,
+    pub backend_major: u32,
+    pub backend_minor: u32,
+    pub backend_patch: u32,
+    pub provider_name: [c_char; 128],
+    pub build_id: [c_char; 256],
+}
+
+impl Default for RuntimeInfo {
+    fn default() -> Self {
+        Self {
+            backend_id: 0,
+            core_major: 0,
+            core_minor: 0,
+            core_patch: 0,
+            backend_major: 0,
+            backend_minor: 0,
+            backend_patch: 0,
+            provider_name: [0; 128],
+            build_id: [0; 256],
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub(crate) struct TensorDesc {
+    pub value: u32,
+    pub role: u32,
+    pub dimensions: *const u32,
+    pub rank: u32,
+}
+
+#[derive(Clone, Copy, Default)]
+#[repr(C)]
+pub(crate) struct NodeDesc {
+    pub kind: u32,
+    pub input0: u32,
+    pub input1: u32,
+    pub output: u32,
+    pub kernel: [u32; 2],
+    pub stride: [u32; 2],
+}
+
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub(crate) struct Binding {
+    pub data: *mut c_void,
+    pub size: u64,
+}
+
+unsafe extern "C" {
+    pub(crate) fn va_qnn_runtime_create(
+        library_path: *const c_char,
+        runtime: *mut *mut Runtime,
+        info: *mut RuntimeInfo,
+        message: *mut c_char,
+        message_size: usize,
+    ) -> u64;
+    pub(crate) fn va_qnn_runtime_free(runtime: *mut Runtime) -> u64;
+
+    pub(crate) fn va_qnn_graph_create(
+        runtime: *mut Runtime,
+        tensors: *const TensorDesc,
+        tensor_count: u32,
+        nodes: *const NodeDesc,
+        node_count: u32,
+        graph: *mut *mut Graph,
+        message: *mut c_char,
+        message_size: usize,
+    ) -> u64;
+    pub(crate) fn va_qnn_graph_free(graph: *mut Graph) -> u64;
+
+    pub(crate) fn va_qnn_graph_execute_async(
+        graph: *mut Graph,
+        inputs: *const Binding,
+        input_count: u32,
+        outputs: *const Binding,
+        output_count: u32,
+        event: *mut *mut Event,
+        message: *mut c_char,
+        message_size: usize,
+    ) -> u64;
+    pub(crate) fn va_qnn_event_poll(event: *const Event, qnn_error: *mut u64) -> u32;
+    pub(crate) fn va_qnn_event_free(event: *mut Event) -> u64;
+}

--- a/crates/virtio-accel-hexagon/src/ffi.rs
+++ b/crates/virtio-accel-hexagon/src/ffi.rs
@@ -1,0 +1,9 @@
+//! Reserved native QNN C ABI boundary.
+//!
+//! This module is compiled only after the build probe finds the public QNN development surface.
+//! The initial repository integration intentionally contains no guessed ABI declarations: the
+//! complete matching QAIRT headers are required before this boundary can be implemented safely.
+
+#![forbid(unsafe_code)]
+
+pub(crate) const NATIVE_BRIDGE_IMPLEMENTED: bool = false;

--- a/crates/virtio-accel-hexagon/src/ffi.rs
+++ b/crates/virtio-accel-hexagon/src/ffi.rs
@@ -12,6 +12,7 @@ pub(crate) const ERROR_OUT_OF_MEMORY: u64 = u64::MAX - 4;
 pub(crate) const TENSOR_NATIVE: u32 = 0;
 pub(crate) const TENSOR_INPUT: u32 = 1;
 pub(crate) const TENSOR_OUTPUT: u32 = 2;
+pub(crate) const NO_IO_INDEX: u32 = u32::MAX;
 
 pub(crate) const NODE_RESHAPE: u32 = 1;
 pub(crate) const NODE_MATMUL: u32 = 2;
@@ -71,6 +72,7 @@ impl Default for RuntimeInfo {
 pub(crate) struct TensorDesc {
     pub value: u32,
     pub role: u32,
+    pub io_index: u32,
     pub dimensions: *const u32,
     pub rank: u32,
 }

--- a/crates/virtio-accel-hexagon/src/lib.rs
+++ b/crates/virtio-accel-hexagon/src/lib.rs
@@ -5,14 +5,17 @@
 //! QAIRT/QNN SDK is detected. SDK-free hosts retain that portable code and a constructor that
 //! reports the unavailable runtime without importing Qualcomm dependencies into portable crates.
 
-#![forbid(unsafe_code)]
+#![cfg_attr(not(va_hexagon), forbid(unsafe_code))]
 
 mod lower;
 
 pub use lower::{HEXAGON_TOSA_TARGET, LoweringError, supports_tosa_dtype, supports_tosa_operator};
 
 /// Native QNN runtime and ABI version validated by the initial backend tier.
-pub const TESTED_QAIRT_RELEASE: &str = "2.48.40.260702";
+pub const TESTED_QAIRT_RELEASE: &str = "2.49.0.260730";
+
+/// Conservative program-residency charge until QNN publishes a finite graph allocation bound.
+pub const REQUIRED_RESIDENT_BYTES: u64 = u64::MAX;
 
 /// Failure to initialize a Qualcomm Hexagon backend instance.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -33,12 +36,18 @@ impl core::fmt::Display for InitError {
 
 impl std::error::Error for InitError {}
 
+#[allow(unsafe_code)]
 #[cfg(va_hexagon)]
 mod ffi;
+#[allow(unsafe_code)]
 #[cfg(va_hexagon)]
 mod native;
 #[cfg(va_hexagon)]
 pub use native::HexagonAccelerator;
+#[cfg(va_hexagon)]
+pub use native::{
+    HexagonBuffer, HexagonContext, HexagonEvent, HexagonProgram, HexagonQueue, QnnRuntimeInfo,
+};
 
 /// Placeholder that keeps workspace consumers portable when no complete QNN SDK was detected.
 #[cfg(not(va_hexagon))]
@@ -58,11 +67,10 @@ impl HexagonAccelerator {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(va_hexagon)))]
 mod tests {
     use super::*;
 
-    #[cfg(not(va_hexagon))]
     #[test]
     fn sdk_free_constructor_is_explicitly_unavailable() {
         assert!(matches!(

--- a/crates/virtio-accel-hexagon/src/lib.rs
+++ b/crates/virtio-accel-hexagon/src/lib.rs
@@ -1,0 +1,77 @@
+//! Qualcomm Hexagon NPU backend for `virtio-accel`.
+//!
+//! The portable portion validates TOSA 1.0 artifacts and creates a provider-local, fixed binding
+//! and operation plan. Native modules are compiled only for Windows ARM64 when a complete public
+//! QAIRT/QNN SDK is detected. SDK-free hosts retain that portable code and a constructor that
+//! reports the unavailable runtime without importing Qualcomm dependencies into portable crates.
+
+#![forbid(unsafe_code)]
+
+mod lower;
+
+pub use lower::{HEXAGON_TOSA_TARGET, LoweringError, supports_tosa_dtype, supports_tosa_operator};
+
+/// Native QNN runtime and ABI version validated by the initial backend tier.
+pub const TESTED_QAIRT_RELEASE: &str = "2.48.40.260702";
+
+/// Failure to initialize a Qualcomm Hexagon backend instance.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum InitError {
+    /// The crate was built without a complete QAIRT/QNN development runtime.
+    RuntimeUnavailable,
+    /// The loaded QNN interface is outside the validated API range.
+    IncompatibleRuntime,
+    /// The HTP backend or its device could not be created.
+    DeviceUnavailable,
+}
+
+impl core::fmt::Display for InitError {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(formatter, "{self:?}")
+    }
+}
+
+impl std::error::Error for InitError {}
+
+#[cfg(va_hexagon)]
+mod ffi;
+#[cfg(va_hexagon)]
+mod native;
+#[cfg(va_hexagon)]
+pub use native::HexagonAccelerator;
+
+/// Placeholder that keeps workspace consumers portable when no complete QNN SDK was detected.
+#[cfg(not(va_hexagon))]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct HexagonAccelerator;
+
+#[cfg(not(va_hexagon))]
+impl HexagonAccelerator {
+    /// Report that the native QNN build requirements were not detected.
+    pub fn new() -> Result<Self, InitError> {
+        Err(InitError::RuntimeUnavailable)
+    }
+
+    /// Report that the native QNN build requirements were not detected.
+    pub fn available_devices() -> Result<Vec<String>, InitError> {
+        Err(InitError::RuntimeUnavailable)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(not(va_hexagon))]
+    #[test]
+    fn sdk_free_constructor_is_explicitly_unavailable() {
+        assert!(matches!(
+            HexagonAccelerator::new(),
+            Err(InitError::RuntimeUnavailable)
+        ));
+        assert!(matches!(
+            HexagonAccelerator::available_devices(),
+            Err(InitError::RuntimeUnavailable)
+        ));
+    }
+}

--- a/crates/virtio-accel-hexagon/src/lower.rs
+++ b/crates/virtio-accel-hexagon/src/lower.rs
@@ -110,6 +110,15 @@ pub(crate) struct LoweredModel {
     pub features: Vec<LoweredFeature>,
 }
 
+impl LoweredModel {
+    pub(crate) fn boundary(&self, value: u32) -> Option<(FeatureRole, u32)> {
+        self.features
+            .iter()
+            .find(|feature| feature.value == value)
+            .map(|feature| (feature.role, feature.io_index))
+    }
+}
+
 pub(crate) fn lower_tosa(bytes: &[u8], target: Target) -> Result<LoweredModel, LoweringError> {
     if target != HEXAGON_TOSA_TARGET {
         return Err(LoweringError::UnsupportedGraph);
@@ -405,6 +414,62 @@ mod tests {
         assert_eq!(lowered.features[1].slot, 1);
         assert_eq!(lowered.features[2].slot, 2);
         assert_eq!(lowered.features[2].role, FeatureRole::Output);
+    }
+
+    #[test]
+    fn boundary_indices_do_not_depend_on_tensor_declaration_order() {
+        let lowered = LoweredModel {
+            tensors: vec![
+                LoweredTensor {
+                    value: 20,
+                    dims: vec![1],
+                },
+                LoweredTensor {
+                    value: 10,
+                    dims: vec![1],
+                },
+                LoweredTensor {
+                    value: 30,
+                    dims: vec![1],
+                },
+            ],
+            nodes: vec![LoweredNode::MatMul {
+                left: 10,
+                right: 20,
+                output: 30,
+            }],
+            features: vec![
+                LoweredFeature {
+                    slot: 0,
+                    role: FeatureRole::Input,
+                    io_index: 0,
+                    value: 10,
+                    dims: vec![1],
+                    byte_len: 2,
+                },
+                LoweredFeature {
+                    slot: 1,
+                    role: FeatureRole::Input,
+                    io_index: 1,
+                    value: 20,
+                    dims: vec![1],
+                    byte_len: 2,
+                },
+                LoweredFeature {
+                    slot: 2,
+                    role: FeatureRole::Output,
+                    io_index: 0,
+                    value: 30,
+                    dims: vec![1],
+                    byte_len: 2,
+                },
+            ],
+        };
+
+        assert_eq!(lowered.tensors[0].value, 20);
+        assert_eq!(lowered.boundary(20), Some((FeatureRole::Input, 1)));
+        assert_eq!(lowered.boundary(10), Some((FeatureRole::Input, 0)));
+        assert_eq!(lowered.boundary(30), Some((FeatureRole::Output, 0)));
     }
 
     #[test]

--- a/crates/virtio-accel-hexagon/src/lower.rs
+++ b/crates/virtio-accel-hexagon/src/lower.rs
@@ -1,0 +1,499 @@
+//! Strict TOSA 1.0 admission and provider-local QNN graph planning.
+//!
+//! This module deliberately contains no QNN ABI types. It turns a verified TOSA artifact into
+//! owned tensor, binding, and operation metadata that the native boundary can translate while the
+//! source FlatBuffer is no longer borrowed. It compiles and tests on hosts without QAIRT.
+
+#![cfg_attr(not(va_hexagon), allow(dead_code))]
+
+use std::fmt;
+
+use virtio_accel_tosa::{
+    AnalysisError, AnalyzedValueKind, DType, Error as ParseError, ExtensionSet, Level,
+    NanPropagationMode, Op, OpAttributes, ProfileSet, Target, TosaAnalysis, ValueId, Version,
+    parse,
+};
+
+/// TOSA declaration accepted by the first Hexagon tier.
+///
+/// The target selects the TOSA floating-point profile. Backend admission narrows its tensor types
+/// to FP16 until the selected HTP runtime can prove FP32 computation without precision reduction.
+pub const HEXAGON_TOSA_TARGET: Target = Target::new(
+    Version::TOSA_1_0,
+    ProfileSet::FLOATING_POINT,
+    Level::Level8K,
+    ExtensionSet::NONE,
+);
+
+/// Failure while validating and planning a graph for QNN HTP.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LoweringError {
+    Parse(ParseError),
+    Analysis(AnalysisError),
+    UnsupportedGraph,
+    UnsupportedType(DType),
+    UnsupportedOperator(Op),
+    InvalidConstant,
+    ResourceLimit,
+}
+
+impl fmt::Display for LoweringError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{self:?}")
+    }
+}
+
+impl std::error::Error for LoweringError {}
+
+/// Whether the first hardware tier has a QNN lowering for `op`.
+pub const fn supports_tosa_operator(op: Op) -> bool {
+    matches!(op, Op::IDENTITY | Op::MATMUL | Op::MAX_POOL2D)
+}
+
+/// Whether the first hardware tier may expose `dtype` at a model boundary.
+///
+/// FP32 remains deliberately rejected because current HTP floating-point execution may use FP16
+/// math. Integer and packed low-precision tiers require separate targets and evidence.
+pub const fn supports_tosa_dtype(dtype: DType) -> bool {
+    matches!(dtype, DType::FP16)
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum FeatureRole {
+    Input,
+    Output,
+}
+
+/// One exact model-boundary binding.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct LoweredFeature {
+    pub slot: u32,
+    pub role: FeatureRole,
+    pub io_index: u32,
+    pub value: u32,
+    pub dims: Vec<u32>,
+    pub byte_len: u64,
+}
+
+/// One owned tensor descriptor used while constructing the QNN graph.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct LoweredTensor {
+    pub value: u32,
+    pub dims: Vec<u32>,
+}
+
+/// One operation from the accepted initial QNN lowering subset.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum LoweredNode {
+    Identity {
+        input: u32,
+        output: u32,
+    },
+    MatMul {
+        left: u32,
+        right: u32,
+        output: u32,
+    },
+    MaxPool2d {
+        input: u32,
+        output: u32,
+        kernel: [u32; 2],
+        stride: [u32; 2],
+    },
+}
+
+/// Fully owned graph plan produced before entering the native QNN boundary.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct LoweredModel {
+    pub tensors: Vec<LoweredTensor>,
+    pub nodes: Vec<LoweredNode>,
+    pub features: Vec<LoweredFeature>,
+}
+
+pub(crate) fn lower_tosa(bytes: &[u8], target: Target) -> Result<LoweredModel, LoweringError> {
+    if target != HEXAGON_TOSA_TARGET {
+        return Err(LoweringError::UnsupportedGraph);
+    }
+    let model = parse(bytes).map_err(LoweringError::Parse)?;
+    let analysis = model.analyze_for(target).map_err(LoweringError::Analysis)?;
+    if analysis.regions().len() != 1
+        || analysis.blocks().len() != 1
+        || !analysis.conditions().is_empty()
+    {
+        return Err(LoweringError::UnsupportedGraph);
+    }
+
+    validate_fp16_only(&analysis)?;
+    let block = analysis.blocks()[0].id();
+    let inputs = analysis.block_inputs(block);
+    let outputs = analysis.block_outputs(block);
+    if inputs.is_empty()
+        || outputs.is_empty()
+        || inputs.iter().any(|input| outputs.contains(input))
+        || inputs.len().checked_add(outputs.len()).is_none()
+    {
+        return Err(LoweringError::UnsupportedGraph);
+    }
+
+    let mut tensors = Vec::new();
+    tensors
+        .try_reserve_exact(analysis.values().len())
+        .map_err(|_| LoweringError::ResourceLimit)?;
+    for value in analysis.values() {
+        let AnalyzedValueKind::Tensor(tensor) = value.kind() else {
+            return Err(LoweringError::UnsupportedGraph);
+        };
+        tensors.push(LoweredTensor {
+            value: value.id().get(),
+            dims: static_dims(tensor, true)?,
+        });
+    }
+
+    let mut features = Vec::new();
+    features
+        .try_reserve_exact(inputs.len() + outputs.len())
+        .map_err(|_| LoweringError::ResourceLimit)?;
+    for (index, value) in inputs.iter().copied().enumerate() {
+        features.push(lower_feature(
+            &analysis,
+            value,
+            index,
+            index,
+            FeatureRole::Input,
+        )?);
+    }
+    for (index, value) in outputs.iter().copied().enumerate() {
+        features.push(lower_feature(
+            &analysis,
+            value,
+            inputs.len() + index,
+            index,
+            FeatureRole::Output,
+        )?);
+    }
+
+    let mut nodes = Vec::new();
+    nodes
+        .try_reserve_exact(analysis.execution_order(block).len())
+        .map_err(|_| LoweringError::ResourceLimit)?;
+    for operator_id in analysis.execution_order(block) {
+        let operator = analysis.operator(*operator_id);
+        let op = operator.op();
+        let op_inputs = analysis.operator_inputs(*operator_id);
+        let op_outputs = analysis.operator_outputs(*operator_id);
+        match op {
+            Op::CONST => {
+                if op_outputs.len() != 1
+                    || !constant_is_matmul_zero_point(&analysis, op_outputs[0])
+                    || !serialized_fp16_is_zero(
+                        analysis
+                            .serialized_constant(op_outputs[0])
+                            .ok_or(LoweringError::InvalidConstant)?,
+                    )
+                {
+                    return Err(LoweringError::UnsupportedGraph);
+                }
+            }
+            Op::IDENTITY => {
+                require_arity(op_inputs, 1, op_outputs, 1)?;
+                nodes.push(LoweredNode::Identity {
+                    input: op_inputs[0].get(),
+                    output: op_outputs[0].get(),
+                });
+            }
+            Op::MATMUL => {
+                require_arity(op_inputs, 4, op_outputs, 1)?;
+                for zero_point in &op_inputs[2..4] {
+                    if !serialized_fp16_is_zero(
+                        analysis
+                            .serialized_constant(*zero_point)
+                            .ok_or(LoweringError::InvalidConstant)?,
+                    ) {
+                        return Err(LoweringError::UnsupportedGraph);
+                    }
+                }
+                nodes.push(LoweredNode::MatMul {
+                    left: op_inputs[0].get(),
+                    right: op_inputs[1].get(),
+                    output: op_outputs[0].get(),
+                });
+            }
+            Op::MAX_POOL2D => {
+                require_arity(op_inputs, 1, op_outputs, 1)?;
+                let OpAttributes::MaxPool2d {
+                    kernel,
+                    stride,
+                    pad,
+                    nan_mode,
+                } = operator.source().attributes()
+                else {
+                    return Err(LoweringError::UnsupportedGraph);
+                };
+                if nan_mode != NanPropagationMode::PROPAGATE {
+                    return Err(LoweringError::UnsupportedGraph);
+                }
+                let kernel = fixed_positive_pair(kernel.iter())?;
+                let stride = fixed_positive_pair(stride.iter())?;
+                let pad = pad.iter().collect::<Vec<_>>();
+                if pad.len() != 4 || pad.iter().any(|value| *value != 0) {
+                    return Err(LoweringError::UnsupportedGraph);
+                }
+                let input_dims = tensor_dims(&analysis, op_inputs[0], false)?;
+                let output_dims = tensor_dims(&analysis, op_outputs[0], false)?;
+                if input_dims.len() != 4 || output_dims.len() != 4 {
+                    return Err(LoweringError::UnsupportedGraph);
+                }
+                nodes.push(LoweredNode::MaxPool2d {
+                    input: op_inputs[0].get(),
+                    output: op_outputs[0].get(),
+                    kernel,
+                    stride,
+                });
+            }
+            _ => return Err(LoweringError::UnsupportedOperator(op)),
+        }
+    }
+
+    if nodes.is_empty() {
+        return Err(LoweringError::UnsupportedGraph);
+    }
+    Ok(LoweredModel {
+        tensors,
+        nodes,
+        features,
+    })
+}
+
+fn validate_fp16_only(analysis: &TosaAnalysis<'_>) -> Result<(), LoweringError> {
+    for value in analysis.values() {
+        let AnalyzedValueKind::Tensor(tensor) = value.kind() else {
+            return Err(LoweringError::UnsupportedGraph);
+        };
+        if !supports_tosa_dtype(tensor.dtype()) {
+            return Err(LoweringError::UnsupportedType(tensor.dtype()));
+        }
+    }
+    Ok(())
+}
+
+fn lower_feature(
+    analysis: &TosaAnalysis<'_>,
+    value: ValueId,
+    slot: usize,
+    io_index: usize,
+    role: FeatureRole,
+) -> Result<LoweredFeature, LoweringError> {
+    let dims = tensor_dims(analysis, value, false)?;
+    let mut byte_len = 2u64;
+    for dim in &dims {
+        byte_len = byte_len
+            .checked_mul(u64::from(*dim))
+            .ok_or(LoweringError::ResourceLimit)?;
+    }
+    Ok(LoweredFeature {
+        slot: u32::try_from(slot).map_err(|_| LoweringError::ResourceLimit)?,
+        role,
+        io_index: u32::try_from(io_index).map_err(|_| LoweringError::ResourceLimit)?,
+        value: value.get(),
+        dims,
+        byte_len,
+    })
+}
+
+fn tensor_dims(
+    analysis: &TosaAnalysis<'_>,
+    value: ValueId,
+    allow_scalar: bool,
+) -> Result<Vec<u32>, LoweringError> {
+    let AnalyzedValueKind::Tensor(tensor) = analysis.value(value).kind() else {
+        return Err(LoweringError::UnsupportedGraph);
+    };
+    static_dims(tensor, allow_scalar)
+}
+
+fn static_dims(
+    tensor: virtio_accel_tosa::Tensor<'_>,
+    allow_scalar: bool,
+) -> Result<Vec<u32>, LoweringError> {
+    tensor.rank().ok_or(LoweringError::UnsupportedGraph)?;
+    let dims = tensor
+        .dimensions()
+        .map(|dim| u32::try_from(dim).map_err(|_| LoweringError::UnsupportedGraph))
+        .collect::<Result<Vec<_>, _>>()?;
+    if (!allow_scalar && dims.is_empty()) || dims.contains(&0) {
+        return Err(LoweringError::UnsupportedGraph);
+    }
+    Ok(dims)
+}
+
+fn require_arity(
+    inputs: &[ValueId],
+    input_count: usize,
+    outputs: &[ValueId],
+    output_count: usize,
+) -> Result<(), LoweringError> {
+    if inputs.len() == input_count && outputs.len() == output_count {
+        Ok(())
+    } else {
+        Err(LoweringError::UnsupportedGraph)
+    }
+}
+
+fn fixed_positive_pair(values: impl Iterator<Item = i32>) -> Result<[u32; 2], LoweringError> {
+    let values = values.collect::<Vec<_>>();
+    if values.len() != 2 || values.iter().any(|value| *value <= 0) {
+        return Err(LoweringError::UnsupportedGraph);
+    }
+    Ok([
+        u32::try_from(values[0]).map_err(|_| LoweringError::UnsupportedGraph)?,
+        u32::try_from(values[1]).map_err(|_| LoweringError::UnsupportedGraph)?,
+    ])
+}
+
+fn serialized_fp16_is_zero(bytes: &[u8]) -> bool {
+    bytes.len() == 2 && u16::from_le_bytes(bytes.try_into().expect("length checked")) & 0x7fff == 0
+}
+
+fn constant_is_matmul_zero_point(analysis: &TosaAnalysis<'_>, value: ValueId) -> bool {
+    let mut consumed = false;
+    for operator in analysis.operators() {
+        for (index, input) in analysis.operator_inputs(operator.id()).iter().enumerate() {
+            if *input != value {
+                continue;
+            }
+            consumed = true;
+            if operator.op() != Op::MATMUL || !matches!(index, 2 | 3) {
+                return false;
+            }
+        }
+    }
+    consumed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use virtio_accel_conformance::numerics::{
+        IDENTITY_EDGES_FP16, IDENTITY_EDGES_FP32, IDENTITY_FP8E4M3, IDENTITY_FP8E5M2,
+        IDENTITY_INT4, IDENTITY_INT8, MATMUL_FP16, MAX_POOL2D_FP16,
+    };
+
+    #[test]
+    fn plans_the_complete_initial_fp16_corpus_without_qairt() {
+        let cases = [
+            ("identity", IDENTITY_EDGES_FP16.artifact, 1usize, 2usize),
+            ("matmul", MATMUL_FP16.artifact, 1, 3),
+            ("max_pool2d", MAX_POOL2D_FP16.artifact, 1, 2),
+        ];
+        for (name, artifact, nodes, features) in cases {
+            let lowered = lower_tosa(artifact, HEXAGON_TOSA_TARGET)
+                .unwrap_or_else(|error| panic!("{name} failed to lower: {error}"));
+            assert_eq!(lowered.nodes.len(), nodes, "{name}");
+            assert_eq!(lowered.features.len(), features, "{name}");
+            assert!(lowered.features.iter().all(|feature| feature.byte_len > 0));
+        }
+    }
+
+    #[test]
+    fn matmul_discards_only_validated_zero_point_parameters() {
+        let lowered = lower_tosa(MATMUL_FP16.artifact, HEXAGON_TOSA_TARGET).unwrap();
+        assert!(matches!(
+            lowered.nodes.as_slice(),
+            [LoweredNode::MatMul { .. }]
+        ));
+        assert_eq!(lowered.features[0].slot, 0);
+        assert_eq!(lowered.features[1].slot, 1);
+        assert_eq!(lowered.features[2].slot, 2);
+        assert_eq!(lowered.features[2].role, FeatureRole::Output);
+    }
+
+    #[test]
+    fn max_pool_keeps_nhwc_shapes_and_attributes() {
+        let lowered = lower_tosa(MAX_POOL2D_FP16.artifact, HEXAGON_TOSA_TARGET).unwrap();
+        assert!(matches!(
+            lowered.nodes.as_slice(),
+            [LoweredNode::MaxPool2d {
+                kernel: [2, 2],
+                stride: [2, 2],
+                ..
+            }]
+        ));
+        assert_eq!(lowered.features[0].dims.len(), 4);
+        assert_eq!(lowered.features[1].dims.len(), 4);
+    }
+
+    #[test]
+    fn rejects_fp32_until_htp_precision_is_proven() {
+        assert_eq!(
+            lower_tosa(IDENTITY_EDGES_FP32.artifact, HEXAGON_TOSA_TARGET).unwrap_err(),
+            LoweringError::UnsupportedType(DType::FP32)
+        );
+    }
+
+    #[test]
+    fn rejects_unadvertised_low_precision_profiles_and_extensions() {
+        for (case, target) in [
+            (
+                IDENTITY_INT8,
+                Target::new(
+                    Version::TOSA_1_0,
+                    ProfileSet::INTEGER,
+                    Level::Level8K,
+                    ExtensionSet::NONE,
+                ),
+            ),
+            (
+                IDENTITY_INT4,
+                Target::new(
+                    Version::TOSA_1_0,
+                    ProfileSet::INTEGER,
+                    Level::Level8K,
+                    ExtensionSet::INT4,
+                ),
+            ),
+            (
+                IDENTITY_FP8E4M3,
+                Target::new(
+                    Version::TOSA_1_0,
+                    ProfileSet::FLOATING_POINT,
+                    Level::Level8K,
+                    ExtensionSet::FP8E4M3,
+                ),
+            ),
+            (
+                IDENTITY_FP8E5M2,
+                Target::new(
+                    Version::TOSA_1_0,
+                    ProfileSet::FLOATING_POINT,
+                    Level::Level8K,
+                    ExtensionSet::FP8E5M2,
+                ),
+            ),
+        ] {
+            assert_eq!(
+                lower_tosa(case.artifact, target).unwrap_err(),
+                LoweringError::UnsupportedGraph,
+                "{}",
+                case.name
+            );
+        }
+    }
+
+    #[test]
+    fn advertised_operator_and_dtype_surface_is_exact() {
+        for op in [Op::IDENTITY, Op::MATMUL, Op::MAX_POOL2D] {
+            assert!(supports_tosa_operator(op));
+        }
+        assert!(!supports_tosa_operator(Op::ADD));
+        assert!(supports_tosa_dtype(DType::FP16));
+        for dtype in [
+            DType::FP32,
+            DType::INT8,
+            DType::INT4,
+            DType::FP8E4M3,
+            DType::FP8E5M2,
+        ] {
+            assert!(!supports_tosa_dtype(dtype), "{dtype:?}");
+        }
+    }
+}

--- a/crates/virtio-accel-hexagon/src/native.rs
+++ b/crates/virtio-accel-hexagon/src/native.rs
@@ -1,0 +1,23 @@
+//! Native QNN activation guard.
+//!
+//! QAIRT detection alone is not a support claim. Until the audited bridge is complete, even a host
+//! with the full SDK receives an explicit unavailable result rather than a CPU/GPU fallback or a
+//! partially initialized HTP backend.
+
+#![forbid(unsafe_code)]
+
+use crate::{InitError, ffi};
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct HexagonAccelerator;
+
+impl HexagonAccelerator {
+    pub fn new() -> Result<Self, InitError> {
+        debug_assert!(!ffi::NATIVE_BRIDGE_IMPLEMENTED);
+        Err(InitError::RuntimeUnavailable)
+    }
+
+    pub fn available_devices() -> Result<Vec<String>, InitError> {
+        Err(InitError::RuntimeUnavailable)
+    }
+}

--- a/crates/virtio-accel-hexagon/src/native.rs
+++ b/crates/virtio-accel-hexagon/src/native.rs
@@ -711,17 +711,22 @@ impl Accelerator for HexagonAccelerator {
             .tensors
             .iter()
             .map(|tensor| {
-                let role = lowered
-                    .features
-                    .iter()
-                    .find(|feature| feature.value == tensor.value)
-                    .map_or(ffi::TENSOR_NATIVE, |feature| match feature.role {
-                        FeatureRole::Input => ffi::TENSOR_INPUT,
-                        FeatureRole::Output => ffi::TENSOR_OUTPUT,
-                    });
+                let (role, io_index) = lowered.boundary(tensor.value).map_or(
+                    (ffi::TENSOR_NATIVE, ffi::NO_IO_INDEX),
+                    |(feature_role, io_index)| {
+                        (
+                            match feature_role {
+                                FeatureRole::Input => ffi::TENSOR_INPUT,
+                                FeatureRole::Output => ffi::TENSOR_OUTPUT,
+                            },
+                            io_index,
+                        )
+                    },
+                );
                 ffi::TensorDesc {
                     value: tensor.value,
                     role,
+                    io_index,
                     dimensions: tensor.dims.as_ptr(),
                     rank: tensor.dims.len() as u32,
                 }

--- a/crates/virtio-accel-hexagon/src/native.rs
+++ b/crates/virtio-accel-hexagon/src/native.rs
@@ -1,23 +1,962 @@
-//! Native QNN activation guard.
-//!
-//! QAIRT detection alone is not a support claim. Until the audited bridge is complete, even a host
-//! with the full SDK receives an explicit unavailable result rather than a CPU/GPU fallback or a
-//! partially initialized HTP backend.
+//! Native QNN HTP backend compiled against the detected QAIRT headers.
 
-#![forbid(unsafe_code)]
+use crate::ffi;
+use crate::lower::{FeatureRole, LoweredNode, lower_tosa};
+use crate::{InitError, REQUIRED_RESIDENT_BYTES};
+use std::alloc::{Layout, alloc_zeroed, dealloc};
+use std::cell::{Cell, RefCell};
+use std::ffi::{CStr, CString};
+use std::marker::PhantomData;
+use std::path::Path;
+use std::ptr::{self, NonNull};
+use std::rc::Rc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+use virtio_accel_core::{
+    Accelerator, AcceleratorClass, AccessMode, AllocatedBuffer, ArtifactRef, BackendError,
+    BindingRef, BufferDesc, BufferInfo, BufferProperties, BufferUsage, ByteSink, ByteSource,
+    Capabilities, ContextDesc, DeviceIdentity, DeviceInfo, DeviceLimits, EventState, MemoryDomain,
+    QueueDesc, ReleaseFailure, SubmitFailure, Timeout,
+};
 
-use crate::{InitError, ffi};
+const QNN_EXTERNAL_DOMAIN: u32 = 0x0051_4e4e;
+const MAX_TOSA_ARTIFACT_BYTES: u64 = 256 * 1024 * 1024;
+const MIN_ALIGNMENT: usize = 4096;
+const TRANSFER_CHUNK_BYTES: usize = 64 * 1024;
+const EXCLUSIVE_NATIVE_ACCESS: u64 = u64::MAX;
+const MAX_SHARED_NATIVE_USERS: u64 = u64::MAX - 1;
+const MESSAGE_BYTES: usize = 512;
 
-#[derive(Clone, Copy, Debug, Default)]
-pub struct HexagonAccelerator;
+fn status_error(status: u64) -> BackendError {
+    match status {
+        ffi::ERROR_INCOMPATIBLE => BackendError::Incompatible,
+        ffi::ERROR_BUSY => BackendError::Busy,
+        ffi::ERROR_INVALID_ARGUMENT => BackendError::InvalidArgument,
+        ffi::ERROR_OUT_OF_MEMORY => BackendError::OutOfMemory,
+        ffi::ERROR_INTERNAL => BackendError::DeviceLost,
+        other => BackendError::External {
+            domain: QNN_EXTERNAL_DOMAIN,
+            code: other as i64,
+        },
+    }
+}
+
+fn check_status(status: u64) -> Result<(), BackendError> {
+    if status == ffi::SUCCESS {
+        Ok(())
+    } else {
+        Err(status_error(status))
+    }
+}
+
+fn c_array(array: &[core::ffi::c_char]) -> String {
+    // SAFETY: bridge-owned fixed arrays are always initialized and explicitly NUL-terminated.
+    unsafe { CStr::from_ptr(array.as_ptr()) }
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn qnn_library_path() -> Result<CString, InitError> {
+    let root = Path::new(env!("VIRTIO_ACCEL_QNN_SDK_ROOT"));
+    let path = root.join("lib/aarch64-windows-msvc/QnnHtp.dll");
+    CString::new(path.to_string_lossy().as_bytes()).map_err(|_| InitError::RuntimeUnavailable)
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct QnnRuntimeInfo {
+    pub provider_name: String,
+    pub build_id: String,
+    pub core_version: [u32; 3],
+    pub backend_version: [u32; 3],
+}
+
+struct RuntimeHandle {
+    raw: NonNull<ffi::Runtime>,
+    info: QnnRuntimeInfo,
+}
+
+impl RuntimeHandle {
+    fn new() -> Result<Self, InitError> {
+        let library = qnn_library_path()?;
+        let mut raw = ptr::null_mut();
+        let mut native_info = ffi::RuntimeInfo::default();
+        let mut message = [0; MESSAGE_BYTES];
+        // SAFETY: every pointer is valid for this synchronous call. The bridge copies the DLL
+        // path and initializes either a complete owned runtime or a null output.
+        let status = unsafe {
+            ffi::va_qnn_runtime_create(
+                library.as_ptr(),
+                &mut raw,
+                &mut native_info,
+                message.as_mut_ptr(),
+                message.len(),
+            )
+        };
+        if status != ffi::SUCCESS {
+            return Err(if status == ffi::ERROR_INCOMPATIBLE {
+                InitError::IncompatibleRuntime
+            } else {
+                InitError::DeviceUnavailable
+            });
+        }
+        let raw = NonNull::new(raw).ok_or(InitError::DeviceUnavailable)?;
+        Ok(Self {
+            raw,
+            info: QnnRuntimeInfo {
+                provider_name: c_array(&native_info.provider_name),
+                build_id: c_array(&native_info.build_id),
+                core_version: [
+                    native_info.core_major,
+                    native_info.core_minor,
+                    native_info.core_patch,
+                ],
+                backend_version: [
+                    native_info.backend_major,
+                    native_info.backend_minor,
+                    native_info.backend_patch,
+                ],
+            },
+        })
+    }
+}
+
+impl Drop for RuntimeHandle {
+    fn drop(&mut self) {
+        // SAFETY: this value owns the runtime and is the final Rc owner. Child graph/event values
+        // retain their own Rc, so none can still reference the native runtime here.
+        let status = unsafe { ffi::va_qnn_runtime_free(self.raw.as_ptr()) };
+        debug_assert_eq!(status, ffi::SUCCESS);
+    }
+}
+
+struct GraphHandle {
+    raw: Cell<Option<NonNull<ffi::Graph>>>,
+    _runtime: Rc<RuntimeHandle>,
+}
+
+impl GraphHandle {
+    fn release(&self) -> Result<(), BackendError> {
+        let Some(raw) = self.raw.get() else {
+            return Ok(());
+        };
+        // SAFETY: raw is one live bridge graph owned by this value. A successful call consumes it.
+        let status = unsafe { ffi::va_qnn_graph_free(raw.as_ptr()) };
+        check_status(status)?;
+        self.raw.set(None);
+        Ok(())
+    }
+}
+
+impl Drop for GraphHandle {
+    fn drop(&mut self) {
+        if let Some(raw) = self.raw.get() {
+            // SAFETY: best-effort cleanup of the graph owned by this value. A busy result leaks the
+            // native graph rather than freeing descriptors that an execution may still use.
+            let _ = unsafe { ffi::va_qnn_graph_free(raw.as_ptr()) };
+        }
+    }
+}
+
+#[derive(Debug)]
+struct AlignedAllocation {
+    pointer: NonNull<u8>,
+    layout: Layout,
+    in_flight: AtomicU64,
+}
+
+impl AlignedAllocation {
+    fn new(bytes: u64, requested_alignment: u64) -> Result<Self, BackendError> {
+        let bytes = usize::try_from(bytes).map_err(|_| BackendError::OutOfMemory)?;
+        let requested_alignment =
+            usize::try_from(requested_alignment).map_err(|_| BackendError::OutOfMemory)?;
+        let alignment = requested_alignment.max(MIN_ALIGNMENT);
+        let allocation_bytes = bytes
+            .checked_add(alignment - 1)
+            .map(|value| value & !(alignment - 1))
+            .ok_or(BackendError::OutOfMemory)?;
+        let layout = Layout::from_size_align(allocation_bytes, alignment)
+            .map_err(|_| BackendError::OutOfMemory)?;
+        // SAFETY: layout is valid and nonzero; Drop uses the identical layout exactly once.
+        let pointer =
+            NonNull::new(unsafe { alloc_zeroed(layout) }).ok_or(BackendError::OutOfMemory)?;
+        Ok(Self {
+            pointer,
+            layout,
+            in_flight: AtomicU64::new(0),
+        })
+    }
+
+    fn pointer_at(&self, offset: usize) -> *mut u8 {
+        // SAFETY: callers validate offset and range against the logical allocation first.
+        unsafe { self.pointer.as_ptr().add(offset) }
+    }
+}
+
+impl Drop for AlignedAllocation {
+    fn drop(&mut self) {
+        // SAFETY: pointer came from alloc_zeroed with this exact layout and has not been freed.
+        unsafe { dealloc(self.pointer.as_ptr(), self.layout) };
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum BackingAccess {
+    Shared,
+    Exclusive,
+}
+
+impl BackingAccess {
+    const fn for_binding(access: AccessMode) -> Self {
+        match access {
+            AccessMode::Read => Self::Shared,
+            AccessMode::Write | AccessMode::ReadWrite => Self::Exclusive,
+        }
+    }
+
+    const fn combine(self, other: Self) -> Self {
+        if matches!(self, Self::Exclusive) || matches!(other, Self::Exclusive) {
+            Self::Exclusive
+        } else {
+            Self::Shared
+        }
+    }
+}
+
+#[derive(Debug)]
+struct EventBacking {
+    key: usize,
+    allocation: Rc<AlignedAllocation>,
+    access: BackingAccess,
+    acquired: bool,
+}
+
+impl EventBacking {
+    fn new(allocation: Rc<AlignedAllocation>, access: AccessMode) -> Self {
+        Self {
+            key: Rc::as_ptr(&allocation) as usize,
+            allocation,
+            access: BackingAccess::for_binding(access),
+            acquired: false,
+        }
+    }
+
+    fn acquire(&mut self) -> Result<(), BackendError> {
+        match self.access {
+            BackingAccess::Shared => {
+                self.allocation
+                    .in_flight
+                    .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+                        (current < MAX_SHARED_NATIVE_USERS).then_some(current + 1)
+                    })
+                    .map_err(|_| BackendError::Busy)?;
+            }
+            BackingAccess::Exclusive => {
+                self.allocation
+                    .in_flight
+                    .compare_exchange(
+                        0,
+                        EXCLUSIVE_NATIVE_ACCESS,
+                        Ordering::AcqRel,
+                        Ordering::Acquire,
+                    )
+                    .map_err(|_| BackendError::Busy)?;
+            }
+        }
+        self.acquired = true;
+        Ok(())
+    }
+}
+
+impl Drop for EventBacking {
+    fn drop(&mut self) {
+        if !self.acquired {
+            return;
+        }
+        match self.access {
+            BackingAccess::Shared => {
+                let prior = self.allocation.in_flight.fetch_sub(1, Ordering::Release);
+                debug_assert!((1..=MAX_SHARED_NATIVE_USERS).contains(&prior));
+            }
+            BackingAccess::Exclusive => {
+                let result = self.allocation.in_flight.compare_exchange(
+                    EXCLUSIVE_NATIVE_ACCESS,
+                    0,
+                    Ordering::Release,
+                    Ordering::Relaxed,
+                );
+                debug_assert_eq!(result, Ok(EXCLUSIVE_NATIVE_ACCESS));
+            }
+        }
+    }
+}
+
+fn prepare_event_backings(backings: &mut Vec<EventBacking>) -> Result<(), BackendError> {
+    backings.sort_unstable_by_key(|backing| backing.key);
+    backings.dedup_by(|current, previous| {
+        if current.key != previous.key {
+            return false;
+        }
+        previous.access = previous.access.combine(current.access);
+        true
+    });
+    for backing in backings {
+        backing.acquire()?;
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy, Debug)]
+struct SlotPlan {
+    slot: u32,
+    role: FeatureRole,
+    io_index: usize,
+    byte_len: u64,
+}
+
+#[derive(Debug)]
+pub struct HexagonContext {
+    id: u64,
+}
+
+#[derive(Debug)]
+pub struct HexagonBuffer {
+    context_id: u64,
+    desc: BufferDesc,
+    allocation: Rc<AlignedAllocation>,
+    _not_send_sync: PhantomData<Rc<()>>,
+}
+
+pub struct HexagonProgram {
+    context_id: u64,
+    graph: Rc<GraphHandle>,
+    slots: Vec<SlotPlan>,
+    _not_send_sync: PhantomData<Rc<()>>,
+}
+
+impl std::fmt::Debug for HexagonProgram {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("HexagonProgram")
+            .field("context_id", &self.context_id)
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Debug)]
+pub struct HexagonQueue {
+    context_id: u64,
+}
+
+pub struct HexagonEvent {
+    raw: Cell<Option<NonNull<ffi::Event>>>,
+    backings: RefCell<Vec<EventBacking>>,
+    latched: Cell<Option<EventState>>,
+    _graph: Rc<GraphHandle>,
+    _not_send_sync: PhantomData<Rc<()>>,
+}
+
+impl std::fmt::Debug for HexagonEvent {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("HexagonEvent")
+            .field("latched", &self.latched.get())
+            .finish_non_exhaustive()
+    }
+}
+
+impl HexagonEvent {
+    fn poll_native(&self) -> EventState {
+        if let Some(state) = self.latched.get() {
+            return state;
+        }
+        let Some(raw) = self.raw.get() else {
+            return EventState::Failed(BackendError::DeviceLost);
+        };
+        let mut error = ffi::SUCCESS;
+        // SAFETY: raw stays owned by this event until terminal release.
+        let state = unsafe { ffi::va_qnn_event_poll(raw.as_ptr(), &mut error) };
+        let terminal = match state {
+            ffi::EVENT_PENDING => return EventState::Pending,
+            ffi::EVENT_COMPLETE => EventState::Complete,
+            ffi::EVENT_FAILED => EventState::Failed(status_error(error)),
+            _ => EventState::Failed(BackendError::DeviceLost),
+        };
+        self.backings.borrow_mut().clear();
+        self.latched.set(Some(terminal));
+        terminal
+    }
+
+    fn release_native(&self) -> Result<(), BackendError> {
+        let Some(raw) = self.raw.get() else {
+            return Ok(());
+        };
+        // SAFETY: terminal-state checks happen in the bridge and success consumes the event.
+        check_status(unsafe { ffi::va_qnn_event_free(raw.as_ptr()) })?;
+        self.raw.set(None);
+        Ok(())
+    }
+}
+
+impl Drop for HexagonEvent {
+    fn drop(&mut self) {
+        while self.poll_native() == EventState::Pending {
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        let _ = self.release_native();
+    }
+}
+
+pub struct HexagonAccelerator {
+    runtime: Rc<RuntimeHandle>,
+    next_id: AtomicU64,
+    info: DeviceInfo,
+    _not_send_sync: PhantomData<Rc<()>>,
+}
+
+impl std::fmt::Debug for HexagonAccelerator {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("HexagonAccelerator")
+            .field("runtime", &self.runtime.info)
+            .finish_non_exhaustive()
+    }
+}
 
 impl HexagonAccelerator {
     pub fn new() -> Result<Self, InitError> {
-        debug_assert!(!ffi::NATIVE_BRIDGE_IMPLEMENTED);
-        Err(InitError::RuntimeUnavailable)
+        let runtime = Rc::new(RuntimeHandle::new()?);
+        Ok(Self {
+            runtime,
+            next_id: AtomicU64::new(0),
+            info: DeviceInfo {
+                identity: DeviceIdentity {
+                    uuid: *b"qualcomm-htp-v73",
+                    class: AcceleratorClass::NPU,
+                    vendor_id: 0x17cb,
+                    device_id: 73,
+                },
+                capabilities: Capabilities::HOST_VISIBLE_MEMORY | Capabilities::SHARED_MEMORY,
+                limits: DeviceLimits {
+                    max_contexts: 64,
+                    max_buffers_per_context: 1_024,
+                    max_programs_per_context: 64,
+                    max_queues_per_context: 64,
+                    max_events_per_context: 1,
+                    max_bindings_per_submission: 256,
+                    max_buffer_bytes: u64::from(u32::MAX),
+                    max_artifact_bytes: MAX_TOSA_ARTIFACT_BYTES,
+                },
+            },
+            _not_send_sync: PhantomData,
+        })
     }
 
     pub fn available_devices() -> Result<Vec<String>, InitError> {
-        Err(InitError::RuntimeUnavailable)
+        let runtime = RuntimeHandle::new()?;
+        Ok(vec![format!(
+            "QNN HTP {} (core {}.{}.{}, backend {}.{}.{})",
+            runtime.info.provider_name,
+            runtime.info.core_version[0],
+            runtime.info.core_version[1],
+            runtime.info.core_version[2],
+            runtime.info.backend_version[0],
+            runtime.info.backend_version[1],
+            runtime.info.backend_version[2]
+        )])
+    }
+
+    pub fn runtime_info(&self) -> &QnnRuntimeInfo {
+        &self.runtime.info
+    }
+
+    fn next_id(&self) -> Result<u64, BackendError> {
+        self.next_id
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |value| {
+                value.checked_add(1)
+            })
+            .map(|value| value + 1)
+            .map_err(|_| BackendError::ResourceLimit)
+    }
+
+    fn checked_range(
+        buffer: &HexagonBuffer,
+        offset: u64,
+        bytes: u64,
+    ) -> Result<(usize, usize), BackendError> {
+        let end = offset
+            .checked_add(bytes)
+            .filter(|end| *end <= buffer.desc.bytes())
+            .ok_or(BackendError::OutOfBounds)?;
+        Ok((
+            usize::try_from(offset).map_err(|_| BackendError::OutOfBounds)?,
+            usize::try_from(end).map_err(|_| BackendError::OutOfBounds)?,
+        ))
+    }
+
+    fn lowering_error(error: crate::LoweringError) -> BackendError {
+        match error {
+            crate::LoweringError::Parse(_) | crate::LoweringError::Analysis(_) => {
+                BackendError::InvalidArgument
+            }
+            crate::LoweringError::ResourceLimit => BackendError::ResourceLimit,
+            crate::LoweringError::UnsupportedGraph
+            | crate::LoweringError::UnsupportedType(_)
+            | crate::LoweringError::UnsupportedOperator(_)
+            | crate::LoweringError::InvalidConstant => BackendError::Unsupported,
+        }
+    }
+}
+
+impl Accelerator for HexagonAccelerator {
+    type Context = HexagonContext;
+    type Buffer = HexagonBuffer;
+    type Program = HexagonProgram;
+    type Queue = HexagonQueue;
+    type Event = HexagonEvent;
+
+    fn device_info(&self) -> Result<DeviceInfo, BackendError> {
+        Ok(self.info)
+    }
+
+    fn create_context(&self, desc: ContextDesc) -> Result<Self::Context, BackendError> {
+        self.info.validate_context_desc(desc)?;
+        Ok(HexagonContext {
+            id: self.next_id()?,
+        })
+    }
+
+    fn destroy_context(
+        &self,
+        _context: Self::Context,
+    ) -> Result<(), ReleaseFailure<Self::Context>> {
+        Ok(())
+    }
+
+    fn allocate_buffer(
+        &self,
+        context: &Self::Context,
+        desc: BufferDesc,
+    ) -> Result<AllocatedBuffer<Self::Buffer>, BackendError> {
+        self.info.validate_buffer_desc(desc)?;
+        if desc.domain == MemoryDomain::Device {
+            return Err(BackendError::Unsupported);
+        }
+        let allocation = Rc::new(AlignedAllocation::new(desc.bytes(), desc.alignment())?);
+        let properties = BufferProperties::HOST_VISIBLE
+            | if desc.is_program_visible() || desc.domain == MemoryDomain::Shared {
+                BufferProperties::DIRECT_BINDING
+            } else {
+                BufferProperties::empty()
+            };
+        let info = BufferInfo::new(
+            desc,
+            allocation.layout.size() as u64,
+            allocation.layout.align() as u64,
+            properties,
+        )?;
+        Ok(AllocatedBuffer::new(
+            HexagonBuffer {
+                context_id: context.id,
+                desc,
+                allocation,
+                _not_send_sync: PhantomData,
+            },
+            info,
+        ))
+    }
+
+    fn write_buffer(
+        &self,
+        buffer: &mut Self::Buffer,
+        offset: u64,
+        data: &dyn ByteSource,
+    ) -> Result<(), BackendError> {
+        if !buffer
+            .desc
+            .usage
+            .contains(BufferUsage::TRANSFER_DESTINATION)
+        {
+            return Err(BackendError::PermissionDenied);
+        }
+        if buffer.allocation.in_flight.load(Ordering::Acquire) != 0 {
+            return Err(BackendError::Busy);
+        }
+        let (start, end) = Self::checked_range(buffer, offset, data.len())?;
+        let length = end - start;
+        if let Some(source) = data.as_contiguous() {
+            if source.len() != length {
+                return Err(BackendError::InvalidArgument);
+            }
+            // SAFETY: the exclusive buffer borrow and in-flight gate protect the validated range.
+            unsafe {
+                ptr::copy_nonoverlapping(
+                    source.as_ptr(),
+                    buffer.allocation.pointer_at(start),
+                    length,
+                )
+            };
+            return Ok(());
+        }
+        let mut scratch = [0; TRANSFER_CHUNK_BYTES];
+        let mut copied = 0;
+        while copied < length {
+            let chunk = (length - copied).min(scratch.as_slice().len());
+            data.read_at(copied as u64, &mut scratch[..chunk])?;
+            // SAFETY: each chunk remains inside the validated exclusive range.
+            unsafe {
+                ptr::copy_nonoverlapping(
+                    scratch.as_ptr(),
+                    buffer.allocation.pointer_at(start + copied),
+                    chunk,
+                )
+            };
+            copied += chunk;
+        }
+        Ok(())
+    }
+
+    fn read_buffer(
+        &self,
+        buffer: &Self::Buffer,
+        offset: u64,
+        data: &mut dyn ByteSink,
+    ) -> Result<(), BackendError> {
+        if !buffer.desc.usage.contains(BufferUsage::TRANSFER_SOURCE) {
+            return Err(BackendError::PermissionDenied);
+        }
+        if buffer.allocation.in_flight.load(Ordering::Acquire) != 0 {
+            return Err(BackendError::Busy);
+        }
+        let (start, end) = Self::checked_range(buffer, offset, data.len())?;
+        let length = end - start;
+        if let Some(target) = data.as_contiguous_mut() {
+            if target.len() != length {
+                return Err(BackendError::InvalidArgument);
+            }
+            // SAFETY: the in-flight gate proves no QNN execution can mutate this range.
+            unsafe {
+                ptr::copy_nonoverlapping(
+                    buffer.allocation.pointer_at(start),
+                    target.as_mut_ptr(),
+                    length,
+                )
+            };
+            return Ok(());
+        }
+        let mut scratch = [0; TRANSFER_CHUNK_BYTES];
+        let mut copied = 0;
+        while copied < length {
+            let chunk = (length - copied).min(scratch.as_slice().len());
+            // SAFETY: each chunk remains inside the validated source range.
+            unsafe {
+                ptr::copy_nonoverlapping(
+                    buffer.allocation.pointer_at(start + copied),
+                    scratch.as_mut_ptr(),
+                    chunk,
+                )
+            };
+            data.write_at(copied as u64, &scratch[..chunk])?;
+            copied += chunk;
+        }
+        Ok(())
+    }
+
+    fn free_buffer(&self, _buffer: Self::Buffer) -> Result<(), ReleaseFailure<Self::Buffer>> {
+        Ok(())
+    }
+
+    fn load_program(
+        &self,
+        context: &Self::Context,
+        artifact: ArtifactRef<'_>,
+    ) -> Result<Self::Program, BackendError> {
+        if artifact.payload.len() > self.info.limits.max_artifact_bytes {
+            return Err(BackendError::ResourceLimit);
+        }
+        if artifact.resident_bytes != REQUIRED_RESIDENT_BYTES {
+            return Err(BackendError::ResourceLimit);
+        }
+        if artifact.format != virtio_accel_tosa::ARTIFACT_FORMAT {
+            return Err(BackendError::Unsupported);
+        }
+        let target = virtio_accel_tosa::Target::from_identity(artifact.target)
+            .map_err(|_| BackendError::Incompatible)?;
+        let mut owned = Vec::new();
+        let bytes = match artifact.payload.as_contiguous() {
+            Some(bytes) => bytes,
+            None => {
+                let len = usize::try_from(artifact.payload.len())
+                    .map_err(|_| BackendError::ResourceLimit)?;
+                owned
+                    .try_reserve_exact(len)
+                    .map_err(|_| BackendError::OutOfMemory)?;
+                owned.resize(len, 0);
+                artifact.payload.read_at(0, &mut owned)?;
+                &owned
+            }
+        };
+        let lowered = lower_tosa(bytes, target).map_err(Self::lowering_error)?;
+
+        let slots = lowered
+            .features
+            .iter()
+            .map(|feature| SlotPlan {
+                slot: feature.slot,
+                role: feature.role,
+                io_index: feature.io_index as usize,
+                byte_len: feature.byte_len,
+            })
+            .collect::<Vec<_>>();
+        let tensor_descriptions = lowered
+            .tensors
+            .iter()
+            .map(|tensor| {
+                let role = lowered
+                    .features
+                    .iter()
+                    .find(|feature| feature.value == tensor.value)
+                    .map_or(ffi::TENSOR_NATIVE, |feature| match feature.role {
+                        FeatureRole::Input => ffi::TENSOR_INPUT,
+                        FeatureRole::Output => ffi::TENSOR_OUTPUT,
+                    });
+                ffi::TensorDesc {
+                    value: tensor.value,
+                    role,
+                    dimensions: tensor.dims.as_ptr(),
+                    rank: tensor.dims.len() as u32,
+                }
+            })
+            .collect::<Vec<_>>();
+        let node_descriptions = lowered
+            .nodes
+            .iter()
+            .map(|node| match node {
+                LoweredNode::Identity { input, output } => ffi::NodeDesc {
+                    kind: ffi::NODE_RESHAPE,
+                    input0: *input,
+                    output: *output,
+                    ..ffi::NodeDesc::default()
+                },
+                LoweredNode::MatMul {
+                    left,
+                    right,
+                    output,
+                } => ffi::NodeDesc {
+                    kind: ffi::NODE_MATMUL,
+                    input0: *left,
+                    input1: *right,
+                    output: *output,
+                    ..ffi::NodeDesc::default()
+                },
+                LoweredNode::MaxPool2d {
+                    input,
+                    output,
+                    kernel,
+                    stride,
+                } => ffi::NodeDesc {
+                    kind: ffi::NODE_MAX_POOL_2D,
+                    input0: *input,
+                    output: *output,
+                    kernel: *kernel,
+                    stride: *stride,
+                    ..ffi::NodeDesc::default()
+                },
+            })
+            .collect::<Vec<_>>();
+        let mut graph = ptr::null_mut();
+        let mut message = [0; MESSAGE_BYTES];
+        // SAFETY: descriptor slices and their dimension storage remain live for the synchronous
+        // call; the bridge copies and retains its own descriptors before returning.
+        check_status(unsafe {
+            ffi::va_qnn_graph_create(
+                self.runtime.raw.as_ptr(),
+                tensor_descriptions.as_ptr(),
+                tensor_descriptions.len() as u32,
+                node_descriptions.as_ptr(),
+                node_descriptions.len() as u32,
+                &mut graph,
+                message.as_mut_ptr(),
+                message.len(),
+            )
+        })?;
+        let graph = NonNull::new(graph).ok_or(BackendError::DeviceLost)?;
+        Ok(HexagonProgram {
+            context_id: context.id,
+            graph: Rc::new(GraphHandle {
+                raw: Cell::new(Some(graph)),
+                _runtime: Rc::clone(&self.runtime),
+            }),
+            slots,
+            _not_send_sync: PhantomData,
+        })
+    }
+
+    fn unload_program(&self, program: Self::Program) -> Result<(), ReleaseFailure<Self::Program>> {
+        if Rc::strong_count(&program.graph) != 1 {
+            return Err(ReleaseFailure::Rejected {
+                error: BackendError::Busy,
+                resource: program,
+            });
+        }
+        match program.graph.release() {
+            Ok(()) => Ok(()),
+            Err(BackendError::Busy) => Err(ReleaseFailure::Rejected {
+                error: BackendError::Busy,
+                resource: program,
+            }),
+            Err(error) => Err(ReleaseFailure::Indeterminate { error }),
+        }
+    }
+
+    fn create_queue(
+        &self,
+        context: &Self::Context,
+        desc: QueueDesc,
+    ) -> Result<Self::Queue, BackendError> {
+        self.info.validate_queue_desc(desc)?;
+        Ok(HexagonQueue {
+            context_id: context.id,
+        })
+    }
+
+    fn destroy_queue(&self, _queue: Self::Queue) -> Result<(), ReleaseFailure<Self::Queue>> {
+        Ok(())
+    }
+
+    fn submit(
+        &self,
+        queue: &Self::Queue,
+        program: &Self::Program,
+        bindings: &[BindingRef<'_, Self::Buffer>],
+        timeout: Timeout,
+    ) -> Result<Self::Event, SubmitFailure<Self::Event>> {
+        if !matches!(timeout, Timeout::Infinite) {
+            return Err(SubmitFailure::Rejected(BackendError::Unsupported));
+        }
+        if queue.context_id != program.context_id {
+            return Err(SubmitFailure::Rejected(BackendError::InvalidArgument));
+        }
+        if bindings.len() != program.slots.len()
+            || bindings.len() > self.info.limits.max_bindings_per_submission as usize
+        {
+            return Err(SubmitFailure::Rejected(BackendError::Incompatible));
+        }
+        let mut pointers = vec![ptr::null_mut(); program.slots.len()];
+        let mut backings = Vec::with_capacity(bindings.len());
+        let mut seen = vec![false; program.slots.len()];
+        for binding in bindings {
+            if binding.buffer.context_id != queue.context_id {
+                return Err(SubmitFailure::Rejected(BackendError::InvalidArgument));
+            }
+            if !binding.buffer.desc.allows_access(binding.access) {
+                return Err(SubmitFailure::Rejected(BackendError::PermissionDenied));
+            }
+            let index = program
+                .slots
+                .binary_search_by_key(&binding.slot, |slot| slot.slot)
+                .map_err(|_| SubmitFailure::Rejected(BackendError::Incompatible))?;
+            if seen[index] {
+                return Err(SubmitFailure::Rejected(BackendError::InvalidArgument));
+            }
+            seen[index] = true;
+            let plan = program.slots[index];
+            let expected_access = match plan.role {
+                FeatureRole::Input => AccessMode::Read,
+                FeatureRole::Output => AccessMode::Write,
+            };
+            if binding.access != expected_access || binding.range.bytes() != plan.byte_len {
+                return Err(SubmitFailure::Rejected(BackendError::Incompatible));
+            }
+            let (start, _) =
+                Self::checked_range(binding.buffer, binding.range.offset, binding.range.bytes())
+                    .map_err(SubmitFailure::Rejected)?;
+            pointers[index] = binding.buffer.allocation.pointer_at(start).cast();
+            backings.push(EventBacking::new(
+                Rc::clone(&binding.buffer.allocation),
+                binding.access,
+            ));
+        }
+        prepare_event_backings(&mut backings).map_err(SubmitFailure::Rejected)?;
+
+        let input_count = program
+            .slots
+            .iter()
+            .filter(|slot| slot.role == FeatureRole::Input)
+            .count();
+        let output_count = program.slots.len() - input_count;
+        let mut inputs = vec![
+            ffi::Binding {
+                data: ptr::null_mut(),
+                size: 0,
+            };
+            input_count
+        ];
+        let mut outputs = vec![
+            ffi::Binding {
+                data: ptr::null_mut(),
+                size: 0,
+            };
+            output_count
+        ];
+        for (index, plan) in program.slots.iter().enumerate() {
+            let binding = ffi::Binding {
+                data: pointers[index],
+                size: plan.byte_len,
+            };
+            match plan.role {
+                FeatureRole::Input => inputs[plan.io_index] = binding,
+                FeatureRole::Output => outputs[plan.io_index] = binding,
+            }
+        }
+        let Some(graph) = program.graph.raw.get() else {
+            return Err(SubmitFailure::Rejected(BackendError::InvalidArgument));
+        };
+        let mut event = ptr::null_mut();
+        let mut message = [0; MESSAGE_BYTES];
+        // SAFETY: the graph is live; bindings point into guarded allocations retained by the Rust
+        // event. The bridge copies descriptors and owns them until its worker reaches completion.
+        let status = unsafe {
+            ffi::va_qnn_graph_execute_async(
+                graph.as_ptr(),
+                inputs.as_ptr(),
+                inputs.len() as u32,
+                outputs.as_ptr(),
+                outputs.len() as u32,
+                &mut event,
+                message.as_mut_ptr(),
+                message.len(),
+            )
+        };
+        check_status(status).map_err(SubmitFailure::Rejected)?;
+        let event =
+            NonNull::new(event).ok_or_else(|| SubmitFailure::Rejected(BackendError::DeviceLost))?;
+        Ok(HexagonEvent {
+            raw: Cell::new(Some(event)),
+            backings: RefCell::new(backings),
+            latched: Cell::new(None),
+            _graph: Rc::clone(&program.graph),
+            _not_send_sync: PhantomData,
+        })
+    }
+
+    fn poll_event(&self, event: &Self::Event) -> Result<EventState, BackendError> {
+        Ok(event.poll_native())
+    }
+
+    fn destroy_event(&self, event: Self::Event) -> Result<(), ReleaseFailure<Self::Event>> {
+        if event.poll_native() == EventState::Pending {
+            return Err(ReleaseFailure::Rejected {
+                error: BackendError::Busy,
+                resource: event,
+            });
+        }
+        match event.release_native() {
+            Ok(()) => Ok(()),
+            Err(BackendError::Busy) => Err(ReleaseFailure::Rejected {
+                error: BackendError::Busy,
+                resource: event,
+            }),
+            Err(error) => Err(ReleaseFailure::Indeterminate { error }),
+        }
     }
 }

--- a/crates/virtio-accel-hexagon/tests/hexagon.rs
+++ b/crates/virtio-accel-hexagon/tests/hexagon.rs
@@ -1,0 +1,238 @@
+#![cfg(va_hexagon)]
+
+use std::time::{Duration, Instant};
+use virtio_accel_conformance::numerics::{
+    IDENTITY_EDGES_FP16, MATMUL_FP16, MAX_POOL2D_FP16, TosaFloat16Case,
+};
+use virtio_accel_core::{
+    Accelerator, AccessMode, BackendError, BindingRef, BufferDesc, BufferRange, BufferUsage,
+    ByteSink, ByteSource, ContextDesc, EventState, MemoryDomain, QueueDesc, ReleaseFailure,
+    SubmitFailure, Timeout,
+};
+use virtio_accel_hexagon::{HEXAGON_TOSA_TARGET, HexagonAccelerator, REQUIRED_RESIDENT_BYTES};
+use virtio_accel_tosa::parse;
+
+#[derive(Debug)]
+struct SliceSource<'a>(&'a [u8]);
+
+impl ByteSource for SliceSource<'_> {
+    fn len(&self) -> u64 {
+        self.0.len() as u64
+    }
+
+    fn read_at(&self, offset: u64, target: &mut [u8]) -> Result<(), BackendError> {
+        ByteSource::read_at(self.0, offset, target)
+    }
+
+    fn as_contiguous(&self) -> Option<&[u8]> {
+        Some(self.0)
+    }
+}
+
+#[derive(Debug)]
+struct SliceSink<'a>(&'a mut [u8]);
+
+impl ByteSink for SliceSink<'_> {
+    fn len(&self) -> u64 {
+        self.0.len() as u64
+    }
+
+    fn write_at(&mut self, offset: u64, source: &[u8]) -> Result<(), BackendError> {
+        ByteSink::write_at(self.0, offset, source)
+    }
+
+    fn as_contiguous_mut(&mut self) -> Option<&mut [u8]> {
+        Some(self.0)
+    }
+}
+
+fn fp16_bytes(values: &[u16]) -> Vec<u8> {
+    values
+        .iter()
+        .flat_map(|value| value.to_le_bytes())
+        .collect()
+}
+
+fn run_case(case: TosaFloat16Case) {
+    let backend = HexagonAccelerator::new().expect("initialize QNN HTP");
+    let context = backend
+        .create_context(ContextDesc::default())
+        .expect("create context");
+    let model = parse(case.artifact).expect("parse corpus TOSA");
+    let program = backend
+        .load_program(
+            &context,
+            model
+                .artifact_ref(HEXAGON_TOSA_TARGET, REQUIRED_RESIDENT_BYTES)
+                .expect("artifact envelope"),
+        )
+        .expect("finalize corpus graph on HTP");
+
+    let input_bytes = case
+        .inputs
+        .iter()
+        .map(|input| fp16_bytes(input.bits))
+        .collect::<Vec<_>>();
+    let mut inputs = Vec::with_capacity(input_bytes.len());
+    for bytes in &input_bytes {
+        let (mut buffer, _) = backend
+            .allocate_buffer(
+                &context,
+                BufferDesc::new(
+                    bytes.len() as u64,
+                    4096,
+                    MemoryDomain::Shared,
+                    BufferUsage::TRANSFER_DESTINATION | BufferUsage::PROGRAM_INPUT,
+                )
+                .expect("input descriptor"),
+            )
+            .expect("allocate input")
+            .into_parts();
+        backend
+            .write_buffer(&mut buffer, 0, &SliceSource(bytes))
+            .expect("write input");
+        inputs.push(buffer);
+    }
+    let output_len = case.outputs[0].bits.len() * 2;
+    let (output, _) = backend
+        .allocate_buffer(
+            &context,
+            BufferDesc::new(
+                output_len as u64,
+                4096,
+                MemoryDomain::Shared,
+                BufferUsage::TRANSFER_SOURCE | BufferUsage::PROGRAM_OUTPUT,
+            )
+            .expect("output descriptor"),
+        )
+        .expect("allocate output")
+        .into_parts();
+    let queue = backend
+        .create_queue(&context, QueueDesc::default())
+        .expect("create queue");
+    let mut bindings = inputs
+        .iter()
+        .enumerate()
+        .map(|(slot, buffer)| BindingRef {
+            slot: slot as u32,
+            buffer,
+            range: BufferRange::new(0, input_bytes[slot].len() as u64).expect("input range"),
+            access: AccessMode::Read,
+        })
+        .collect::<Vec<_>>();
+    bindings.push(BindingRef {
+        slot: inputs.len() as u32,
+        buffer: &output,
+        range: BufferRange::new(0, output_len as u64).expect("output range"),
+        access: AccessMode::Write,
+    });
+
+    let output_binding = bindings.len() - 1;
+    bindings[output_binding].access = AccessMode::Read;
+    assert!(matches!(
+        backend.submit(&queue, &program, &bindings, Timeout::Infinite),
+        Err(SubmitFailure::Rejected(BackendError::PermissionDenied))
+    ));
+    bindings[output_binding].access = AccessMode::Write;
+    bindings[output_binding].range =
+        BufferRange::new(0, output_len as u64 - 2).expect("short output range");
+    assert!(matches!(
+        backend.submit(&queue, &program, &bindings, Timeout::Infinite),
+        Err(SubmitFailure::Rejected(BackendError::Incompatible))
+    ));
+    bindings[output_binding].range = BufferRange::new(0, output_len as u64).expect("output range");
+    bindings[output_binding].slot = 0;
+    assert!(matches!(
+        backend.submit(&queue, &program, &bindings, Timeout::Infinite),
+        Err(SubmitFailure::Rejected(BackendError::InvalidArgument))
+    ));
+    bindings[output_binding].slot = inputs.len() as u32;
+    assert!(matches!(
+        backend.submit(&queue, &program, &bindings, Timeout::from_wire_ns(1)),
+        Err(SubmitFailure::Rejected(BackendError::Unsupported))
+    ));
+    let event = backend
+        .submit(&queue, &program, &bindings, Timeout::Infinite)
+        .unwrap_or_else(|failure| match failure {
+            SubmitFailure::Rejected(error) => panic!("{} rejected: {error:?}", case.name),
+            SubmitFailure::Indeterminate { error, .. } => {
+                panic!("{} indeterminate: {error:?}", case.name)
+            }
+        });
+    let deadline = Instant::now() + Duration::from_secs(15);
+    loop {
+        match backend.poll_event(&event).expect("poll event") {
+            EventState::Pending if Instant::now() < deadline => std::thread::yield_now(),
+            EventState::Pending => panic!("{} timed out", case.name),
+            EventState::Complete => break,
+            terminal => panic!("{} failed: {terminal:?}", case.name),
+        }
+    }
+    assert_eq!(
+        backend
+            .poll_event(&event)
+            .expect("poll stable terminal event"),
+        EventState::Complete
+    );
+    let mut output_bytes = vec![0; output_len];
+    backend
+        .read_buffer(&output, 0, &mut SliceSink(&mut output_bytes))
+        .expect("read output while the terminal event remains live");
+    let actual = output_bytes
+        .chunks_exact(2)
+        .map(|bytes| u16::from_le_bytes([bytes[0], bytes[1]]))
+        .collect::<Vec<_>>();
+    assert!(
+        case.output_matches(0, &actual),
+        "{} oracle mismatch",
+        case.name
+    );
+
+    let program = match backend.unload_program(program) {
+        Err(ReleaseFailure::Rejected {
+            error: BackendError::Busy,
+            resource,
+        }) => resource,
+        result => panic!("program release with a live event returned {result:?}"),
+    };
+    backend
+        .destroy_event(event)
+        .expect("destroy terminal event");
+    backend.destroy_queue(queue).expect("destroy queue");
+    backend
+        .unload_program(program)
+        .expect("unload released program");
+    backend.free_buffer(output).expect("free output");
+    for input in inputs {
+        backend.free_buffer(input).expect("free input");
+    }
+    backend.destroy_context(context).expect("destroy context");
+}
+
+#[test]
+fn reports_the_pinned_qnn_htp_runtime() {
+    let backend = HexagonAccelerator::new().expect("initialize QNN HTP");
+    assert_eq!(backend.runtime_info().core_version, [2, 38, 0]);
+    assert_eq!(backend.runtime_info().backend_version, [5, 49, 0]);
+    assert!(backend.runtime_info().provider_name.contains("HTP"));
+    backend
+        .device_info()
+        .expect("device info")
+        .validate()
+        .unwrap();
+}
+
+#[test]
+fn executes_fp16_identity_on_htp() {
+    run_case(IDENTITY_EDGES_FP16);
+}
+
+#[test]
+fn executes_batched_non_square_fp16_matmul_on_htp() {
+    run_case(MATMUL_FP16);
+}
+
+#[test]
+fn executes_nhwc_fp16_max_pool_on_htp() {
+    run_case(MAX_POOL2D_FP16);
+}

--- a/crates/virtio-accel-hexagon/tests/hexagon.rs
+++ b/crates/virtio-accel-hexagon/tests/hexagon.rs
@@ -2,7 +2,7 @@
 
 use std::time::{Duration, Instant};
 use virtio_accel_conformance::numerics::{
-    IDENTITY_EDGES_FP16, MATMUL_FP16, MAX_POOL2D_FP16, TosaFloat16Case,
+    IDENTITY_EDGES_FP16, MATMUL_FP16, MAX_POOL2D_FP16, MOCK_LINEAR_CLASSIFIER_FP16, TosaFloat16Case,
 };
 use virtio_accel_core::{
     Accelerator, AccessMode, BackendError, BindingRef, BufferDesc, BufferRange, BufferUsage,
@@ -230,6 +230,11 @@ fn executes_fp16_identity_on_htp() {
 #[test]
 fn executes_batched_non_square_fp16_matmul_on_htp() {
     run_case(MATMUL_FP16);
+}
+
+#[test]
+fn executes_mock_linear_classifier_on_htp() {
+    run_case(MOCK_LINEAR_CLASSIFIER_FP16);
 }
 
 #[test]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -349,13 +349,12 @@ enumerated device and reports the direct-binding and explicit-transfer counters 
 conformance diagnostics hook. This keeps the Core ML and Intel paths on one bounded TOSA contract
 without requiring either provider to adopt the other's native graph representation.
 
-The Qualcomm adapter uses the same seam but is not yet a production lowering boundary. Its safe,
-SDK-free planner admits only static FP16 identity, MATMUL, and NHWC MAX_POOL2D graphs, owns the
-resulting tensor/slot/operation metadata, and rejects FP32 or low-precision tiers before native
-work. The root support matrix remains `Planned` until a complete QAIRT/QNN C development package is
-available to implement and audit direct HTP graph construction, exact caller-buffer binding,
-worker-backed completion, and hardware conformance. Driver-only and AppBuilder/Genie installations
-are intentionally insufficient to enable that boundary.
+The Qualcomm adapter uses the same seam. Its safe planner admits only static FP16 identity, MATMUL,
+and NHWC MAX_POOL2D graphs, owns the resulting tensor/slot/operation metadata, and rejects FP32 or
+low-precision tiers before native work. With a complete QAIRT/QNN C development package on Windows
+ARM64, its audited boundary creates and finalizes QNN HTP graphs, binds exact caller buffers, and
+publishes completion from a bounded worker. Driver-only and AppBuilder/Genie installations are
+intentionally insufficient to enable that boundary.
 
 The portable command engine depends on `virtio-accel-proto`, `virtio-accel-core`, and the
 transport-neutral region metadata re-exported by `virtio-accel-device`. Its baseline processor:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -349,6 +349,14 @@ enumerated device and reports the direct-binding and explicit-transfer counters 
 conformance diagnostics hook. This keeps the Core ML and Intel paths on one bounded TOSA contract
 without requiring either provider to adopt the other's native graph representation.
 
+The Qualcomm adapter uses the same seam but is not yet a production lowering boundary. Its safe,
+SDK-free planner admits only static FP16 identity, MATMUL, and NHWC MAX_POOL2D graphs, owns the
+resulting tensor/slot/operation metadata, and rejects FP32 or low-precision tiers before native
+work. The root support matrix remains `Planned` until a complete QAIRT/QNN C development package is
+available to implement and audit direct HTP graph construction, exact caller-buffer binding,
+worker-backed completion, and hardware conformance. Driver-only and AppBuilder/Genie installations
+are intentionally insufficient to enable that boundary.
+
 The portable command engine depends on `virtio-accel-proto`, `virtio-accel-core`, and the
 transport-neutral region metadata re-exported by `virtio-accel-device`. Its baseline processor:
 

--- a/docs/backend-implementer-guide.md
+++ b/docs/backend-implementer-guide.md
@@ -209,6 +209,11 @@ submit, poll, transfer, and teardown sequence against the mock backend. On macOS
 `cargo run -p virtio-accel-coreml --example tosa_coreml` for the production artifact path from a
 device-neutral TOSA graph through Core ML execution and the same backend lifecycle.
 
+`cargo run -p virtio-accel-hexagon --example tosa_hexagon` currently exercises only the explicit
+unavailable-runtime surface. Its safe FP16 TOSA planner is useful as an admission example, but it is
+not a backend-conformance example until the QNN HTP lifecycle and direct-binding diagnostics are
+implemented.
+
 ## Common traps
 
 - Advertising a capability because a slow fallback exists, while the fallback violates direct

--- a/docs/backend-implementer-guide.md
+++ b/docs/backend-implementer-guide.md
@@ -209,10 +209,9 @@ submit, poll, transfer, and teardown sequence against the mock backend. On macOS
 `cargo run -p virtio-accel-coreml --example tosa_coreml` for the production artifact path from a
 device-neutral TOSA graph through Core ML execution and the same backend lifecycle.
 
-`cargo run -p virtio-accel-hexagon --example tosa_hexagon` currently exercises only the explicit
-unavailable-runtime surface. Its safe FP16 TOSA planner is useful as an admission example, but it is
-not a backend-conformance example until the QNN HTP lifecycle and direct-binding diagnostics are
-implemented.
+`cargo run -p virtio-accel-hexagon --example tosa_hexagon` exercises the QNN HTP lifecycle and
+direct bindings on a configured Windows ARM64 QAIRT host. Without that build environment, it retains
+the explicit unavailable-runtime surface.
 
 ## Common traps
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -154,8 +154,8 @@ destruction.
 
 ## Qualcomm Hexagon evidence status
 
-`virtio-accel-hexagon` has no native performance claim yet. Its SDK-free tests prove deterministic
-FP16 graph planning and exact binding byte counts only. Admission latency, QNN descriptor reuse,
-provider staging counters, and submit-to-complete timing must not be recorded as Hexagon evidence
-until the audited HTP path runs on the pinned Snapdragon/QAIRT/driver combination and passes the
-semantic and numerical suites.
+`virtio-accel-hexagon` makes no throughput or latency claim yet. The pinned Snapdragon/QAIRT/driver
+tests prove HTP execution and exact FP16 numerical results for identity, MATMUL, and MAX_POOL2D, but
+do not yet provide a statistically controlled performance run. Any future admission or
+submit-to-complete measurements must record the provider build, driver, power mode, graph, warmup,
+and sample distribution.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -151,3 +151,11 @@ Wall-clock results must be recorded on a pinned OpenVINO runtime and identified 
 timing claim is made; the deterministic regression tests instead pin capacity reuse, pointer
 scrubbing, guard release at terminal observation, and tensor-metadata release after request
 destruction.
+
+## Qualcomm Hexagon evidence status
+
+`virtio-accel-hexagon` has no native performance claim yet. Its SDK-free tests prove deterministic
+FP16 graph planning and exact binding byte counts only. Admission latency, QNN descriptor reuse,
+provider staging counters, and submit-to-complete timing must not be recorded as Hexagon evidence
+until the audited HTP path runs on the pinned Snapdragon/QAIRT/driver combination and passes the
+semantic and numerical suites.

--- a/docs/plans/issue-77-qualcomm-hexagon.md
+++ b/docs/plans/issue-77-qualcomm-hexagon.md
@@ -29,9 +29,10 @@ Completed on this branch:
 - Lowered identity with QNN Reshape and MATMUL with QNN MatMul. The documented native PoolMax2d
   tensor-parameter path fails finalization on this Windows HTP runtime, so zero-padded MAX_POOL2D is
   lowered to HTP Gather and ElementWiseMaximum nodes without a CPU/GPU fallback.
-- Added seven SDK-free tests and four hardware tests. The hardware suite validates runtime/device
-  identity, every advertised FP16 numerical oracle, stable terminal polling, timeout rejection,
-  live-event graph retention, and ordered teardown.
+- Added seven SDK-free tests and five hardware tests, including a two-sample FP16 linear classifier
+  with direct-bound learned weights. The hardware suite validates runtime/device identity, every
+  advertised FP16 numerical oracle, stable terminal polling, timeout rejection, live-event graph
+  retention, and ordered teardown.
 - Integrated the fourteenth package into workspace metadata, CI examples, release policy,
   publication order, portability/architecture/API/performance docs, and an experimental root
   support-matrix row limited to the pinned evidence.

--- a/docs/plans/issue-77-qualcomm-hexagon.md
+++ b/docs/plans/issue-77-qualcomm-hexagon.md
@@ -1,0 +1,339 @@
+# Issue #77 plan: Qualcomm Hexagon NPU backend
+
+Status: proposed implementation plan
+
+Issue: [#77 — Build the Qualcomm Hexagon NPU backend](https://github.com/MicroPerceptron/virtio-accel/issues/77)
+
+Planning branch: `codex/issue-77-qualcomm-hexagon-plan`
+
+Last reviewed: 2026-08-17
+
+## Outcome
+
+Add a separately packaged `virtio-accel-hexagon` host-native crate that implements
+`virtio_accel_core::Accelerator` over the Qualcomm Hexagon NPU. The first supported path will
+execute a deliberately small, static TOSA 1.0 subset on a Snapdragon NPU, keep Qualcomm types and
+unsafe code inside the adapter crate, and compile as an unavailable-runtime placeholder everywhere
+else.
+
+Completion means that the backend passes the mandatory semantic conformance suite, passes every
+numerical corpus case it advertises, binds caller-owned provider allocations without a
+submission-time provider bounce buffer, and has reproducible hardware evidence on the selected
+Snapdragon device and runtime.
+
+## Initial technical decisions
+
+1. **Runtime:** use the public Qualcomm AI Runtime SDK (QAIRT), specifically the QNN C API with the
+   HTP backend (`QnnHtp`), rather than SNPE, ONNX Runtime, or a framework delegate. QNN is the
+   lowest public graph/runtime boundary intended to target the Hexagon NPU directly.
+2. **First host/device tier:** target Windows 11 on ARM64 and Snapdragon X Series first. Add Android,
+   Qualcomm Linux, and other Snapdragon/Dragonwing families only as later runtime adapters after
+   the first tier is conformant. Record the exact SoC, Windows build, NPU driver, QAIRT release,
+   QNN API version, and HTP library set used by the hardware lane.
+3. **Artifact path:** accept TOSA bytes at the portable boundary, validate and analyze them with
+   `virtio-accel-tosa`, then construct and finalize a QNN graph inside `load_program`. Do not add an
+   ONNX/TFLite intermediate or invoke compilation from `submit`.
+4. **Execution target:** load only the HTP backend and report only `AcceleratorClass::NPU`. Do not
+   load QNN CPU or GPU backends as fallback paths.
+5. **Precision:** advertise only cases demonstrated to preserve TOSA semantics on the chosen HTP.
+   FP16 is the likely first floating-point tier. Reject FP32 during admission unless the selected
+   SDK/device can prove FP32 computation without relaxed or forced FP16 math. Never relabel FP16 as
+   FP32.
+6. **Scheduling:** start with one bounded, serialized worker lane per detected device. `submit`
+   validates and enqueues; the worker performs native dispatch/wait; `poll_event` only reads a
+   latched state and never blocks or drives QNN.
+7. **Buffers:** allocate stable, aligned, provider-owned host memory once, bind its exact range to
+   QNN tensors, and retain it through terminal event release. Explicit reads and writes are the only
+   provider copy boundaries. Runtime-internal transfers are recorded as a platform property, not
+   disguised as provider zero-copy.
+8. **Version policy:** pin one QAIRT/driver combination for hardware evidence. At initialization,
+   validate the QNN provider/API version and required capabilities. A new QAIRT minor or driver
+   becomes supported only after conformance and numerical regression runs; an untested ABI or
+   missing symbol produces `RuntimeUnavailable`/`Unsupported`, not best-effort execution.
+
+These choices follow Qualcomm's public description of QNN as the low-level, accelerator-specific
+API within QAIRT and its documented HTP path for Snapdragon NPUs:
+
+- [Qualcomm AI Engine Direct SDK](https://www.qualcomm.com/developer/software/qualcomm-ai-engine-direct-sdk)
+- [Qualcomm AI Engine Direct/QNN documentation](https://docs.qualcomm.com/bundle/publicresource/topics/80-63442-10/index_QNN.html?product=1601111740009302)
+- [QAIRT and QNN terminology](https://dev.aihub.qualcomm.com/docs/)
+- [Windows on Snapdragon AI](https://www.qualcomm.com/developer/windows-on-snapdragon/windows-on-snapdragon-ai)
+
+## Phase 0: prove the hard constraints
+
+Do this spike before building the full `Accelerator` implementation. Check the spike into the
+backend's tests/examples or record its reproducible source and results; do not leave it as an
+unreviewable local experiment.
+
+- [ ] Install one redistributable QAIRT release on a Snapdragon X test system and inventory the
+      headers, import libraries/DLLs, HTP support libraries, device driver, API version, and license
+      constraints. Do not check vendor binaries or headers into this repository unless their license
+      explicitly permits it.
+- [ ] Use only QNN's HTP backend to create/finalize/execute a minimal identity graph. Confirm from
+      runtime logs/profiling that no node is placed on CPU or GPU.
+- [ ] Bind inputs and outputs directly from stable provider allocations. Record pointer/range and
+      memory-registration behavior before and after execution. Prove that the adapter creates no
+      temporary input/output tensor storage during submission.
+- [ ] Exercise repeated and overlapping submissions to determine QNN graph/context thread-safety,
+      whether execution must be serialized, and when QNN stops retaining tensor descriptors,
+      client-buffer pointers, signals, and graph/context handles.
+- [ ] Determine whether the selected API offers an honest cancellation primitive. If cancellation
+      cannot be bounded and race-safe, leave `EVENT_CANCELLATION` unadvertised.
+- [ ] Run the FP16 and FP32 identity fixtures and inspect the chosen QAIRT release notes/configuration
+      for relaxed or forced FP16 computation. Advertise FP32 only if edge-value tests prove its
+      semantics. Recent QAIRT notes about HTP floating-point behavior make this a release gate, not
+      an assumption.
+- [ ] Verify native support for the exact initial MATMUL and NHWC MAX_POOL2D shapes/attributes. A
+      failing case narrows the advertised target; it is not silently skipped or rerouted.
+- [ ] Measure the largest supported tensor/rank/alignment and any graph/context/queue limits that can
+      be reported honestly through `DeviceLimits`.
+
+Exit gate: a single HTP-only identity runs from a caller-owned provider allocation with stable
+teardown, the precision claim is known, and the SDK redistribution/build strategy is acceptable.
+If exact binding cannot be implemented with the public QNN API on this platform, stop and document
+the blocked acceptance criterion before expanding the backend.
+
+## Phase 1: scaffold a portable host-native crate
+
+- [ ] Add `crates/virtio-accel-hexagon` with `Cargo.toml`, `README.md`, `SAFETY.md`, dual license
+      files, `build.rs`, `src/lib.rs`, `src/ffi.rs`, `src/native.rs`, `src/lower.rs`, tests, and a
+      `tosa_hexagon` example.
+- [ ] Add the crate to workspace members and centralize `virtio-accel-core`,
+      `virtio-accel-tosa`, and test-only `virtio-accel-conformance` dependencies like the existing
+      host backends.
+- [ ] Make `build.rs` probe the QAIRT/QNN include and library roots and verify the required QNN API
+      headers/libraries. Support explicit controls such as `VIRTIO_ACCEL_HEXAGON=0|1`,
+      `VIRTIO_ACCEL_QNN_SDK_ROOT`, and platform-specific library search overrides.
+- [ ] Emit a private `va_hexagon` cfg only when all required build-time pieces exist. Forced-on mode
+      must fail loudly; autodetect mode must compile the placeholder when dependencies are absent.
+- [ ] Keep portable lowering/admission unit tests available without QAIRT. Under
+      `not(va_hexagon)`, forbid unsafe code and expose constructors that consistently return
+      `InitError::RuntimeUnavailable`.
+- [ ] Confirm `cargo check`, `cargo test`, rustdoc, and clippy pass on x86_64 Linux, x86_64 Windows,
+      macOS, and other normal CI hosts with no Qualcomm installation.
+
+## Phase 2: confine and audit the QNN boundary
+
+- [ ] Hand-bind only the QNN C ABI symbols required for backend/provider discovery, logging,
+      device/platform information, backend/context/graph/tensor lifecycle, execution, signals or
+      notification, memory registration if used, error reporting, and teardown.
+- [ ] Load the versioned QNN interface through its provider/interface discovery entry point and
+      validate major/minor compatibility before calling function pointers. Avoid binding internal
+      or sample-only APIs.
+- [ ] Wrap every native handle in one Rust owner with a documented destruction order. Model shared
+      process/device state explicitly with `Arc`/`OnceLock` only where QNN requires it; do not infer
+      that QNN globals are safely re-creatable.
+- [ ] Map QNN failures into stable `BackendError`, `SubmitFailure`, and `ReleaseFailure` outcomes.
+      Preserve the distinction between rejected work and work whose native acceptance is
+      indeterminate.
+- [ ] Write `SAFETY.md` alongside the FFI implementation. Cover ABI/version validation, function
+      pointer lifetime, handle ownership, callback/worker synchronization, tensor descriptor
+      lifetime, client-buffer lifetime and alignment, teardown order, thread-safety, and device-loss
+      poisoning. Give every unsafe block a local `SAFETY:` justification tied to those invariants.
+
+Exit gate: repeated initialization, discovery, and teardown return diagnostics to baseline under
+unit/hardware stress, and unsupported hosts still compile without enabling unsafe modules.
+
+## Phase 3: implement strict TOSA admission and QNN lowering
+
+- [ ] Define one `TargetIdentity` for the first proven HTP tier. Use a separate target identity for
+      any future precision/operator tier; capability expansion must not change an existing target's
+      meaning.
+- [ ] Reuse `virtio-accel-tosa` validation/analysis and require one static region/basic block,
+      positive static shapes, no runtime obligations, supported profile/extension declarations,
+      and an exact input/output slot order.
+- [ ] Implement an explicit lowering table for only the proven cases: identity first, then
+      non-square batched MATMUL, then NHWC MAX_POOL2D. Validate dtype, rank, layout, axes,
+      kernel/stride/padding, accumulator behavior, and output shape before any native graph calls.
+- [ ] Keep constants, QNN parameter objects, tensor names/descriptors, dimensions, and op configs
+      owned by the program builder until QNN's documented copy/retention point.
+- [ ] Construct and finalize the QNN graph in `load_program`; retain the finalized graph/context and
+      a sorted immutable binding plan in the program object. No graph building, shape inference,
+      compilation, or heap growth proportional to model structure may occur in `submit`.
+- [ ] Reject unsupported FP32, INT8, INT4, FP8, dynamic shapes, profiles, extensions, layouts, ops,
+      or attributes during admission with the repository's documented error classification.
+- [ ] Add hardware-free tests for malformed artifacts, unsupported combinations, binding plans,
+      QNN descriptor construction, overflow/limit checks, and deterministic lowering.
+
+Exit gate: every accepted artifact has one deterministic slot/shape/access plan and a finalized HTP
+graph; everything outside that target is rejected before execution.
+
+## Phase 4: implement the `Accelerator` object model
+
+Use the following ownership mapping:
+
+| `Accelerator` object | Hexagon/QNN representation |
+| --- | --- |
+| Backend | One validated QNN HTP provider/device plus a bounded serialized execution lane |
+| Context | Rust ownership/accounting scope backed by the minimum QNN context state required |
+| Buffer | One aligned provider allocation, registration/mapping metadata, and atomic shared/exclusive in-flight guard |
+| Program | Validated TOSA metadata, immutable slot plan, runtime identity, QNN context/graph, and retained native descriptors |
+| Queue | Bounded admission channel and reusable pointer/descriptor scratch owned by the serialized lane |
+| Event | Latched state plus owned program/buffer guards and native completion/error state until release |
+
+- [ ] Discover the HTP device and report stable Qualcomm vendor/product identity,
+      `AcceleratorClass::NPU`, truthful memory domains/alignment/limits, and only demonstrated
+      capabilities.
+- [ ] Implement contexts as ownership/quota scopes; avoid duplicating process-wide provider/device
+      state or scarce QNN resources per guest context without evidence that it is required.
+- [ ] Implement zero-initialized, fallibly allocated, aligned buffers with checked size/alignment and
+      exact retained byte ranges. If QNN memory registration is required, register once at buffer
+      creation and deregister exactly once after all event references are gone.
+- [ ] Implement explicit chunked `write_buffer`/`read_buffer`, including any documented cache
+      synchronization. Reject host transfers while an exclusive native writer is in flight.
+- [ ] Allow overlapping read-only bindings when QNN permits them; enforce one writer or read-write
+      user with `Busy` on conflicts. Validate ownership, access mode, range, alignment, slot,
+      dtype/shape byte size, and duplicate/conflicting bindings before native acceptance.
+- [ ] Bound contexts, buffers, programs, queues, queued submissions, events, and retained bytes.
+      Make all size/count arithmetic checked and surface exhaustion without partial mutation.
+
+Exit gate: the full object lifecycle works with the identity program and no resource, registration,
+or guard leak remains after success, error, explicit release, or backend discard.
+
+## Phase 5: asynchronous execution and failure semantics
+
+- [ ] Have `submit` complete validation and conflict reservation before enqueueing. Once native
+      acceptance may have occurred, retain an event and report indeterminate ownership when the
+      contract requires it.
+- [ ] Use a fixed-capacity channel/ring and one worker lane initially. The worker binds the exact
+      buffer ranges, dispatches the finalized graph, waits outside `submit`/`poll_event`, performs
+      required output synchronization, releases in-flight guards, and publishes one terminal state.
+- [ ] Make `poll_event` a wait-free/nonblocking read of a latched pending/success/error state. Stable
+      terminal polling must never call back into QNN.
+- [ ] Enforce finite timeouts honestly. Reject before admission when possible; after native
+      acceptance, keep ownership until terminal completion. Map a proven bounded cancellation API
+      to `DeadlineExpired`; otherwise document that the timeout cannot revoke native work and do not
+      advertise cancellation.
+- [ ] Poison the backend/device after unrecoverable HTP loss or a completion result that makes
+      resource ownership unknowable. New work fails until the complete backend is discarded.
+- [ ] Order terminal publication after all output visibility work and binding-guard release. Order
+      event teardown so QNN can no longer access descriptors or allocations before Rust releases
+      them.
+
+Exit gate: submissions are nonblocking, terminal states are stable, timeout/indeterminate paths
+preserve ownership, and fault injection cannot produce use-after-free or double release.
+
+## Phase 6: conformance and numerical evidence
+
+- [ ] Add backend-local integration tests modeled on `virtio-accel-openvino/tests/openvino.rs`, with
+      native execution gated by `va_hexagon` and runtime/device availability.
+- [ ] Run every mandatory `virtio-accel-conformance` case. Implement hooks for resource counts,
+      submission-path diagnostics, completion, and fault/device-loss behavior. Every conditional
+      skip must contain an explicit capability reason.
+- [ ] Prove exact provider binding by recording allocation identity/range at bind and dispatch time,
+      with `provider_staged_submissions == 0`. Test input/output offsets and incompatible ranges, not
+      only whole-buffer bindings.
+- [ ] Cover malformed and unsupported TOSA, duplicate/missing bindings, wrong access/shape/size,
+      read/read overlap, read/write conflict, host-transfer conflicts, bounded admission, finite
+      timeouts, stable terminal polling, device loss, rejected versus indeterminate submissions,
+      and all realizable release failures.
+- [ ] Run all advertised shared numerical fixtures on hardware and compare to their oracle,
+      including edge-value precision cases. An advertised dtype/operator pair must have no silent
+      skips.
+- [ ] Stress repeated load/unload, submit/complete/release, context destruction, and backend discard.
+      Assert QNN handles, registrations, events, allocations, and worker jobs return to baseline.
+- [ ] Add ignored release-mode measurements for admission latency, submit-to-complete latency,
+      retained resource high-water marks, and provider staging counts. Record hardware/runtime
+      identity with the results.
+
+Exit gate: mandatory semantic conformance passes; every advertised numerical case passes on the
+selected Snapdragon NPU; resource and direct-binding diagnostics return to baseline.
+
+## Phase 7: documentation, CI, and release integration
+
+- [ ] Add `tosa_hexagon` as a backend-local end-to-end example. Without QAIRT it must print a clear
+      unavailability message and exit successfully; on supported hardware it must execute on HTP and
+      verify its result.
+- [ ] Document SDK acquisition, licensing, environment variables, supported Snapdragon devices,
+      Windows/driver/QAIRT versions, HTP support-library deployment, runtime logging needed to prove
+      placement, build/test commands, target identity, precise operator/dtype boundary, and known
+      limitations in the crate README.
+- [ ] Update root `README.md`, `CONTRIBUTING.md`, `docs/architecture.md`, `docs/portability.md`,
+      `docs/performance.md`, `docs/public-api.md`, `docs/backend-implementer-guide.md`, the pull
+      request template, and CI examples. Change the Qualcomm support-table row from `Planned` only
+      for cases backed by hardware tests.
+- [ ] Update the release-policy crate count/order, `ci/check-release-policy.py` package and unsafe
+      exception allowlists, `ci/publication.py`, workspace metadata, lockfile, packaging tests, and
+      ordered local-registry dry run.
+- [ ] Add portable CI for format, clippy, unit tests, docs, placeholder builds, forced-off builds,
+      and package verification on hosts without QAIRT.
+- [ ] Add a hardware workflow only when a controlled Snapdragon runner exists. Pin its OS image,
+      NPU driver, QAIRT release, and SDK checksum; avoid storing licensed SDK payloads in the repo or
+      ordinary public CI artifacts.
+- [ ] Run the workspace release checks and document whether adding this adapter is a Cargo minor
+      with no protocol change. Do not modify the virtio wire ABI or portable `Accelerator` contract
+      solely for QNN.
+
+Exit gate: portable CI is green without Qualcomm dependencies, the pinned hardware lane is green or
+its exact manual replacement commands are published, packaging succeeds, and support claims match
+the evidence.
+
+## Expected file impact
+
+New paths:
+
+- `crates/virtio-accel-hexagon/**`
+- `docs/plans/issue-77-qualcomm-hexagon.md`
+
+Existing paths expected to change during implementation:
+
+- `Cargo.toml` and `Cargo.lock`
+- `README.md` and `CONTRIBUTING.md`
+- `.github/workflows/ci.yml` and `.github/PULL_REQUEST_TEMPLATE.md`
+- `ci/check-release-policy.py` and `ci/publication.py`
+- `docs/architecture.md`, `docs/backend-implementer-guide.md`, `docs/performance.md`,
+  `docs/portability.md`, `docs/public-api.md`, and `docs/release-policy.md`
+
+Portable protocol, guest, device, and transport crates should not need Qualcomm-specific changes.
+Any discovered need to change them is a design-review stop rather than routine scope.
+
+## Recommended implementation slices
+
+1. **Feasibility evidence:** HTP-only identity, exact buffer binding, precision result, runtime/license
+   inventory.
+2. **Portable scaffold:** crate, build probe, placeholder, lowering data structures and unit tests.
+3. **Native lifecycle:** audited FFI, discovery, contexts, allocations, transfers, graph load/release.
+4. **Execution semantics:** bounded worker, submission/event lifetime, conflicts, timeout/device-loss
+   behavior.
+5. **Coverage:** MATMUL/MAX_POOL2D lowerings, semantic conformance, numerical corpus, stress and
+   diagnostics.
+6. **Productization:** example, docs, CI/hardware evidence, performance notes, package/release policy.
+
+Each slice should leave unsupported capabilities unadvertised and keep workspace builds green on a
+host with no QAIRT installation.
+
+## Definition of done
+
+- [ ] A supported Snapdragon host enumerates an honest Qualcomm Hexagon NPU device and runs the
+      documented TOSA example through QNN HTP.
+- [ ] The complete workspace builds, lints, tests, documents, and packages without Qualcomm
+      dependencies.
+- [ ] Every mandatory semantic conformance case passes or has a contract-authorized, explicit
+      capability skip.
+- [ ] Every advertised TOSA operator/dtype case passes the shared numerical oracle on hardware.
+- [ ] Provider diagnostics prove direct caller-allocation binding with no submission-time provider
+      staging.
+- [ ] Timeout, stable polling, binding conflicts, device loss, rejected/indeterminate ownership,
+      and exact-once teardown are tested.
+- [ ] Unsafe QNN interaction is confined and audited in `SAFETY.md`.
+- [ ] Documentation and the root support matrix claim no more than the pinned evidence proves.
+- [ ] No Qualcomm API or type leaks into a portable crate, and protocol 1.0 bytes/semantics remain
+      unchanged.
+
+## Open questions to close during Phase 0
+
+- Which exact Snapdragon X SoC and test machine will be the baseline hardware runner?
+- Which QAIRT release and Windows NPU driver combination is redistributable and supportable for the
+  repository's public CI/release process?
+- Does that QNN HTP combination preserve FP32 semantics, or must the first target advertise FP16
+  only?
+- Which public QNN allocation/registration path gives stable caller-owned buffers on Windows ARM64,
+  and what alignment/cache rules apply?
+- At what calls does QNN copy versus retain graph configs, tensor descriptors, dimensions, names,
+  client buffers, and completion objects?
+- Can QNN cancel accepted HTP work with bounded race-safe semantics, or should the backend expose
+  timeout observation without cancellation?
+- Which MATMUL and MAX_POOL2D attributes/shapes compile on the baseline HTP without CPU/GPU
+  partitioning?
+- Is one process-wide backend/device/context required by the selected QNN release, or can contexts be
+  safely isolated without duplicating scarce hardware state?

--- a/docs/plans/issue-77-qualcomm-hexagon.md
+++ b/docs/plans/issue-77-qualcomm-hexagon.md
@@ -8,6 +8,37 @@ Planning branch: `codex/issue-77-qualcomm-hexagon-plan`
 
 Last reviewed: 2026-08-17
 
+## Implementation checkpoint (2026-08-17)
+
+Completed on this branch:
+
+- Confirmed the development host is Windows ARM64 on Snapdragon X126100 and that Windows has a
+  started Qualcomm Hexagon NPU (`ComputeAccelerator`, driver `30.0.222.0`).
+- Verified Qualcomm's public `qai-appbuilder` QAIRT 2.48.40 asset against its published SHA-256.
+  That asset contains Genie/AppBuilder components but no public `QnnInterface.h` or Windows ARM64
+  `QnnHtp` application import library; the build probe rejects it as incomplete.
+- Added and packaged `virtio-accel-hexagon`, including strict SDK detection, an honest
+  unavailable-runtime surface, an SDK-free example, license files, and the native safety gates.
+- Implemented deterministic, owned FP16 TOSA planning for identity, non-square batched MATMUL, and
+  NHWC MAX_POOL2D. FP32, INT8, INT4, FP8, unsupported targets, attributes, shapes, and operators are
+  rejected before native work.
+- Added seven backend-local tests covering the advertised planner surface and rejection boundary.
+- Integrated the fourteenth package into workspace metadata, CI examples, release policy,
+  publication order, portability/architecture/API/performance docs, and the root support matrix
+  without changing Qualcomm from `Planned`.
+- Passed formatting, release policy, workspace Clippy with warnings denied, full workspace tests,
+  warning-free rustdoc, standalone package verification, and the ordered 14-package local-registry
+  publication dry run.
+
+Blocked pending the full licensed QAIRT/QNN C development package:
+
+- The audited QNN interface/provider bindings, HTP device/context/graph lifecycle, exact client
+  buffers, worker-backed execution/events, fault/timeout semantics, semantic conformance, and
+  numerical hardware evidence cannot be implemented or validated safely from driver-private DLLs
+  or guessed ABI layouts.
+- Native support must remain unavailable and the README support row must remain `Planned` until
+  those requirements pass on the detected NPU.
+
 ## Outcome
 
 Add a separately packaged `virtio-accel-hexagon` host-native crate that implements

--- a/docs/plans/issue-77-qualcomm-hexagon.md
+++ b/docs/plans/issue-77-qualcomm-hexagon.md
@@ -1,6 +1,6 @@
 # Issue #77 plan: Qualcomm Hexagon NPU backend
 
-Status: proposed implementation plan
+Status: initial hardware tier implemented; broader conformance and hardware CI remain follow-up
 
 Issue: [#77 — Build the Qualcomm Hexagon NPU backend](https://github.com/MicroPerceptron/virtio-accel/issues/77)
 
@@ -14,30 +14,37 @@ Completed on this branch:
 
 - Confirmed the development host is Windows ARM64 on Snapdragon X126100 and that Windows has a
   started Qualcomm Hexagon NPU (`ComputeAccelerator`, driver `30.0.222.0`).
-- Verified Qualcomm's public `qai-appbuilder` QAIRT 2.48.40 asset against its published SHA-256.
-  That asset contains Genie/AppBuilder components but no public `QnnInterface.h` or Windows ARM64
-  `QnnHtp` application import library; the build probe rejects it as incomplete.
+- Installed the complete QAIRT `2.49.0.260730` Community SDK and validated its public QNN headers,
+  Windows ARM64 HTP library, provider build `v2.49.0.260730134355`, core API `2.38.0`, backend API
+  `5.49.0`, and v73 DSP support libraries.
 - Added and packaged `virtio-accel-hexagon`, including strict SDK detection, an honest
-  unavailable-runtime surface, an SDK-free example, license files, and the native safety gates.
+  unavailable-runtime surface, a hardware example, license files, and the audited native boundary.
 - Implemented deterministic, owned FP16 TOSA planning for identity, non-square batched MATMUL, and
   NHWC MAX_POOL2D. FP32, INT8, INT4, FP8, unsupported targets, attributes, shapes, and operators are
   rejected before native work.
-- Added seven backend-local tests covering the advertised planner surface and rejection boundary.
+- Implemented public QNN provider discovery and compatibility checks, HTP backend/device/context/
+  graph lifecycle, aligned direct client buffers, strict binding validation, a bounded one-request
+  worker, nonblocking stable event polling, busy release semantics, and explicit finite-timeout
+  rejection.
+- Lowered identity with QNN Reshape and MATMUL with QNN MatMul. The documented native PoolMax2d
+  tensor-parameter path fails finalization on this Windows HTP runtime, so zero-padded MAX_POOL2D is
+  lowered to HTP Gather and ElementWiseMaximum nodes without a CPU/GPU fallback.
+- Added seven SDK-free tests and four hardware tests. The hardware suite validates runtime/device
+  identity, every advertised FP16 numerical oracle, stable terminal polling, timeout rejection,
+  live-event graph retention, and ordered teardown.
 - Integrated the fourteenth package into workspace metadata, CI examples, release policy,
-  publication order, portability/architecture/API/performance docs, and the root support matrix
-  without changing Qualcomm from `Planned`.
-- Passed formatting, release policy, workspace Clippy with warnings denied, full workspace tests,
-  warning-free rustdoc, standalone package verification, and the ordered 14-package local-registry
-  publication dry run.
+  publication order, portability/architecture/API/performance docs, and an experimental root
+  support-matrix row limited to the pinned evidence.
+- Passed native and SDK-free Clippy with warnings denied, native and SDK-free crate tests, the HTP
+  example, formatting, and full SDK-free workspace Clippy/tests.
 
-Blocked pending the full licensed QAIRT/QNN C development package:
+Remaining follow-up beyond the initial issue tier:
 
-- The audited QNN interface/provider bindings, HTP device/context/graph lifecycle, exact client
-  buffers, worker-backed execution/events, fault/timeout semantics, semantic conformance, and
-  numerical hardware evidence cannot be implemented or validated safely from driver-private DLLs
-  or guessed ABI layouts.
-- Native support must remain unavailable and the README support row must remain `Planned` until
-  those requirements pass on the detected NPU.
+- Run the reusable backend semantic conformance harness with Hexagon-specific hooks, add controlled
+  device-loss/fault injection and repeated stress/resource accounting, and collect formal direct-
+  binding diagnostics in addition to the bridge's construction guarantee.
+- Add a controlled Windows ARM64 hardware CI runner, performance measurements, more operators and
+  precision tiers, and bounded cancellation only if a future validated QNN interface supports it.
 
 ## Outcome
 
@@ -96,11 +103,11 @@ Do this spike before building the full `Accelerator` implementation. Check the s
 backend's tests/examples or record its reproducible source and results; do not leave it as an
 unreviewable local experiment.
 
-- [ ] Install one redistributable QAIRT release on a Snapdragon X test system and inventory the
+- [x] Install one redistributable QAIRT release on a Snapdragon X test system and inventory the
       headers, import libraries/DLLs, HTP support libraries, device driver, API version, and license
       constraints. Do not check vendor binaries or headers into this repository unless their license
       explicitly permits it.
-- [ ] Use only QNN's HTP backend to create/finalize/execute a minimal identity graph. Confirm from
+- [x] Use only QNN's HTP backend to create/finalize/execute a minimal identity graph. Confirm from
       runtime logs/profiling that no node is placed on CPU or GPU.
 - [ ] Bind inputs and outputs directly from stable provider allocations. Record pointer/range and
       memory-registration behavior before and after execution. Prove that the adapter creates no
@@ -108,13 +115,13 @@ unreviewable local experiment.
 - [ ] Exercise repeated and overlapping submissions to determine QNN graph/context thread-safety,
       whether execution must be serialized, and when QNN stops retaining tensor descriptors,
       client-buffer pointers, signals, and graph/context handles.
-- [ ] Determine whether the selected API offers an honest cancellation primitive. If cancellation
+- [x] Determine whether the selected API offers an honest cancellation primitive. If cancellation
       cannot be bounded and race-safe, leave `EVENT_CANCELLATION` unadvertised.
 - [ ] Run the FP16 and FP32 identity fixtures and inspect the chosen QAIRT release notes/configuration
       for relaxed or forced FP16 computation. Advertise FP32 only if edge-value tests prove its
       semantics. Recent QAIRT notes about HTP floating-point behavior make this a release gate, not
       an assumption.
-- [ ] Verify native support for the exact initial MATMUL and NHWC MAX_POOL2D shapes/attributes. A
+- [x] Verify native support for the exact initial MATMUL and NHWC MAX_POOL2D shapes/attributes. A
       failing case narrows the advertised target; it is not silently skipped or rerouted.
 - [ ] Measure the largest supported tensor/rank/alignment and any graph/context/queue limits that can
       be reported honestly through `DeviceLimits`.
@@ -126,38 +133,38 @@ the blocked acceptance criterion before expanding the backend.
 
 ## Phase 1: scaffold a portable host-native crate
 
-- [ ] Add `crates/virtio-accel-hexagon` with `Cargo.toml`, `README.md`, `SAFETY.md`, dual license
+- [x] Add `crates/virtio-accel-hexagon` with `Cargo.toml`, `README.md`, `SAFETY.md`, dual license
       files, `build.rs`, `src/lib.rs`, `src/ffi.rs`, `src/native.rs`, `src/lower.rs`, tests, and a
       `tosa_hexagon` example.
-- [ ] Add the crate to workspace members and centralize `virtio-accel-core`,
+- [x] Add the crate to workspace members and centralize `virtio-accel-core`,
       `virtio-accel-tosa`, and test-only `virtio-accel-conformance` dependencies like the existing
       host backends.
-- [ ] Make `build.rs` probe the QAIRT/QNN include and library roots and verify the required QNN API
+- [x] Make `build.rs` probe the QAIRT/QNN include and library roots and verify the required QNN API
       headers/libraries. Support explicit controls such as `VIRTIO_ACCEL_HEXAGON=0|1`,
       `VIRTIO_ACCEL_QNN_SDK_ROOT`, and platform-specific library search overrides.
-- [ ] Emit a private `va_hexagon` cfg only when all required build-time pieces exist. Forced-on mode
+- [x] Emit a private `va_hexagon` cfg only when all required build-time pieces exist. Forced-on mode
       must fail loudly; autodetect mode must compile the placeholder when dependencies are absent.
-- [ ] Keep portable lowering/admission unit tests available without QAIRT. Under
+- [x] Keep portable lowering/admission unit tests available without QAIRT. Under
       `not(va_hexagon)`, forbid unsafe code and expose constructors that consistently return
       `InitError::RuntimeUnavailable`.
-- [ ] Confirm `cargo check`, `cargo test`, rustdoc, and clippy pass on x86_64 Linux, x86_64 Windows,
+- [x] Confirm `cargo check`, `cargo test`, rustdoc, and clippy pass on x86_64 Linux, x86_64 Windows,
       macOS, and other normal CI hosts with no Qualcomm installation.
 
 ## Phase 2: confine and audit the QNN boundary
 
-- [ ] Hand-bind only the QNN C ABI symbols required for backend/provider discovery, logging,
+- [x] Hand-bind only the QNN C ABI symbols required for backend/provider discovery, logging,
       device/platform information, backend/context/graph/tensor lifecycle, execution, signals or
       notification, memory registration if used, error reporting, and teardown.
-- [ ] Load the versioned QNN interface through its provider/interface discovery entry point and
+- [x] Load the versioned QNN interface through its provider/interface discovery entry point and
       validate major/minor compatibility before calling function pointers. Avoid binding internal
       or sample-only APIs.
-- [ ] Wrap every native handle in one Rust owner with a documented destruction order. Model shared
+- [x] Wrap every native handle in one Rust owner with a documented destruction order. Model shared
       process/device state explicitly with `Arc`/`OnceLock` only where QNN requires it; do not infer
       that QNN globals are safely re-creatable.
-- [ ] Map QNN failures into stable `BackendError`, `SubmitFailure`, and `ReleaseFailure` outcomes.
+- [x] Map QNN failures into stable `BackendError`, `SubmitFailure`, and `ReleaseFailure` outcomes.
       Preserve the distinction between rejected work and work whose native acceptance is
       indeterminate.
-- [ ] Write `SAFETY.md` alongside the FFI implementation. Cover ABI/version validation, function
+- [x] Write `SAFETY.md` alongside the FFI implementation. Cover ABI/version validation, function
       pointer lifetime, handle ownership, callback/worker synchronization, tensor descriptor
       lifetime, client-buffer lifetime and alignment, teardown order, thread-safety, and device-loss
       poisoning. Give every unsafe block a local `SAFETY:` justification tied to those invariants.
@@ -167,23 +174,23 @@ unit/hardware stress, and unsupported hosts still compile without enabling unsaf
 
 ## Phase 3: implement strict TOSA admission and QNN lowering
 
-- [ ] Define one `TargetIdentity` for the first proven HTP tier. Use a separate target identity for
+- [x] Define one `TargetIdentity` for the first proven HTP tier. Use a separate target identity for
       any future precision/operator tier; capability expansion must not change an existing target's
       meaning.
-- [ ] Reuse `virtio-accel-tosa` validation/analysis and require one static region/basic block,
+- [x] Reuse `virtio-accel-tosa` validation/analysis and require one static region/basic block,
       positive static shapes, no runtime obligations, supported profile/extension declarations,
       and an exact input/output slot order.
-- [ ] Implement an explicit lowering table for only the proven cases: identity first, then
+- [x] Implement an explicit lowering table for only the proven cases: identity first, then
       non-square batched MATMUL, then NHWC MAX_POOL2D. Validate dtype, rank, layout, axes,
       kernel/stride/padding, accumulator behavior, and output shape before any native graph calls.
-- [ ] Keep constants, QNN parameter objects, tensor names/descriptors, dimensions, and op configs
+- [x] Keep constants, QNN parameter objects, tensor names/descriptors, dimensions, and op configs
       owned by the program builder until QNN's documented copy/retention point.
-- [ ] Construct and finalize the QNN graph in `load_program`; retain the finalized graph/context and
+- [x] Construct and finalize the QNN graph in `load_program`; retain the finalized graph/context and
       a sorted immutable binding plan in the program object. No graph building, shape inference,
       compilation, or heap growth proportional to model structure may occur in `submit`.
-- [ ] Reject unsupported FP32, INT8, INT4, FP8, dynamic shapes, profiles, extensions, layouts, ops,
+- [x] Reject unsupported FP32, INT8, INT4, FP8, dynamic shapes, profiles, extensions, layouts, ops,
       or attributes during admission with the repository's documented error classification.
-- [ ] Add hardware-free tests for malformed artifacts, unsupported combinations, binding plans,
+- [x] Add hardware-free tests for malformed artifacts, unsupported combinations, binding plans,
       QNN descriptor construction, overflow/limit checks, and deterministic lowering.
 
 Exit gate: every accepted artifact has one deterministic slot/shape/access plan and a finalized HTP
@@ -202,17 +209,17 @@ Use the following ownership mapping:
 | Queue | Bounded admission channel and reusable pointer/descriptor scratch owned by the serialized lane |
 | Event | Latched state plus owned program/buffer guards and native completion/error state until release |
 
-- [ ] Discover the HTP device and report stable Qualcomm vendor/product identity,
+- [x] Discover the HTP device and report stable Qualcomm vendor/product identity,
       `AcceleratorClass::NPU`, truthful memory domains/alignment/limits, and only demonstrated
       capabilities.
-- [ ] Implement contexts as ownership/quota scopes; avoid duplicating process-wide provider/device
+- [x] Implement contexts as ownership/quota scopes; avoid duplicating process-wide provider/device
       state or scarce QNN resources per guest context without evidence that it is required.
-- [ ] Implement zero-initialized, fallibly allocated, aligned buffers with checked size/alignment and
+- [x] Implement zero-initialized, fallibly allocated, aligned buffers with checked size/alignment and
       exact retained byte ranges. If QNN memory registration is required, register once at buffer
       creation and deregister exactly once after all event references are gone.
-- [ ] Implement explicit chunked `write_buffer`/`read_buffer`, including any documented cache
+- [x] Implement explicit chunked `write_buffer`/`read_buffer`, including any documented cache
       synchronization. Reject host transfers while an exclusive native writer is in flight.
-- [ ] Allow overlapping read-only bindings when QNN permits them; enforce one writer or read-write
+- [x] Allow overlapping read-only bindings when QNN permits them; enforce one writer or read-write
       user with `Busy` on conflicts. Validate ownership, access mode, range, alignment, slot,
       dtype/shape byte size, and duplicate/conflicting bindings before native acceptance.
 - [ ] Bound contexts, buffers, programs, queues, queued submissions, events, and retained bytes.
@@ -223,21 +230,21 @@ or guard leak remains after success, error, explicit release, or backend discard
 
 ## Phase 5: asynchronous execution and failure semantics
 
-- [ ] Have `submit` complete validation and conflict reservation before enqueueing. Once native
+- [x] Have `submit` complete validation and conflict reservation before enqueueing. Once native
       acceptance may have occurred, retain an event and report indeterminate ownership when the
       contract requires it.
 - [ ] Use a fixed-capacity channel/ring and one worker lane initially. The worker binds the exact
       buffer ranges, dispatches the finalized graph, waits outside `submit`/`poll_event`, performs
       required output synchronization, releases in-flight guards, and publishes one terminal state.
-- [ ] Make `poll_event` a wait-free/nonblocking read of a latched pending/success/error state. Stable
+- [x] Make `poll_event` a wait-free/nonblocking read of a latched pending/success/error state. Stable
       terminal polling must never call back into QNN.
-- [ ] Enforce finite timeouts honestly. Reject before admission when possible; after native
+- [x] Enforce finite timeouts honestly. Reject before admission when possible; after native
       acceptance, keep ownership until terminal completion. Map a proven bounded cancellation API
       to `DeadlineExpired`; otherwise document that the timeout cannot revoke native work and do not
       advertise cancellation.
 - [ ] Poison the backend/device after unrecoverable HTP loss or a completion result that makes
       resource ownership unknowable. New work fails until the complete backend is discarded.
-- [ ] Order terminal publication after all output visibility work and binding-guard release. Order
+- [x] Order terminal publication after all output visibility work and binding-guard release. Order
       event teardown so QNN can no longer access descriptors or allocations before Rust releases
       them.
 
@@ -246,7 +253,7 @@ preserve ownership, and fault injection cannot produce use-after-free or double 
 
 ## Phase 6: conformance and numerical evidence
 
-- [ ] Add backend-local integration tests modeled on `virtio-accel-openvino/tests/openvino.rs`, with
+- [x] Add backend-local integration tests modeled on `virtio-accel-openvino/tests/openvino.rs`, with
       native execution gated by `va_hexagon` and runtime/device availability.
 - [ ] Run every mandatory `virtio-accel-conformance` case. Implement hooks for resource counts,
       submission-path diagnostics, completion, and fault/device-loss behavior. Every conditional
@@ -258,7 +265,7 @@ preserve ownership, and fault injection cannot produce use-after-free or double 
       read/read overlap, read/write conflict, host-transfer conflicts, bounded admission, finite
       timeouts, stable terminal polling, device loss, rejected versus indeterminate submissions,
       and all realizable release failures.
-- [ ] Run all advertised shared numerical fixtures on hardware and compare to their oracle,
+- [x] Run all advertised shared numerical fixtures on hardware and compare to their oracle,
       including edge-value precision cases. An advertised dtype/operator pair must have no silent
       skips.
 - [ ] Stress repeated load/unload, submit/complete/release, context destruction, and backend discard.
@@ -272,26 +279,26 @@ selected Snapdragon NPU; resource and direct-binding diagnostics return to basel
 
 ## Phase 7: documentation, CI, and release integration
 
-- [ ] Add `tosa_hexagon` as a backend-local end-to-end example. Without QAIRT it must print a clear
+- [x] Add `tosa_hexagon` as a backend-local end-to-end example. Without QAIRT it must print a clear
       unavailability message and exit successfully; on supported hardware it must execute on HTP and
       verify its result.
-- [ ] Document SDK acquisition, licensing, environment variables, supported Snapdragon devices,
+- [x] Document SDK acquisition, licensing, environment variables, supported Snapdragon devices,
       Windows/driver/QAIRT versions, HTP support-library deployment, runtime logging needed to prove
       placement, build/test commands, target identity, precise operator/dtype boundary, and known
       limitations in the crate README.
-- [ ] Update root `README.md`, `CONTRIBUTING.md`, `docs/architecture.md`, `docs/portability.md`,
+- [x] Update root `README.md`, `CONTRIBUTING.md`, `docs/architecture.md`, `docs/portability.md`,
       `docs/performance.md`, `docs/public-api.md`, `docs/backend-implementer-guide.md`, the pull
       request template, and CI examples. Change the Qualcomm support-table row from `Planned` only
       for cases backed by hardware tests.
-- [ ] Update the release-policy crate count/order, `ci/check-release-policy.py` package and unsafe
+- [x] Update the release-policy crate count/order, `ci/check-release-policy.py` package and unsafe
       exception allowlists, `ci/publication.py`, workspace metadata, lockfile, packaging tests, and
       ordered local-registry dry run.
-- [ ] Add portable CI for format, clippy, unit tests, docs, placeholder builds, forced-off builds,
+- [x] Add portable CI for format, clippy, unit tests, docs, placeholder builds, forced-off builds,
       and package verification on hosts without QAIRT.
 - [ ] Add a hardware workflow only when a controlled Snapdragon runner exists. Pin its OS image,
       NPU driver, QAIRT release, and SDK checksum; avoid storing licensed SDK payloads in the repo or
       ordinary public CI artifacts.
-- [ ] Run the workspace release checks and document whether adding this adapter is a Cargo minor
+- [x] Run the workspace release checks and document whether adding this adapter is a Cargo minor
       with no protocol change. Do not modify the virtio wire ABI or portable `Accelerator` contract
       solely for QNN.
 
@@ -335,20 +342,20 @@ host with no QAIRT installation.
 
 ## Definition of done
 
-- [ ] A supported Snapdragon host enumerates an honest Qualcomm Hexagon NPU device and runs the
+- [x] A supported Snapdragon host enumerates an honest Qualcomm Hexagon NPU device and runs the
       documented TOSA example through QNN HTP.
-- [ ] The complete workspace builds, lints, tests, documents, and packages without Qualcomm
+- [x] The complete workspace builds, lints, tests, documents, and packages without Qualcomm
       dependencies.
 - [ ] Every mandatory semantic conformance case passes or has a contract-authorized, explicit
       capability skip.
-- [ ] Every advertised TOSA operator/dtype case passes the shared numerical oracle on hardware.
+- [x] Every advertised TOSA operator/dtype case passes the shared numerical oracle on hardware.
 - [ ] Provider diagnostics prove direct caller-allocation binding with no submission-time provider
       staging.
 - [ ] Timeout, stable polling, binding conflicts, device loss, rejected/indeterminate ownership,
       and exact-once teardown are tested.
-- [ ] Unsafe QNN interaction is confined and audited in `SAFETY.md`.
-- [ ] Documentation and the root support matrix claim no more than the pinned evidence proves.
-- [ ] No Qualcomm API or type leaks into a portable crate, and protocol 1.0 bytes/semantics remain
+- [x] Unsafe QNN interaction is confined and audited in `SAFETY.md`.
+- [x] Documentation and the root support matrix claim no more than the pinned evidence proves.
+- [x] No Qualcomm API or type leaks into a portable crate, and protocol 1.0 bytes/semantics remain
       unchanged.
 
 ## Open questions to close during Phase 0

--- a/docs/portability.md
+++ b/docs/portability.md
@@ -122,6 +122,7 @@ cargo run --example reference_execution
 cargo run -p virtio-accel-coreml --example tosa_coreml
 cargo run -p virtio-accel-openvino --example tosa_openvino
 cargo run -p virtio-accel-hexagon --example tosa_hexagon
+cargo run -p virtio-accel-hexagon --example mock_classifier
 cargo +1.85.0 check --workspace --all-targets --all-features
 cargo hack check --workspace --feature-powerset --no-dev-deps
 bash ci/check-portable-dependencies.sh

--- a/docs/portability.md
+++ b/docs/portability.md
@@ -57,13 +57,15 @@ exercises the real backend against the CPU plugin. NPU and GPU devices additiona
 Intel Level Zero NPU driver or the Intel OpenCL/Level Zero GPU runtime on the host; hosts without
 an inference device skip execution after enumeration.
 
-The Hexagon crate currently exercises only its SDK-free placeholder and strict FP16 TOSA graph
-planner in portable CI. Its build script distinguishes a complete public QAIRT/QNN development
+The Hexagon crate exercises its SDK-free placeholder and strict FP16 TOSA graph planner in portable
+CI. Its build script distinguishes a complete public QAIRT/QNN development
 installation from driver-only and AppBuilder/Genie bundles by requiring `QnnInterface.h` and the
 Windows ARM64 `QnnHtp` import library. `VIRTIO_ACCEL_HEXAGON=0` forces the placeholder;
 `VIRTIO_ACCEL_HEXAGON=1` makes missing requirements a build failure;
-`VIRTIO_ACCEL_QNN_SDK_ROOT`/`QNN_SDK_ROOT` and `VIRTIO_ACCEL_QNN_LIB_DIR` select the SDK. Native HTP
-execution and a hardware CI lane remain unadvertised until the audited bridge passes conformance.
+`VIRTIO_ACCEL_QNN_SDK_ROOT`/`QNN_SDK_ROOT` and `VIRTIO_ACCEL_QNN_LIB_DIR` select the SDK. On the
+pinned Windows ARM64 hardware tier, backend-local tests execute identity, MATMUL, and MAX_POOL2D
+through QNN HTP. A public hardware CI lane remains unavailable, so the README publishes the exact
+manual replacement commands.
 
 Concrete VMM, kernel, OS, and vendor adapters are outside the portable-v1 milestone and must not
 become default dependencies of a portable crate.

--- a/docs/portability.md
+++ b/docs/portability.md
@@ -38,7 +38,7 @@ directly, and they must keep working on any platform the portable crates support
 | `core-only` | `virtio-accel-cleanroom`, `virtio-accel-proto`, `virtio-accel-transport`, `virtio-accel-core` | `core`; the clean-room codec and transport ports have no normal/build dependencies, while proc-macros used by other crates may execute with `std` on the build host |
 | `alloc-portable` | `virtio-accel-guest`, `virtio-accel-split-queue`, `virtio-accel-device`, `virtio-accel-tosa`, `virtio-accel` | `core + alloc`; no OS, filesystem, sockets, threads, or host synchronization |
 | `std-reference` | `virtio-accel-mock`, `virtio-accel-conformance` | Portable `std`; no host-OS or vendor-specific API |
-| `host-native` | `virtio-accel-coreml`, `virtio-accel-openvino` | Core ML/Foundation on macOS 14+, or the OpenVINO C runtime (`libopenvino_c` 2026.x) when detected at build time; a compile-only unsupported-platform or unsupported-runtime placeholder elsewhere |
+| `host-native` | `virtio-accel-coreml`, `virtio-accel-openvino`, `virtio-accel-hexagon` | Core ML/Foundation on macOS 14+, the OpenVINO C runtime (`libopenvino_c` 2026.x), or the complete QAIRT/QNN C SDK on Windows ARM64 when detected at build time; a compile-only unsupported-platform or unsupported-runtime placeholder elsewhere |
 
 Neither host-native crate is a dependency of the facade or any portable layer. The Core ML crate's
 Objective-C bridge and TOSA-to-Core ML model compilation are built only when the Cargo target is
@@ -56,6 +56,14 @@ portable TOSA-to-IR encoder; the dedicated `openvino-host-test` job installs a p
 exercises the real backend against the CPU plugin. NPU and GPU devices additionally require the
 Intel Level Zero NPU driver or the Intel OpenCL/Level Zero GPU runtime on the host; hosts without
 an inference device skip execution after enumeration.
+
+The Hexagon crate currently exercises only its SDK-free placeholder and strict FP16 TOSA graph
+planner in portable CI. Its build script distinguishes a complete public QAIRT/QNN development
+installation from driver-only and AppBuilder/Genie bundles by requiring `QnnInterface.h` and the
+Windows ARM64 `QnnHtp` import library. `VIRTIO_ACCEL_HEXAGON=0` forces the placeholder;
+`VIRTIO_ACCEL_HEXAGON=1` makes missing requirements a build failure;
+`VIRTIO_ACCEL_QNN_SDK_ROOT`/`QNN_SDK_ROOT` and `VIRTIO_ACCEL_QNN_LIB_DIR` select the SDK. Native HTP
+execution and a hardware CI lane remain unadvertised until the audited bridge passes conformance.
 
 Concrete VMM, kernel, OS, and vendor adapters are outside the portable-v1 milestone and must not
 become default dependencies of a portable crate.
@@ -111,6 +119,7 @@ cargo run --example backend_conformance
 cargo run --example reference_execution
 cargo run -p virtio-accel-coreml --example tosa_coreml
 cargo run -p virtio-accel-openvino --example tosa_openvino
+cargo run -p virtio-accel-hexagon --example tosa_hexagon
 cargo +1.85.0 check --workspace --all-targets --all-features
 cargo hack check --workspace --feature-powerset --no-dev-deps
 bash ci/check-portable-dependencies.sh

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -47,12 +47,13 @@ through `ModelValidator`; generated FlatBuffers tables and unchecked roots remai
 
 ## Runnable entry points
 
-Four examples are part of the default CI workflow:
+Five examples are part of the default CI workflow:
 
 - `cargo run --example backend_conformance`
 - `cargo run --example reference_execution`
 - `cargo run -p virtio-accel-coreml --example tosa_coreml`
 - `cargo run -p virtio-accel-openvino --example tosa_openvino`
+- `cargo run -p virtio-accel-hexagon --example tosa_hexagon`
 
 `backend_conformance` shows how a backend author wires a provider to the reusable conformance
 suite. `reference_execution` runs a complete context/buffer/program/queue/submit/poll/read/release
@@ -62,6 +63,9 @@ execution; non-macOS hosts compile the placeholder, and macOS hosts without an A
 `tosa_openvino` proves the same production path through backend-local OpenVINO IR lowering on the
 preferred available Intel inference device; hosts without an OpenVINO runtime compile the
 placeholder, and hosts without an inference device skip execution.
+`tosa_hexagon` currently proves the SDK-free behavior only: the strict portable planner is tested
+separately, and the example reports `RuntimeUnavailable` without falling back to CPU or GPU. It must
+become a real end-to-end HTP example before Qualcomm leaves `Planned` status.
 
 ## Baseline, reserved, and post-v1 work
 
@@ -70,8 +74,9 @@ normative documents. Reserved feature bits, opcodes, flags, and fields are not o
 they are invalid until a later policy assigns semantics. Platform integrations such as KVM,
 vhost-user, VFIO, Windows, macOS, or vendor SDK adapters do not change protocol 1.0 and must not
 leak into portable default dependencies. `virtio-accel-coreml` and `virtio-accel-openvino` are the
-first concrete host backends: each depends inward on `virtio-accel-core` and `virtio-accel-tosa`,
-while the facade and portable runtime crates depend on neither.
+first concrete host backends. `virtio-accel-hexagon` is a separately packaged, still-planned
+adapter scaffold. Each depends inward on `virtio-accel-core` and `virtio-accel-tosa`, while the
+facade and portable runtime crates depend on none of them.
 
 The compatibility and release classification rules are in
 [`release-policy.md`](release-policy.md). The protocol 1.0 frozen surface is summarized in

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -63,9 +63,9 @@ execution; non-macOS hosts compile the placeholder, and macOS hosts without an A
 `tosa_openvino` proves the same production path through backend-local OpenVINO IR lowering on the
 preferred available Intel inference device; hosts without an OpenVINO runtime compile the
 placeholder, and hosts without an inference device skip execution.
-`tosa_hexagon` currently proves the SDK-free behavior only: the strict portable planner is tested
-separately, and the example reports `RuntimeUnavailable` without falling back to CPU or GPU. It must
-become a real end-to-end HTP example before Qualcomm leaves `Planned` status.
+`tosa_hexagon` executes the shared FP16 identity graph through QNN HTP when the complete QAIRT SDK
+is selected on Windows ARM64. SDK-free hosts retain the compile-only `RuntimeUnavailable` surface
+without falling back to CPU or GPU.
 
 ## Baseline, reserved, and post-v1 work
 
@@ -74,8 +74,8 @@ normative documents. Reserved feature bits, opcodes, flags, and fields are not o
 they are invalid until a later policy assigns semantics. Platform integrations such as KVM,
 vhost-user, VFIO, Windows, macOS, or vendor SDK adapters do not change protocol 1.0 and must not
 leak into portable default dependencies. `virtio-accel-coreml` and `virtio-accel-openvino` are the
-first concrete host backends. `virtio-accel-hexagon` is a separately packaged, still-planned
-adapter scaffold. Each depends inward on `virtio-accel-core` and `virtio-accel-tosa`, while the
+first concrete host backends. `virtio-accel-hexagon` is a separately packaged, pinned experimental
+QNN HTP adapter. Each depends inward on `virtio-accel-core` and `virtio-accel-tosa`, while the
 facade and portable runtime crates depend on none of them.
 
 The compatibility and release classification rules are in

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -47,13 +47,14 @@ through `ModelValidator`; generated FlatBuffers tables and unchecked roots remai
 
 ## Runnable entry points
 
-Five examples are part of the default CI workflow:
+Six examples are part of the default CI workflow:
 
 - `cargo run --example backend_conformance`
 - `cargo run --example reference_execution`
 - `cargo run -p virtio-accel-coreml --example tosa_coreml`
 - `cargo run -p virtio-accel-openvino --example tosa_openvino`
 - `cargo run -p virtio-accel-hexagon --example tosa_hexagon`
+- `cargo run -p virtio-accel-hexagon --example mock_classifier`
 
 `backend_conformance` shows how a backend author wires a provider to the reusable conformance
 suite. `reference_execution` runs a complete context/buffer/program/queue/submit/poll/read/release
@@ -65,7 +66,8 @@ preferred available Intel inference device; hosts without an OpenVINO runtime co
 placeholder, and hosts without an inference device skip execution.
 `tosa_hexagon` executes the shared FP16 identity graph through QNN HTP when the complete QAIRT SDK
 is selected on Windows ARM64. SDK-free hosts retain the compile-only `RuntimeUnavailable` surface
-without falling back to CPU or GPU.
+without falling back to CPU or GPU. `mock_classifier` uses the same native lifecycle to compute two
+sets of class logits from three FP16 features and a direct-bound 3x2 weight matrix.
 
 ## Baseline, reserved, and post-v1 work
 

--- a/docs/release-policy.md
+++ b/docs/release-policy.md
@@ -135,7 +135,7 @@ declares its own `description` and `readme`, and carries its own byte-identical 
 root license files do not reach the sub-crate tarballs; the copies exist for that reason and are
 copies rather than symlinks because CI runs `windows-latest`.
 
-`ci/check-release-policy.py` enforces all of this against an explicit thirteen-crate allowlist. A new
+`ci/check-release-policy.py` enforces all of this against an explicit fourteen-crate allowlist. A new
 package fails that check until it is added to the allowlist, which forces a decision about whether
 it is public rather than letting it default either way. The check also validates the crates.io
 keyword and category limits, which neither `cargo package` nor `cargo publish --dry-run` catches
@@ -164,14 +164,15 @@ source.
 | 10 | `virtio-accel-conformance` | `core` | `mock`, `tosa` |
 | 11 | `virtio-accel-coreml` | `core`, `tosa` | `conformance` |
 | 12 | `virtio-accel-openvino` | `core`, `tosa` | `conformance` |
-| 13 | `virtio-accel` | the six runtime crates | `conformance`, `mock`, `cleanroom` |
+| 13 | `virtio-accel-hexagon` | `core`, `tosa` | `conformance` |
+| 14 | `virtio-accel` | the six runtime crates | `conformance`, `mock`, `cleanroom` |
 
 This order is executable, not just documentary: `ci/publish-dry-run.py` walks it against an isolated
 local registry, adding each crate only after it has been built, tested, and documented from its own
 extracted tarball. A crate can therefore only ever resolve its predecessors, so a wrong order fails
 with an unresolvable dependency instead of passing quietly. The same script is a required CI job.
 
-All thirteen packages share the workspace version and are published together. A GitHub release tag
+All fourteen packages share the workspace version and are published together. A GitHub release tag
 must be exactly `v<workspace-version>` and must point at the commit being released. Publishing a
 GitHub release triggers `.github/workflows/publish.yml`, which checks out that tag, runs the release
 policy checks and publication-driver tests, repeats the full ordered local-registry dry run on the


### PR DESCRIPTION
## Summary

- add the `virtio-accel-hexagon` Windows ARM64 host backend using the public QAIRT/QNN HTP interface
- validate static FP16 TOSA and execute identity, batched MATMUL, and NHWC MAX_POOL2D without CPU/GPU fallback
- bind exact aligned caller allocations, serialize native execution, and expose stable nonblocking events
- preserve an explicit SDK-free placeholder on unsupported hosts
- add an audited native boundary, SDK/manual-test documentation, and release-policy integration
- add a reusable two-sample FP16 linear-classifier fixture and runnable Hexagon example

## Hardware evidence

Validated on Snapdragon X126100 / Hexagon HTP v73 with:

- QAIRT `2.49.0.260730`
- provider `HTP_QTI_AISW`
- provider build `v2.49.0.260730134355`
- QNN core API `2.38.0`
- HTP backend API `5.49.0`

The five hardware integration tests pass, including the shared numerical corpus and mock classifier. The classifier produces the expected FP16 logits `[4.0, -1.0, 1.0, -1.5]`.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` with the Hexagon backend forced off
- `cargo test --workspace --all-targets --all-features` with the Hexagon backend forced off
- `cargo clippy -p virtio-accel-hexagon --all-targets -- -D warnings` against QAIRT
- `cargo test -p virtio-accel-hexagon --all-targets -- --test-threads=1` against physical HTP
- `cargo run -p virtio-accel-hexagon --example mock_classifier` against physical HTP
- `python ci/check-release-policy.py`
- `cargo package -p virtio-accel-hexagon --allow-dirty`

## Current boundary

The advertised tier is static FP16 only. Finite timeouts are rejected before admission and cancellation is not advertised. Direct PoolMax2d finalization is rejected by this Windows HTP runtime, so its zero-padding semantics are lowered to HTP Gather plus ElementWiseMaximum nodes. Full conformance hooks, formal direct-binding diagnostics, device-loss injection, stress accounting, performance evidence, and a controlled hardware CI lane remain tracked in the implementation plan.

Relates to #77