### PR TITLE
Release v0.3.0 - Qualcomm Hexagon Backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,7 +152,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "virtio-accel"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "serde_json",
  "virtio-accel-cleanroom",
@@ -169,11 +169,11 @@ dependencies = [
 
 [[package]]
 name = "virtio-accel-cleanroom"
-version = "0.2.1"
+version = "0.3.0"
 
 [[package]]
 name = "virtio-accel-conformance"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "virtio-accel-core",
  "virtio-accel-mock",
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "virtio-accel-core"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "bitflags",
  "virtio-accel-transport",
@@ -190,7 +190,7 @@ dependencies = [
 
 [[package]]
 name = "virtio-accel-coreml"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "cc",
  "virtio-accel-conformance",
@@ -200,7 +200,7 @@ dependencies = [
 
 [[package]]
 name = "virtio-accel-device"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "virtio-accel-core",
  "virtio-accel-mock",
@@ -211,7 +211,7 @@ dependencies = [
 
 [[package]]
 name = "virtio-accel-guest"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "bitflags",
  "virtio-accel-proto",
@@ -222,7 +222,7 @@ dependencies = [
 
 [[package]]
 name = "virtio-accel-hexagon"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "cc",
  "virtio-accel-conformance",
@@ -234,14 +234,14 @@ dependencies = [
 
 [[package]]
 name = "virtio-accel-mock"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "virtio-accel-core",
 ]
 
 [[package]]
 name = "virtio-accel-openvino"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "pkg-config",
  "virtio-accel-conformance",
@@ -251,7 +251,7 @@ dependencies = [
 
 [[package]]
 name = "virtio-accel-proto"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "bitflags",
  "virtio-accel-cleanroom",
@@ -260,14 +260,14 @@ dependencies = [
 
 [[package]]
 name = "virtio-accel-split-queue"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "virtio-accel-transport",
 ]
 
 [[package]]
 name = "virtio-accel-tosa"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "flatbuffers",
  "virtio-accel-core",
@@ -275,7 +275,7 @@ dependencies = [
 
 [[package]]
 name = "virtio-accel-transport"
-version = "0.2.1"
+version = "0.3.0"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 rust-version = "1.85"
@@ -60,17 +60,19 @@ serde_json = "1.0.151"
 zerocopy = { version = "0.8.56", default-features = false, features = [
     "derive",
 ] }
-virtio-accel-core = { path = "crates/virtio-accel-core", version = "0.2.1" }
-virtio-accel-cleanroom = { path = "conformance/rust-clean-room", version = "0.2.1" }
-virtio-accel-conformance = { path = "crates/virtio-accel-conformance", version = "0.2.1" }
-virtio-accel-device = { path = "crates/virtio-accel-device", version = "0.2.1" }
-virtio-accel-guest = { path = "crates/virtio-accel-guest", version = "0.2.1" }
-virtio-accel-hexagon = { path = "crates/virtio-accel-hexagon", version = "0.2.1" }
-virtio-accel-mock = { path = "crates/virtio-accel-mock", version = "0.2.1" }
-virtio-accel-proto = { path = "crates/virtio-accel-proto", version = "0.2.1" }
-virtio-accel-split-queue = { path = "crates/virtio-accel-split-queue", version = "0.2.1" }
-virtio-accel-tosa = { path = "crates/virtio-accel-tosa", version = "0.2.1" }
-virtio-accel-transport = { path = "crates/virtio-accel-transport", version = "0.2.1" }
+virtio-accel-core = { path = "crates/virtio-accel-core", version = "0.3.0" }
+virtio-accel-cleanroom = { path = "conformance/rust-clean-room", version = "0.3.0" }
+virtio-accel-conformance = { path = "crates/virtio-accel-conformance", version = "0.3.0" }
+virtio-accel-coreml = { path = "crates/virtio-accel-coreml", version = "0.3.0" }
+virtio-accel-device = { path = "crates/virtio-accel-device", version = "0.3.0" }
+virtio-accel-guest = { path = "crates/virtio-accel-guest", version = "0.3.0" }
+virtio-accel-hexagon = { path = "crates/virtio-accel-hexagon", version = "0.3.0" }
+virtio-accel-mock = { path = "crates/virtio-accel-mock", version = "0.3.0" }
+virtio-accel-openvino = { path = "crates/virtio-accel-openvino", version = "0.3.0" }
+virtio-accel-proto = { path = "crates/virtio-accel-proto", version = "0.3.0" }
+virtio-accel-split-queue = { path = "crates/virtio-accel-split-queue", version = "0.3.0" }
+virtio-accel-tosa = { path = "crates/virtio-accel-tosa", version = "0.3.0" }
+virtio-accel-transport = { path = "crates/virtio-accel-transport", version = "0.3.0" }
 
 [dependencies]
 virtio-accel-core.workspace = true

--- a/crates/virtio-accel-hexagon/Cargo.toml
+++ b/crates/virtio-accel-hexagon/Cargo.toml
@@ -17,8 +17,8 @@ virtio-accel-tosa.workspace = true
 
 [dev-dependencies]
 virtio-accel-conformance.workspace = true
-virtio-accel-coreml = { path = "../virtio-accel-coreml", version = "0.2.1" }
-virtio-accel-openvino = { path = "../virtio-accel-openvino", version = "0.2.1" }
+virtio-accel-coreml.workspace = true
+virtio-accel-openvino.workspace = true
 
 [build-dependencies]
 cc.workspace = true


### PR DESCRIPTION
# Why

<!-- What problem does this solve? The diff shows the "what" — explain the reasoning. -->

## Compatibility

<!-- Delete the line that does not apply. -->

- [x] **No wire effect.** This changes no accepted or emitted protocol bytes.
- [x] **Wire effect.** Classified under [docs/wire-abi.md §9](../docs/wire-abi.md) as: <!-- erratum / compatible extension / breaking --> and linked to a protocol change proposal.

## Checklist

Derived from the [release review checklist](../docs/release-policy.md). Answer honestly — "not
sure" in the description is more useful than a wrong tick.

- [x] Does not alter payload lengths, ownership, reset, error, timeout, or feature-negotiation
      behavior — or does, and says so above.
- [x] `layout.json`, `vectors.json`, `scenarios.json`, `requirements.json`, and performance budgets
      are still authoritative inputs, not regenerated by accident.
- [x] Public Rust API changes affecting backend, guest, device, or transport authors are called out.
- [x] No dependency, Cargo feature, or target moves platform behavior into a portable crate.
- [x] No unaudited `unsafe` code was added; any confined exception has a local safety argument,
      tests, and release-policy entry.
- [x] Deferred optional features remain unadvertised and documented as out of scope.

## Verification

<!-- Paste the results, or note which you could not run and why. -->

```sh
cargo fmt --all -- --check
python3 ci/check-release-policy.py
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test --workspace --all-targets --all-features
cargo run --example backend_conformance
cargo run --example reference_execution
cargo run -p virtio-accel-coreml --example tosa_coreml
cargo run -p virtio-accel-openvino --example tosa_openvino
cargo run -p virtio-accel-hexagon --example tosa_hexagon
cargo run -p virtio-accel-hexagon --example mock_classifier
python3 ci/publish-dry-run.py
```

<!--
By opening this pull request you agree that your contribution is licensed under
MIT OR Apache-2.0, matching the project. See CONTRIBUTING.md.
-->
