### PR TITLE
Add safe TOSA authoring companion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,6 +237,7 @@ jobs:
           -p virtio-accel-guest
           -p virtio-accel-split-queue
           -p virtio-accel-tosa
+          -p virtio-accel-tosa-build
           -p virtio-accel
           -p virtio-accel-vaccel
           --target ${{ matrix.target }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,6 +274,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "virtio-accel-tosa-build"
+version = "0.3.1"
+dependencies = [
+ "flatbuffers",
+ "virtio-accel-tosa",
+]
+
+[[package]]
 name = "virtio-accel-transport"
 version = "0.3.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ members = [
     "crates/virtio-accel-proto",
     "crates/virtio-accel-split-queue",
     "crates/virtio-accel-tosa",
+    "crates/virtio-accel-tosa-build",
     "crates/virtio-accel-transport",
 ]
 resolver = "3"
@@ -73,6 +74,7 @@ virtio-accel-openvino = { path = "crates/virtio-accel-openvino", version = "0.3.
 virtio-accel-proto = { path = "crates/virtio-accel-proto", version = "0.3.1" }
 virtio-accel-split-queue = { path = "crates/virtio-accel-split-queue", version = "0.3.1" }
 virtio-accel-tosa = { path = "crates/virtio-accel-tosa", version = "0.3.1" }
+virtio-accel-tosa-build = { path = "crates/virtio-accel-tosa-build", version = "0.3.1" }
 virtio-accel-transport = { path = "crates/virtio-accel-transport", version = "0.3.1" }
 virtio-accel-vaccel = { path = "crates/virtio-accel-vaccel", version = "0.3.1" }
 

--- a/README.md
+++ b/README.md
@@ -70,8 +70,9 @@ and [operator matrix](docs/hexagon-operator-matrix.md).
 
 Independently of backend execution, `virtio-accel-tosa` validates the TOSA 1.0 profiles and
 extensions for all five dtype columns, and `virtio-accel-conformance` ships shared fixtures and
-oracles for them. The byte-oriented `virtio-accel-mock` backend remains test infrastructure rather
-than a typed hardware implementation.
+oracles for them. `virtio-accel-tosa-build` provides the matching safe authoring path for static
+single-block graphs and validates every result through that ingestion boundary. The byte-oriented
+`virtio-accel-mock` backend remains test infrastructure rather than a typed hardware implementation.
 
 ## Workspace
 
@@ -82,6 +83,7 @@ than a typed hardware implementation.
 | `virtio-accel-transport`   | `core`         | Dependency-free descriptor-chain, queue, reset, and notification ports                                       |
 | `virtio-accel-core`        | `core`         | Backend lifecycle, memory, program, queue, and event contracts                                               |
 | `virtio-accel-tosa`        | `core + alloc` | Bounded zero-copy TOSA 1.0 validation, lowering analysis, specialization, and packed low-precision utilities |
+| `virtio-accel-tosa-build`  | `core + alloc` | Typed static TOSA 1.0 authoring with mandatory parser and semantic-validation round trips                     |
 | `virtio-accel-vaccel`      | `core`         | Adapter seam for mapping native provider contracts (including vAccel-style backends) to `virtio-accel-core` |
 | `virtio-accel-coreml`      | macOS `std`    | TOSA-to-Core ML lowering, direct buffers, and asynchronous ANE-capable prediction                            |
 | `virtio-accel-openvino`    | Linux `std` (probed) | TOSA-to-OpenVINO IR lowering, direct host-pointer tensors, and asynchronous NPU/GPU/CPU inference      |
@@ -109,6 +111,7 @@ virtio-accel-guest -----------> virtio-accel-transport
 
 virtio-accel-conformance --------------------> virtio-accel-core
 virtio-accel-tosa ---------------------------> virtio-accel-core
+virtio-accel-tosa-build ---------------------> virtio-accel-tosa
 virtio-accel-coreml ----------+--------------> virtio-accel-core
                               |
                               +--------------> virtio-accel-tosa
@@ -168,6 +171,10 @@ graph and typed-attribute views, enforce complete stable-op semantics for a decl
 construct the device-neutral TOSA artifact envelope. `Model::analyze_for` also produces bounded
 dense IDs, topological order, liveness, runtime obligations, and specialization keys for Core ML,
 OpenVINO, or another provider. It is intentionally not re-exported by the facade.
+
+Add `virtio-accel-tosa-build = "0.3"` to produce static single-block TOSA artifacts through typed
+tensor and operator definitions. Successful builds have already passed the same parser and target
+validator providers use at admission.
 
 ## Production TOSA-to-Core ML example
 

--- a/ci/check-portable-dependencies.sh
+++ b/ci/check-portable-dependencies.sh
@@ -20,13 +20,16 @@ for package in "${packages[@]}"; do
 done
 
 # FlatBuffers uses a pure-Rust build script to detect the compiler version, so its host-only
-# rustc_version/semver dependencies legitimately enable std. The TOSA target graph itself must not.
-tosa_tree="$(cargo tree -p virtio-accel-tosa -e normal,features --prefix none)"
-if grep -Eq 'feature "(std|alloc)"' <<<"$tosa_tree"; then
-  echo "virtio-accel-tosa unexpectedly enables a std or alloc target dependency feature:" >&2
-  echo "$tosa_tree" >&2
-  exit 1
-fi
+# rustc_version/semver dependencies legitimately enable std. The TOSA ingestion and authoring
+# target graphs themselves must not.
+for package in virtio-accel-tosa virtio-accel-tosa-build; do
+  tosa_tree="$(cargo tree -p "$package" -e normal,features --prefix none)"
+  if grep -Eq 'feature "(std|alloc)"' <<<"$tosa_tree"; then
+    echo "$package unexpectedly enables a std or alloc target dependency feature:" >&2
+    echo "$tosa_tree" >&2
+    exit 1
+  fi
+done
 
 cleanroom_tree="$(cargo tree -p virtio-accel-cleanroom -e normal,build --depth 1 --prefix none)"
 cleanroom_dependencies="$(sed '1d' <<<"$cleanroom_tree")"

--- a/ci/check-release-policy.py
+++ b/ci/check-release-policy.py
@@ -37,6 +37,7 @@ PUBLISHED_PACKAGES = {
     "crates/virtio-accel-vaccel": "virtio-accel-vaccel",
     "crates/virtio-accel-split-queue": "virtio-accel-split-queue",
     "crates/virtio-accel-tosa": "virtio-accel-tosa",
+    "crates/virtio-accel-tosa-build": "virtio-accel-tosa-build",
     "crates/virtio-accel-transport": "virtio-accel-transport",
 }
 

--- a/ci/publication.py
+++ b/ci/publication.py
@@ -22,6 +22,7 @@ PUBLISH_ORDER = (
     "virtio-accel-proto",
     "virtio-accel-core",
     "virtio-accel-tosa",
+    "virtio-accel-tosa-build",
     "virtio-accel-split-queue",
     "virtio-accel-guest",
     "virtio-accel-mock",

--- a/crates/virtio-accel-tosa-build/Cargo.toml
+++ b/crates/virtio-accel-tosa-build/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "virtio-accel-tosa-build"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Safe portable authoring for static TOSA 1.0 artifacts"
+readme = "README.md"
+include = [
+    "/Cargo.toml",
+    "/README.md",
+    "/LICENSE-MIT",
+    "/LICENSE-APACHE",
+    "/src/**",
+]
+
+[dependencies]
+flatbuffers.workspace = true
+virtio-accel-tosa.workspace = true

--- a/crates/virtio-accel-tosa-build/LICENSE-APACHE
+++ b/crates/virtio-accel-tosa-build/LICENSE-APACHE
@@ -1,0 +1,176 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/crates/virtio-accel-tosa-build/LICENSE-MIT
+++ b/crates/virtio-accel-tosa-build/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2026 MicroPerceptron contributors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/crates/virtio-accel-tosa-build/README.md
+++ b/crates/virtio-accel-tosa-build/README.md
@@ -14,7 +14,7 @@ bytes, so successful output is immediately usable as an `ArtifactRef`.
 use virtio_accel_tosa::{
     DType, ExtensionSet, Level, ProfileSet, Target, Version,
 };
-use virtio_accel_tosa_build::{Graph, Operator, OperatorKind, Tensor};
+use virtio_accel_tosa_build::{Graph, Operator, OperatorKind, Shape, Tensor};
 
 let tensors = [
     Tensor::new("input", &[1], DType::FP32),
@@ -41,6 +41,30 @@ let bytes = Graph::new(
 .build(target)?;
 # Ok::<(), virtio_accel_tosa_build::BuildError>(())
 ```
+
+Compile-time shape operands use the separate typed `Shape` namespace and a `ConstShape` producer:
+
+```rust
+# use virtio_accel_tosa::{DType, ExtensionSet, Level, ProfileSet, Target, Version};
+# use virtio_accel_tosa_build::{Graph, Operator, OperatorKind, Shape, Tensor};
+# let target = Target::new(Version::TOSA_1_0, ProfileSet::FLOATING_POINT, Level::Level8K, ExtensionSet::NONE);
+let tensors = [
+    Tensor::new("input", &[1, 4], DType::FP32),
+    Tensor::new("output", &[2, 2], DType::FP32),
+];
+let shapes = [Shape::new("target", &[2, 2])];
+let operators = [
+    Operator::new(OperatorKind::ConstShape, &[], &["target"]),
+    Operator::new(OperatorKind::Reshape, &["input", "target"], &["output"]),
+];
+let bytes = Graph::new("main", &tensors, &operators, &["input"], &["output"])
+    .with_shapes(&shapes)
+    .build(target)?;
+# Ok::<(), virtio_accel_tosa_build::BuildError>(())
+```
+
+Inline tensor bytes are accepted only for a nonempty, exactly sized `Tensor::constant` produced by
+`OperatorKind::Const`; this prevents authoring data that ingestion would classify as nonconstant.
 
 The initial surface deliberately covers the static operator set exercised by
 current compiler frontends. Attribute-bearing operators use typed fields; an

--- a/crates/virtio-accel-tosa-build/README.md
+++ b/crates/virtio-accel-tosa-build/README.md
@@ -1,0 +1,53 @@
+# virtio-accel-tosa-build
+
+`virtio-accel-tosa-build` is the safe, portable authoring companion to
+`virtio-accel-tosa`. It constructs deterministic TOSA 1.0 FlatBuffers for
+static, single-block graphs without exposing generated FlatBuffers bindings,
+table slots, union tags, or raw enum discriminants to callers.
+
+The crate is `no_std + alloc`; it needs no `flatc`, filesystem, host runtime,
+or provider SDK. `Graph::build` validates every completed artifact with the
+production `virtio-accel-tosa` parser and semantic validator before returning
+bytes, so successful output is immediately usable as an `ArtifactRef`.
+
+```rust
+use virtio_accel_tosa::{
+    DType, ExtensionSet, Level, ProfileSet, Target, Version,
+};
+use virtio_accel_tosa_build::{Graph, Operator, OperatorKind, Tensor};
+
+let tensors = [
+    Tensor::new("input", &[1], DType::FP32),
+    Tensor::new("output", &[1], DType::FP32),
+];
+let operators = [Operator::new(
+    OperatorKind::Identity,
+    &["input"],
+    &["output"],
+)];
+let target = Target::new(
+    Version::TOSA_1_0,
+    ProfileSet::FLOATING_POINT,
+    Level::Level8K,
+    ExtensionSet::NONE,
+);
+let bytes = Graph::new(
+    "main",
+    &tensors,
+    &operators,
+    &["input"],
+    &["output"],
+)
+.build(target)?;
+# Ok::<(), virtio_accel_tosa_build::BuildError>(())
+```
+
+The initial surface deliberately covers the static operator set exercised by
+current compiler frontends. Attribute-bearing operators use typed fields; an
+unsupported operator cannot be smuggled in as a raw number. Multi-block
+control flow, dynamic shapes, variables, external tensor data, and custom
+operators remain outside this first authoring boundary.
+
+## License
+
+Licensed under Apache-2.0 or MIT, at your option.

--- a/crates/virtio-accel-tosa-build/src/lib.rs
+++ b/crates/virtio-accel-tosa-build/src/lib.rs
@@ -9,6 +9,7 @@
 
 extern crate alloc;
 
+use alloc::collections::BTreeSet;
 use alloc::vec::Vec;
 use core::fmt;
 
@@ -27,6 +28,10 @@ mod slot {
     pub const TENSOR_TYPE: u16 = 8;
     pub const TENSOR_DATA: u16 = 10;
 
+    pub const SHAPE_NAME: u16 = 4;
+    pub const SHAPE_RANK: u16 = 6;
+    pub const SHAPE_DATA: u16 = 8;
+
     pub const OPERATOR_OP: u16 = 4;
     pub const OPERATOR_ATTRIBUTE_TYPE: u16 = 6;
     pub const OPERATOR_ATTRIBUTE: u16 = 8;
@@ -38,6 +43,7 @@ mod slot {
     pub const BLOCK_TENSORS: u16 = 8;
     pub const BLOCK_INPUTS: u16 = 10;
     pub const BLOCK_OUTPUTS: u16 = 12;
+    pub const BLOCK_SHAPES: u16 = 14;
 
     pub const REGION_NAME: u16 = 4;
     pub const REGION_BLOCKS: u16 = 6;
@@ -51,6 +57,24 @@ mod slot {
     pub const VERSION_DRAFT: u16 = 10;
 
     pub const NAN_MODE: u16 = 4;
+}
+
+/// A serialized compile-time shape value.
+///
+/// Shape values occupy the TOSA shape namespace rather than the tensor namespace. They must be
+/// produced by [`OperatorKind::ConstShape`] before an operator such as `RESHAPE` consumes them.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Shape<'a> {
+    /// Unique block-local shape name.
+    pub name: &'a str,
+    /// Signed 64-bit TOSA shape components. A scalar target shape uses an empty slice.
+    pub values: &'a [i64],
+}
+
+impl<'a> Shape<'a> {
+    pub const fn new(name: &'a str, values: &'a [i64]) -> Self {
+        Self { name, values }
+    }
 }
 
 /// A statically shaped tensor definition.
@@ -124,6 +148,7 @@ pub enum OperatorKind {
     Cast,
     Const,
     Identity,
+    ConstShape,
 }
 
 impl OperatorKind {
@@ -159,6 +184,7 @@ impl OperatorKind {
             Self::Cast => Op::CAST,
             Self::Const => Op::CONST,
             Self::Identity => Op::IDENTITY,
+            Self::ConstShape => Op::CONST_SHAPE,
         }
     }
 }
@@ -186,6 +212,7 @@ impl<'a> Operator<'a> {
 pub struct Graph<'a> {
     pub name: &'a str,
     pub tensors: &'a [Tensor<'a>],
+    pub shapes: &'a [Shape<'a>],
     pub operators: &'a [Operator<'a>],
     pub inputs: &'a [&'a str],
     pub outputs: &'a [&'a str],
@@ -202,10 +229,17 @@ impl<'a> Graph<'a> {
         Self {
             name,
             tensors,
+            shapes: &[],
             operators,
             inputs,
             outputs,
         }
+    }
+
+    /// Add compile-time shape values to this graph.
+    pub const fn with_shapes(mut self, shapes: &'a [Shape<'a>]) -> Self {
+        self.shapes = shapes;
+        self
     }
 
     /// Serialize and semantically validate this graph for `target`.
@@ -234,6 +268,44 @@ impl<'a> Graph<'a> {
                 return Err(BuildError::UnsupportedDType(tensor.dtype));
             }
         }
+
+        for shape in self.shapes {
+            if u32::try_from(shape.values.len()).is_err() {
+                return Err(BuildError::ShapeRankOverflow);
+            }
+        }
+
+        let mut constant_tensors = BTreeSet::new();
+        let mut constant_shapes = BTreeSet::new();
+        for operator in self.operators {
+            let outputs = match operator.kind {
+                OperatorKind::Const => &mut constant_tensors,
+                OperatorKind::ConstShape => &mut constant_shapes,
+                _ => continue,
+            };
+            outputs.extend(operator.outputs.iter().copied());
+        }
+
+        for tensor in self.tensors {
+            match tensor.data {
+                Some([]) => return Err(BuildError::EmptyConstantData),
+                Some(_) if !constant_tensors.contains(tensor.name) => {
+                    return Err(BuildError::TensorDataWithoutConst);
+                }
+                Some(_) => {}
+                None if constant_tensors.contains(tensor.name) => {
+                    return Err(BuildError::ConstWithoutTensorData);
+                }
+                None => {}
+            }
+        }
+        if self
+            .shapes
+            .iter()
+            .any(|shape| !constant_shapes.contains(shape.name))
+        {
+            return Err(BuildError::ShapeWithoutConstShape);
+        }
         Ok(())
     }
 
@@ -245,6 +317,14 @@ impl<'a> Graph<'a> {
                 .tensors
                 .iter()
                 .map(|tensor| tensor_table(&mut builder, *tensor))
+                .collect();
+            builder.create_vector(&tables)
+        };
+        let shapes = {
+            let tables: Vec<_> = self
+                .shapes
+                .iter()
+                .map(|shape| shape_table(&mut builder, *shape))
                 .collect();
             builder.create_vector(&tables)
         };
@@ -266,6 +346,7 @@ impl<'a> Graph<'a> {
             builder.push_slot_always(slot::BLOCK_TENSORS, tensors);
             builder.push_slot_always(slot::BLOCK_INPUTS, inputs);
             builder.push_slot_always(slot::BLOCK_OUTPUTS, outputs);
+            builder.push_slot_always(slot::BLOCK_SHAPES, shapes);
             builder.end_table(table)
         };
         let region = {
@@ -295,6 +376,25 @@ impl<'a> Graph<'a> {
         builder.finish(graph, Some("TOSA"));
         builder.finished_data().to_vec()
     }
+}
+
+fn shape_table(builder: &mut FlatBufferBuilder<'_>, shape: Shape<'_>) -> Table {
+    let name = builder.create_string(shape.name);
+    let bytes: Vec<_> = shape
+        .values
+        .iter()
+        .flat_map(|value| value.to_le_bytes())
+        .collect();
+    let data = builder.create_vector(&bytes);
+    let table = builder.start_table();
+    builder.push_slot_always(slot::SHAPE_NAME, name);
+    builder.push_slot::<u32>(
+        slot::SHAPE_RANK,
+        u32::try_from(shape.values.len()).expect("shape rank checked before serialization"),
+        0,
+    );
+    builder.push_slot_always(slot::SHAPE_DATA, data);
+    builder.end_table(table)
 }
 
 fn tensor_table(builder: &mut FlatBufferBuilder<'_>, tensor: Tensor<'_>) -> Table {
@@ -353,6 +453,11 @@ fn string_vector<'a>(
 pub enum BuildError {
     EmptyGraphName,
     DynamicShape,
+    ShapeRankOverflow,
+    EmptyConstantData,
+    TensorDataWithoutConst,
+    ConstWithoutTensorData,
+    ShapeWithoutConstShape,
     UnsupportedDType(DType),
     Parse(virtio_accel_tosa::Error),
     Semantic(SemanticError),
@@ -364,6 +469,19 @@ impl fmt::Display for BuildError {
             Self::EmptyGraphName => formatter.write_str("graph name must not be empty"),
             Self::DynamicShape => {
                 formatter.write_str("the single-block authoring surface requires static shapes")
+            }
+            Self::ShapeRankOverflow => formatter.write_str("shape rank does not fit TOSA u32"),
+            Self::EmptyConstantData => {
+                formatter.write_str("tensor constants require nonempty inline data")
+            }
+            Self::TensorDataWithoutConst => {
+                formatter.write_str("inline tensor data requires a CONST producer")
+            }
+            Self::ConstWithoutTensorData => {
+                formatter.write_str("CONST outputs require nonempty inline tensor data")
+            }
+            Self::ShapeWithoutConstShape => {
+                formatter.write_str("shape values require a CONST_SHAPE producer")
             }
             Self::UnsupportedDType(dtype) => {
                 write!(formatter, "unsupported TOSA 1.0 dtype {dtype:?}")
@@ -440,6 +558,135 @@ mod tests {
         let model = virtio_accel_tosa::parse(&bytes).unwrap();
         let block = model.regions().next().unwrap().blocks().next().unwrap();
         assert_eq!(block.operators().len(), 2);
+    }
+
+    #[test]
+    fn reshape_uses_a_typed_const_shape_operand() {
+        let tensors = [
+            Tensor::new("input", &[1, 4], DType::FP32),
+            Tensor::new("output", &[2, 2], DType::FP32),
+        ];
+        let shapes = [Shape::new("target", &[2, 2])];
+        let operators = [
+            Operator::new(OperatorKind::ConstShape, &[], &["target"]),
+            Operator::new(OperatorKind::Reshape, &["input", "target"], &["output"]),
+        ];
+        let bytes = Graph::new("main", &tensors, &operators, &["input"], &["output"])
+            .with_shapes(&shapes)
+            .build(FLOAT_TARGET)
+            .unwrap();
+
+        let model = virtio_accel_tosa::parse(&bytes).unwrap();
+        let block = model.regions().next().unwrap().blocks().next().unwrap();
+        assert_eq!(block.shapes().len(), 1);
+        assert_eq!(block.shapes().next().unwrap().values().unwrap().len(), 2);
+        assert_eq!(block.operators().len(), 2);
+    }
+
+    #[test]
+    fn inline_tensor_data_requires_a_nonempty_const_producer() {
+        let one = 1.0_f32.to_le_bytes();
+        let data_without_const = [Tensor::constant("value", &[1], DType::FP32, &one)];
+        assert!(matches!(
+            Graph::new("main", &data_without_const, &[], &["value"], &["value"])
+                .build(FLOAT_TARGET),
+            Err(BuildError::TensorDataWithoutConst)
+        ));
+
+        let missing_data = [Tensor::new("value", &[1], DType::FP32)];
+        let constant = [Operator::new(OperatorKind::Const, &[], &["value"])];
+        assert!(matches!(
+            Graph::new("main", &missing_data, &constant, &[], &["value"]).build(FLOAT_TARGET),
+            Err(BuildError::ConstWithoutTensorData)
+        ));
+
+        let empty_data = [Tensor::constant("value", &[0], DType::FP32, &[])];
+        assert!(matches!(
+            Graph::new("main", &empty_data, &constant, &[], &["value"]).build(FLOAT_TARGET),
+            Err(BuildError::EmptyConstantData)
+        ));
+    }
+
+    #[test]
+    fn every_operator_kind_serializes_its_pinned_opcode_and_union_tag() {
+        let cases = [
+            (OperatorKind::MatMul, Op::MATMUL, 7),
+            (OperatorKind::Sigmoid, Op::SIGMOID, 13),
+            (OperatorKind::Tanh, Op::TANH, 14),
+            (OperatorKind::Add, Op::ADD, 15),
+            (OperatorKind::LogicalAnd, Op::LOGICAL_AND, 21),
+            (OperatorKind::LogicalOr, Op::LOGICAL_OR, 24),
+            (OperatorKind::LogicalXor, Op::LOGICAL_XOR, 25),
+            (
+                OperatorKind::Maximum {
+                    nan_mode: NanPropagationMode::PROPAGATE,
+                },
+                Op::MAXIMUM,
+                26,
+            ),
+            (
+                OperatorKind::Minimum {
+                    nan_mode: NanPropagationMode::PROPAGATE,
+                },
+                Op::MINIMUM,
+                27,
+            ),
+            (OperatorKind::Mul, Op::MUL, 28),
+            (OperatorKind::Pow, Op::POW, 29),
+            (OperatorKind::Sub, Op::SUB, 30),
+            (OperatorKind::Abs, Op::ABS, 32),
+            (OperatorKind::Cos, Op::COS, 36),
+            (OperatorKind::Exp, Op::EXP, 37),
+            (OperatorKind::Log, Op::LOG, 39),
+            (OperatorKind::LogicalNot, Op::LOGICAL_NOT, 40),
+            (OperatorKind::Negate, Op::NEGATE, 41),
+            (OperatorKind::Reciprocal, Op::RECIPROCAL, 42),
+            (OperatorKind::Rsqrt, Op::RSQRT, 43),
+            (OperatorKind::Sin, Op::SIN, 44),
+            (OperatorKind::Select, Op::SELECT, 45),
+            (OperatorKind::Equal, Op::EQUAL, 46),
+            (OperatorKind::Greater, Op::GREATER, 47),
+            (OperatorKind::GreaterEqual, Op::GREATER_EQUAL, 48),
+            (OperatorKind::Reshape, Op::RESHAPE, 57),
+            (OperatorKind::Cast, Op::CAST, 65),
+            (OperatorKind::Const, Op::CONST, 67),
+            (OperatorKind::Identity, Op::IDENTITY, 68),
+            (OperatorKind::ConstShape, Op::CONST_SHAPE, 75),
+        ];
+
+        for (kind, expected_op, expected_attribute) in cases {
+            let tensors = [
+                Tensor::new("input", &[1], DType::FP32),
+                Tensor::new("output", &[1], DType::FP32),
+            ];
+            let shapes = [Shape::new("target", &[1])];
+            let regular_inputs = ["input"];
+            let reshape_inputs = ["input", "target"];
+            let tensor_output = ["output"];
+            let shape_output = ["target"];
+            let (inputs, outputs): (&[&str], &[&str]) = match kind {
+                OperatorKind::Const => (&[], &tensor_output),
+                OperatorKind::ConstShape => (&[], &shape_output),
+                OperatorKind::Reshape => (&reshape_inputs, &tensor_output),
+                _ => (&regular_inputs, &tensor_output),
+            };
+            let operator = [Operator::new(kind, inputs, outputs)];
+            let graph = Graph::new("main", &tensors, &operator, &[], &[]).with_shapes(&shapes);
+            let bytes = graph.serialize();
+            let model = virtio_accel_tosa::parse(&bytes).unwrap();
+            let parsed = model
+                .regions()
+                .next()
+                .unwrap()
+                .blocks()
+                .next()
+                .unwrap()
+                .operators()
+                .next()
+                .unwrap();
+            assert_eq!(parsed.op(), expected_op);
+            assert_eq!(parsed.attribute_kind().get(), expected_attribute);
+        }
     }
 
     #[test]

--- a/crates/virtio-accel-tosa-build/src/lib.rs
+++ b/crates/virtio-accel-tosa-build/src/lib.rs
@@ -1,0 +1,454 @@
+//! Safe authoring of static, single-block TOSA 1.0 artifacts.
+//!
+//! The raw FlatBuffers layout is private to this crate. [`Graph::build`]
+//! round-trips every artifact through `virtio-accel-tosa`'s bounded parser and
+//! complete target validator before returning owned bytes.
+
+#![no_std]
+#![forbid(unsafe_code)]
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+use core::fmt;
+
+use flatbuffers::{FlatBufferBuilder, TableFinishedWIPOffset, WIPOffset};
+use virtio_accel_tosa::{DType, NanPropagationMode, Op, SemanticError, Target};
+
+type Table = WIPOffset<TableFinishedWIPOffset>;
+
+// These are the six stable container-table vtable positions used by the
+// single-block surface. Keeping them here prevents consumers from duplicating
+// schema layout knowledge; the completed artifact is always verified by the
+// ingestion crate before it crosses this API boundary.
+mod slot {
+    pub const TENSOR_NAME: u16 = 4;
+    pub const TENSOR_SHAPE: u16 = 6;
+    pub const TENSOR_TYPE: u16 = 8;
+    pub const TENSOR_DATA: u16 = 10;
+
+    pub const OPERATOR_OP: u16 = 4;
+    pub const OPERATOR_ATTRIBUTE_TYPE: u16 = 6;
+    pub const OPERATOR_ATTRIBUTE: u16 = 8;
+    pub const OPERATOR_INPUTS: u16 = 10;
+    pub const OPERATOR_OUTPUTS: u16 = 12;
+
+    pub const BLOCK_NAME: u16 = 4;
+    pub const BLOCK_OPERATORS: u16 = 6;
+    pub const BLOCK_TENSORS: u16 = 8;
+    pub const BLOCK_INPUTS: u16 = 10;
+    pub const BLOCK_OUTPUTS: u16 = 12;
+
+    pub const REGION_NAME: u16 = 4;
+    pub const REGION_BLOCKS: u16 = 6;
+
+    pub const GRAPH_VERSION: u16 = 4;
+    pub const GRAPH_REGIONS: u16 = 6;
+
+    pub const VERSION_MAJOR: u16 = 4;
+    pub const VERSION_MINOR: u16 = 6;
+    pub const VERSION_PATCH: u16 = 8;
+    pub const VERSION_DRAFT: u16 = 10;
+
+    pub const NAN_MODE: u16 = 4;
+}
+
+/// A statically shaped tensor definition.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Tensor<'a> {
+    /// Unique block-local tensor name.
+    pub name: &'a str,
+    /// Concrete dimensions. Scalars use an empty slice.
+    pub shape: &'a [i32],
+    /// Stable TOSA 1.0 element type.
+    pub dtype: DType,
+    /// Inline constant bytes, when this tensor is produced by `CONST`.
+    pub data: Option<&'a [u8]>,
+}
+
+impl<'a> Tensor<'a> {
+    /// Define a non-constant tensor.
+    pub const fn new(name: &'a str, shape: &'a [i32], dtype: DType) -> Self {
+        Self {
+            name,
+            shape,
+            dtype,
+            data: None,
+        }
+    }
+
+    /// Define a tensor with inline constant storage.
+    pub const fn constant(name: &'a str, shape: &'a [i32], dtype: DType, data: &'a [u8]) -> Self {
+        Self {
+            name,
+            shape,
+            dtype,
+            data: Some(data),
+        }
+    }
+}
+
+/// Typed operator kinds supported by the initial authoring surface.
+///
+/// Variants with no fields still name their exact TOSA attribute table. This
+/// prevents a caller from pairing an opcode with the wrong union member.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum OperatorKind {
+    MatMul,
+    Sigmoid,
+    Tanh,
+    Add,
+    LogicalAnd,
+    LogicalOr,
+    LogicalXor,
+    Maximum { nan_mode: NanPropagationMode },
+    Minimum { nan_mode: NanPropagationMode },
+    Mul,
+    Pow,
+    Sub,
+    Abs,
+    Cos,
+    Exp,
+    Log,
+    LogicalNot,
+    Negate,
+    Reciprocal,
+    Rsqrt,
+    Sin,
+    Select,
+    Equal,
+    Greater,
+    GreaterEqual,
+    Reshape,
+    Cast,
+    Const,
+    Identity,
+}
+
+impl OperatorKind {
+    /// Stable TOSA opcode selected by this typed variant.
+    pub const fn op(self) -> Op {
+        match self {
+            Self::MatMul => Op::MATMUL,
+            Self::Sigmoid => Op::SIGMOID,
+            Self::Tanh => Op::TANH,
+            Self::Add => Op::ADD,
+            Self::LogicalAnd => Op::LOGICAL_AND,
+            Self::LogicalOr => Op::LOGICAL_OR,
+            Self::LogicalXor => Op::LOGICAL_XOR,
+            Self::Maximum { .. } => Op::MAXIMUM,
+            Self::Minimum { .. } => Op::MINIMUM,
+            Self::Mul => Op::MUL,
+            Self::Pow => Op::POW,
+            Self::Sub => Op::SUB,
+            Self::Abs => Op::ABS,
+            Self::Cos => Op::COS,
+            Self::Exp => Op::EXP,
+            Self::Log => Op::LOG,
+            Self::LogicalNot => Op::LOGICAL_NOT,
+            Self::Negate => Op::NEGATE,
+            Self::Reciprocal => Op::RECIPROCAL,
+            Self::Rsqrt => Op::RSQRT,
+            Self::Sin => Op::SIN,
+            Self::Select => Op::SELECT,
+            Self::Equal => Op::EQUAL,
+            Self::Greater => Op::GREATER,
+            Self::GreaterEqual => Op::GREATER_EQUAL,
+            Self::Reshape => Op::RESHAPE,
+            Self::Cast => Op::CAST,
+            Self::Const => Op::CONST,
+            Self::Identity => Op::IDENTITY,
+        }
+    }
+}
+
+/// One operator and its block-local tensor references.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Operator<'a> {
+    pub kind: OperatorKind,
+    pub inputs: &'a [&'a str],
+    pub outputs: &'a [&'a str],
+}
+
+impl<'a> Operator<'a> {
+    pub const fn new(kind: OperatorKind, inputs: &'a [&'a str], outputs: &'a [&'a str]) -> Self {
+        Self {
+            kind,
+            inputs,
+            outputs,
+        }
+    }
+}
+
+/// A static TOSA graph containing one region and one basic block.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Graph<'a> {
+    pub name: &'a str,
+    pub tensors: &'a [Tensor<'a>],
+    pub operators: &'a [Operator<'a>],
+    pub inputs: &'a [&'a str],
+    pub outputs: &'a [&'a str],
+}
+
+impl<'a> Graph<'a> {
+    pub const fn new(
+        name: &'a str,
+        tensors: &'a [Tensor<'a>],
+        operators: &'a [Operator<'a>],
+        inputs: &'a [&'a str],
+        outputs: &'a [&'a str],
+    ) -> Self {
+        Self {
+            name,
+            tensors,
+            operators,
+            inputs,
+            outputs,
+        }
+    }
+
+    /// Serialize and semantically validate this graph for `target`.
+    ///
+    /// The returned vector is the only allocation retained by the caller.
+    /// Construction is linear in graph metadata and constant bytes. Validation
+    /// runs once on this cold authoring path; providers still perform their own
+    /// authoritative admission during `load_program`.
+    pub fn build(self, target: Target) -> Result<Vec<u8>, BuildError> {
+        self.check_static_surface()?;
+        let bytes = self.serialize();
+        let model = virtio_accel_tosa::parse(&bytes).map_err(BuildError::Parse)?;
+        model.validate_for(target).map_err(BuildError::Semantic)?;
+        Ok(bytes)
+    }
+
+    fn check_static_surface(self) -> Result<(), BuildError> {
+        if self.name.is_empty() {
+            return Err(BuildError::EmptyGraphName);
+        }
+        for tensor in self.tensors {
+            if tensor.shape.iter().any(|dimension| *dimension < 0) {
+                return Err(BuildError::DynamicShape);
+            }
+            if !tensor.dtype.is_tosa_1_0() {
+                return Err(BuildError::UnsupportedDType(tensor.dtype));
+            }
+        }
+        Ok(())
+    }
+
+    fn serialize(self) -> Vec<u8> {
+        let mut builder = FlatBufferBuilder::with_capacity(4096);
+
+        let tensors = {
+            let tables: Vec<_> = self
+                .tensors
+                .iter()
+                .map(|tensor| tensor_table(&mut builder, *tensor))
+                .collect();
+            builder.create_vector(&tables)
+        };
+        let operators = {
+            let tables: Vec<_> = self
+                .operators
+                .iter()
+                .map(|operator| operator_table(&mut builder, *operator))
+                .collect();
+            builder.create_vector(&tables)
+        };
+        let block = {
+            let name = builder.create_string(self.name);
+            let inputs = string_vector(&mut builder, self.inputs);
+            let outputs = string_vector(&mut builder, self.outputs);
+            let table = builder.start_table();
+            builder.push_slot_always(slot::BLOCK_NAME, name);
+            builder.push_slot_always(slot::BLOCK_OPERATORS, operators);
+            builder.push_slot_always(slot::BLOCK_TENSORS, tensors);
+            builder.push_slot_always(slot::BLOCK_INPUTS, inputs);
+            builder.push_slot_always(slot::BLOCK_OUTPUTS, outputs);
+            builder.end_table(table)
+        };
+        let region = {
+            let name = builder.create_string(self.name);
+            let blocks = builder.create_vector(&[block]);
+            let table = builder.start_table();
+            builder.push_slot_always(slot::REGION_NAME, name);
+            builder.push_slot_always(slot::REGION_BLOCKS, blocks);
+            builder.end_table(table)
+        };
+        let graph = {
+            let version = {
+                let table = builder.start_table();
+                builder.push_slot::<i32>(slot::VERSION_MAJOR, 1, -1);
+                builder.push_slot::<i32>(slot::VERSION_MINOR, 0, -1);
+                builder.push_slot::<i32>(slot::VERSION_PATCH, 0, -1);
+                builder.push_slot::<bool>(slot::VERSION_DRAFT, false, true);
+                builder.end_table(table)
+            };
+            let regions = builder.create_vector(&[region]);
+            let table = builder.start_table();
+            builder.push_slot_always(slot::GRAPH_VERSION, version);
+            builder.push_slot_always(slot::GRAPH_REGIONS, regions);
+            builder.end_table(table)
+        };
+
+        builder.finish(graph, Some("TOSA"));
+        builder.finished_data().to_vec()
+    }
+}
+
+fn tensor_table(builder: &mut FlatBufferBuilder<'_>, tensor: Tensor<'_>) -> Table {
+    let name = builder.create_string(tensor.name);
+    let shape = builder.create_vector(tensor.shape);
+    let data = tensor.data.map(|bytes| builder.create_vector(bytes));
+    let table = builder.start_table();
+    builder.push_slot_always(slot::TENSOR_NAME, name);
+    builder.push_slot_always(slot::TENSOR_SHAPE, shape);
+    builder.push_slot::<u32>(slot::TENSOR_TYPE, tensor.dtype.get(), 0);
+    if let Some(data) = data {
+        builder.push_slot_always(slot::TENSOR_DATA, data);
+    }
+    builder.end_table(table)
+}
+
+fn operator_table(builder: &mut FlatBufferBuilder<'_>, operator: Operator<'_>) -> Table {
+    let inputs = string_vector(builder, operator.inputs);
+    let outputs = string_vector(builder, operator.outputs);
+    let attribute = {
+        let table = builder.start_table();
+        match operator.kind {
+            OperatorKind::Maximum { nan_mode } | OperatorKind::Minimum { nan_mode } => {
+                builder.push_slot::<u32>(slot::NAN_MODE, nan_mode.get(), 0);
+            }
+            _ => {}
+        }
+        builder.end_table(table)
+    };
+    let op = operator.kind.op();
+    let table = builder.start_table();
+    builder.push_slot::<u32>(slot::OPERATOR_OP, op.get(), 0);
+    // In the pinned TOSA 1.0 schema, stable Attribute union members are in
+    // the same order as their corresponding stable Op values.
+    builder.push_slot::<u8>(slot::OPERATOR_ATTRIBUTE_TYPE, op.get() as u8, 0);
+    builder.push_slot_always(slot::OPERATOR_ATTRIBUTE, attribute);
+    builder.push_slot_always(slot::OPERATOR_INPUTS, inputs);
+    builder.push_slot_always(slot::OPERATOR_OUTPUTS, outputs);
+    builder.end_table(table)
+}
+
+fn string_vector<'a>(
+    builder: &mut FlatBufferBuilder<'a>,
+    values: &[&str],
+) -> WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<&'a str>>> {
+    let offsets: Vec<_> = values
+        .iter()
+        .map(|value| builder.create_string(value))
+        .collect();
+    builder.create_vector(&offsets)
+}
+
+/// Failure to construct a static graph accepted by the shared TOSA target.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum BuildError {
+    EmptyGraphName,
+    DynamicShape,
+    UnsupportedDType(DType),
+    Parse(virtio_accel_tosa::Error),
+    Semantic(SemanticError),
+}
+
+impl fmt::Display for BuildError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyGraphName => formatter.write_str("graph name must not be empty"),
+            Self::DynamicShape => {
+                formatter.write_str("the single-block authoring surface requires static shapes")
+            }
+            Self::UnsupportedDType(dtype) => {
+                write!(formatter, "unsupported TOSA 1.0 dtype {dtype:?}")
+            }
+            Self::Parse(error) => write!(
+                formatter,
+                "constructed artifact failed structural validation: {error}"
+            ),
+            Self::Semantic(error) => write!(
+                formatter,
+                "constructed artifact failed semantic validation: {error}"
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use virtio_accel_tosa::{ExtensionSet, Level, ProfileSet, Version};
+
+    const FLOAT_TARGET: Target = Target::new(
+        Version::TOSA_1_0,
+        ProfileSet::FLOATING_POINT,
+        Level::Level8K,
+        ExtensionSet::NONE,
+    );
+
+    #[test]
+    fn identity_round_trips_through_production_validation() {
+        let tensors = [
+            Tensor::new("input", &[1, 4], DType::FP32),
+            Tensor::new("output", &[1, 4], DType::FP32),
+        ];
+        let operators = [Operator::new(
+            OperatorKind::Identity,
+            &["input"],
+            &["output"],
+        )];
+        let graph = Graph::new("main", &tensors, &operators, &["input"], &["output"]);
+
+        let first = graph.build(FLOAT_TARGET).unwrap();
+        let second = graph.build(FLOAT_TARGET).unwrap();
+        assert_eq!(first, second);
+
+        let model = virtio_accel_tosa::parse(&first).unwrap();
+        model.validate_for(FLOAT_TARGET).unwrap();
+        let block = model.regions().next().unwrap().blocks().next().unwrap();
+        assert_eq!(block.operators().next().unwrap().op(), Op::IDENTITY);
+    }
+
+    #[test]
+    fn constants_and_typed_nan_attributes_round_trip() {
+        let one = 1.0_f32.to_le_bytes();
+        let tensors = [
+            Tensor::new("lhs", &[1], DType::FP32),
+            Tensor::constant("rhs", &[1], DType::FP32, &one),
+            Tensor::new("output", &[1], DType::FP32),
+        ];
+        let operators = [
+            Operator::new(OperatorKind::Const, &[], &["rhs"]),
+            Operator::new(
+                OperatorKind::Maximum {
+                    nan_mode: NanPropagationMode::PROPAGATE,
+                },
+                &["lhs", "rhs"],
+                &["output"],
+            ),
+        ];
+        let bytes = Graph::new("main", &tensors, &operators, &["lhs"], &["output"])
+            .build(FLOAT_TARGET)
+            .unwrap();
+
+        let model = virtio_accel_tosa::parse(&bytes).unwrap();
+        let block = model.regions().next().unwrap().blocks().next().unwrap();
+        assert_eq!(block.operators().len(), 2);
+    }
+
+    #[test]
+    fn rejects_dynamic_shapes_before_serialization() {
+        let tensors = [Tensor::new("value", &[-1], DType::FP32)];
+        let graph = Graph::new("main", &tensors, &[], &["value"], &["value"]);
+        assert!(matches!(
+            graph.build(FLOAT_TARGET),
+            Err(BuildError::DynamicShape)
+        ));
+    }
+}

--- a/docs/portability.md
+++ b/docs/portability.md
@@ -36,7 +36,7 @@ directly, and they must keep working on any platform the portable crates support
 | Tier | Crates | Allowed runtime surface |
 |---|---|---|
 | `core-only` | `virtio-accel-cleanroom`, `virtio-accel-proto`, `virtio-accel-transport`, `virtio-accel-core` | `core`; the clean-room codec and transport ports have no normal/build dependencies, while proc-macros used by other crates may execute with `std` on the build host |
-| `alloc-portable` | `virtio-accel-guest`, `virtio-accel-split-queue`, `virtio-accel-device`, `virtio-accel-tosa`, `virtio-accel` | `core + alloc`; no OS, filesystem, sockets, threads, or host synchronization |
+| `alloc-portable` | `virtio-accel-guest`, `virtio-accel-split-queue`, `virtio-accel-device`, `virtio-accel-tosa`, `virtio-accel-tosa-build`, `virtio-accel` | `core + alloc`; no OS, filesystem, sockets, threads, or host synchronization |
 | `std-reference` | `virtio-accel-mock`, `virtio-accel-conformance` | Portable `std`; no host-OS or vendor-specific API |
 | `host-native` | `virtio-accel-coreml`, `virtio-accel-openvino`, `virtio-accel-hexagon` | Core ML/Foundation on macOS 14+, the OpenVINO C runtime (`libopenvino_c` 2026.x), or the complete QAIRT/QNN C SDK on Windows ARM64 when detected at build time; a compile-only unsupported-platform or unsupported-runtime placeholder elsewhere |
 

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -3,8 +3,8 @@
 The public Rust API is split into three documentation layers:
 
 1. Human-facing contracts in `virtio-accel-core`, `virtio-accel-guest`,
-   `virtio-accel-device`, `virtio-accel-transport`, `virtio-accel-tosa`, and
-   `virtio-accel-conformance`.
+   `virtio-accel-device`, `virtio-accel-transport`, `virtio-accel-tosa`,
+   `virtio-accel-tosa-build`, and `virtio-accel-conformance`.
 2. Pointer-free wire mirrors in `virtio-accel-proto` and the checked C projection in
    [`include/virtio_accel.h`](../include/virtio_accel.h).
 3. Independent conformance artifacts and the clean-room codec under `conformance/`.
@@ -44,6 +44,10 @@ plan intended for provider lowering, and retains verified `Operator`/`Tensor`/`S
 than copying an owned graph. Dynamic providers can validate host-readable CTC values and use the
 bounded exact-key specialization cache. Provider-specific capability utilities extend the layer
 through `ModelValidator`; generated FlatBuffers tables and unchecked roots remain private.
+
+`virtio-accel-tosa-build` is the authoring companion, not a second ingestion path. It exposes only
+owned output bytes and typed static graph definitions, keeps raw table slots and union tags private,
+and invokes `virtio-accel-tosa` structural and target validation before returning success.
 
 ## Runnable entry points
 

--- a/docs/release-policy.md
+++ b/docs/release-policy.md
@@ -135,7 +135,7 @@ declares its own `description` and `readme`, and carries its own byte-identical 
 root license files do not reach the sub-crate tarballs; the copies exist for that reason and are
 copies rather than symlinks because CI runs `windows-latest`.
 
-`ci/check-release-policy.py` enforces all of this against an explicit fourteen-crate allowlist. A new
+`ci/check-release-policy.py` enforces all of this against an explicit sixteen-crate allowlist. A new
 package fails that check until it is added to the allowlist, which forces a decision about whether
 it is public rather than letting it default either way. The check also validates the crates.io
 keyword and category limits, which neither `cargo package` nor `cargo publish --dry-run` catches

--- a/docs/release-policy.md
+++ b/docs/release-policy.md
@@ -145,7 +145,7 @@ The `fuzz/` harness is a separate workspace at version `0.0.0` and stays `publis
 
 ## Publication, yank, and rollback
 
-Thirteen packages are published to crates.io. Publication is ordered: a crate cannot be published before
+Sixteen packages are published to crates.io. Publication is ordered: a crate cannot be published before
 every crate it depends on, and that includes development dependencies, because a published crate's
 versioned dev-dependencies must resolve from the registry for `cargo test` to run on the packaged
 source.
@@ -157,22 +157,24 @@ source.
 | 3 | `virtio-accel-proto` | — | `cleanroom` |
 | 4 | `virtio-accel-core` | `transport` | — |
 | 5 | `virtio-accel-tosa` | `core`, FlatBuffers | — |
-| 6 | `virtio-accel-split-queue` | `transport` | — |
-| 7 | `virtio-accel-guest` | `proto`, `transport` | `split-queue` |
-| 8 | `virtio-accel-mock` | `core` | — |
-| 9 | `virtio-accel-device` | `core`, `proto`, `transport` | `mock` |
-| 10 | `virtio-accel-conformance` | `core` | `mock`, `tosa` |
-| 11 | `virtio-accel-coreml` | `core`, `tosa` | `conformance` |
-| 12 | `virtio-accel-openvino` | `core`, `tosa` | `conformance` |
-| 13 | `virtio-accel-hexagon` | `core`, `tosa` | `conformance` |
-| 14 | `virtio-accel` | the six runtime crates | `conformance`, `mock`, `cleanroom` |
+| 6 | `virtio-accel-tosa-build` | `tosa`, FlatBuffers | — |
+| 7 | `virtio-accel-split-queue` | `transport` | — |
+| 8 | `virtio-accel-guest` | `proto`, `transport` | `split-queue` |
+| 9 | `virtio-accel-mock` | `core` | — |
+| 10 | `virtio-accel-device` | `core`, `proto`, `transport` | `mock` |
+| 11 | `virtio-accel-conformance` | `core` | `mock`, `tosa` |
+| 12 | `virtio-accel-vaccel` | `core` | `conformance` |
+| 13 | `virtio-accel-coreml` | `core`, `tosa` | `conformance` |
+| 14 | `virtio-accel-openvino` | `core`, `tosa` | `conformance` |
+| 15 | `virtio-accel-hexagon` | `core`, `tosa` | `conformance` |
+| 16 | `virtio-accel` | the six runtime crates | `conformance`, `mock`, `cleanroom` |
 
 This order is executable, not just documentary: `ci/publish-dry-run.py` walks it against an isolated
 local registry, adding each crate only after it has been built, tested, and documented from its own
 extracted tarball. A crate can therefore only ever resolve its predecessors, so a wrong order fails
 with an unresolvable dependency instead of passing quietly. The same script is a required CI job.
 
-All fourteen packages share the workspace version and are published together. A GitHub release tag
+All sixteen packages share the workspace version and are published together. A GitHub release tag
 must be exactly `v<workspace-version>` and must point at the commit being released. Publishing a
 GitHub release triggers `.github/workflows/publish.yml`, which checks out that tag, runs the release
 policy checks and publication-driver tests, repeats the full ordered local-registry dry run on the


### PR DESCRIPTION
## Why

Axiom currently hand-encodes FlatBuffer table slots, TOSA discriminants, union tags, and finalization in its artifact lowerer. That duplication is brittle and puts schema layout knowledge in every compiler frontend.

This adds a separately published `virtio-accel-tosa-build` companion for static single-block graphs. Its typed tensor, shape, constant, and operator surface covers the operator families Axiom currently emits, keeps raw layout details private, produces deterministic bytes, and round-trips every successful build through `virtio-accel-tosa::parse` and `Model::validate_for`.

Closes #111.

## Compatibility

- [x] **No wire effect.** This changes no accepted or emitted virtio protocol bytes. It adds an optional host-side Rust authoring crate for the existing opaque TOSA artifact format.

## Systemic review

- The ingestion trust boundary remains unchanged: generated/unchecked parser bindings stay private and the existing bounded parser remains authoritative.
- `RESHAPE` consumes a typed shape value produced by `CONST_SHAPE`; inline tensor data is nonempty, exactly sized by semantic validation, and accepted only behind a `CONST` producer.
- This is a cold artifact-authoring path. It allocates output and temporary FlatBuffer plus validation metadata once; no provider load or submission hot path changes.
- The new `no_std + alloc` crate is added to portable-target and dependency-policy CI and to the ordered, checksum-safe publication graph.

## Checklist

- [x] Does not alter payload lengths, ownership, reset, error, timeout, or feature-negotiation behavior.
- [x] Versioned conformance artifacts and performance budgets remain authoritative inputs.
- [x] The new public Rust API and publication dependency are documented.
- [x] No platform behavior enters a portable crate.
- [x] No unsafe code was added.
- [x] Deferred optional protocol features remain unadvertised.

## Verification

Passed:

- `cargo fmt --all -- --check`
- `python3 ci/check-release-policy.py` (16 published packages)
- `bash ci/check-portable-dependencies.sh`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps`
- `cargo test --workspace --all-targets --all-features --exclude virtio-accel-coreml`
- focused companion tests: 6 passed, including typed `RESHAPE`, constant-producer enforcement, and every operator opcode/union tag
- portable companion checks on `aarch64-unknown-none`, `riscv64gc-unknown-none-elf`, and `wasm32-unknown-unknown`
- extracted package build/test/doc for `virtio-accel-tosa-build`
- publication-driver unit tests: 5 passed

The unfiltered workspace test and full publication dry run reach the native Core ML suite on this Mac, where the existing backend fails model loading with `External { domain: 1923056564, code: 3 }` (15 failures). The dry run had already packaged, rebuilt, tested, documented, and registered the new companion crate before reaching that unrelated host-specific failure.