### PR TITLE
Add incremental TOSA graph authoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,9 @@ and [operator matrix](docs/hexagon-operator-matrix.md).
 
 Independently of backend execution, `virtio-accel-tosa` validates the TOSA 1.0 profiles and
 extensions for all five dtype columns, and `virtio-accel-conformance` ships shared fixtures and
-oracles for them. `virtio-accel-tosa-build` provides the matching safe authoring path for static
-single-block graphs and validates every result through that ingestion boundary. The byte-oriented
+oracles for them. `virtio-accel-tosa-build` provides matching borrowed and incrementally owned safe
+authoring paths for static single-block graphs and validates every result through that ingestion
+boundary. The byte-oriented
 `virtio-accel-mock` backend remains test infrastructure rather than a typed hardware implementation.
 
 ## Workspace
@@ -83,7 +84,7 @@ single-block graphs and validates every result through that ingestion boundary. 
 | `virtio-accel-transport`   | `core`         | Dependency-free descriptor-chain, queue, reset, and notification ports                                       |
 | `virtio-accel-core`        | `core`         | Backend lifecycle, memory, program, queue, and event contracts                                               |
 | `virtio-accel-tosa`        | `core + alloc` | Bounded zero-copy TOSA 1.0 validation, lowering analysis, specialization, and packed low-precision utilities |
-| `virtio-accel-tosa-build`  | `core + alloc` | Typed static TOSA 1.0 authoring with mandatory parser and semantic-validation round trips                     |
+| `virtio-accel-tosa-build`  | `core + alloc` | Borrowed and incrementally owned static TOSA 1.0 authoring with mandatory validation round trips             |
 | `virtio-accel-vaccel`      | `core`         | Adapter seam for mapping native provider contracts (including vAccel-style backends) to `virtio-accel-core` |
 | `virtio-accel-coreml`      | macOS `std`    | TOSA-to-Core ML lowering, direct buffers, and asynchronous ANE-capable prediction                            |
 | `virtio-accel-openvino`    | Linux `std` (probed) | TOSA-to-OpenVINO IR lowering, direct host-pointer tensors, and asynchronous NPU/GPU/CPU inference      |
@@ -173,8 +174,10 @@ dense IDs, topological order, liveness, runtime obligations, and specialization 
 OpenVINO, or another provider. It is intentionally not re-exported by the facade.
 
 Add `virtio-accel-tosa-build = "0.3"` to produce static single-block TOSA artifacts through typed
-tensor and operator definitions. Successful builds have already passed the same parser and target
-validator providers use at admission.
+tensor and operator definitions. Borrowed definitions suit graph literals; owned definitions let
+compiler frontends assemble runtime-discovered metadata without a parallel owned-to-borrowed
+adapter, while existing constant storage can remain borrowed. Both surfaces pass the same parser
+and target validator providers use at admission.
 
 ## Production TOSA-to-Core ML example
 

--- a/crates/virtio-accel-tosa-build/README.md
+++ b/crates/virtio-accel-tosa-build/README.md
@@ -6,7 +6,9 @@ static, single-block graphs without exposing generated FlatBuffers bindings,
 table slots, union tags, or raw enum discriminants to callers.
 
 The crate is `no_std + alloc`; it needs no `flatc`, filesystem, host runtime,
-or provider SDK. `Graph::build` validates every completed artifact with the
+or provider SDK. Borrowed `Graph` definitions serve statically declared graphs,
+while `OwnedGraph` supports compiler frontends that discover graph metadata
+incrementally. Both build paths validate every completed artifact with the
 production `virtio-accel-tosa` parser and semantic validator before returning
 bytes, so successful output is immediately usable as an `ArtifactRef`.
 
@@ -42,6 +44,36 @@ let bytes = Graph::new(
 # Ok::<(), virtio_accel_tosa_build::BuildError>(())
 ```
 
+Frontends can build the same artifact without maintaining parallel owned and borrowed adapter
+structures:
+
+```rust
+use virtio_accel_tosa::{
+    DType, ExtensionSet, Level, ProfileSet, Target, Version,
+};
+use virtio_accel_tosa_build::{OwnedGraph, OwnedOperator, OwnedTensor, OperatorKind};
+
+let mut graph = OwnedGraph::new("main");
+graph
+    .push_tensor(OwnedTensor::new("input", vec![1], DType::FP32))
+    .push_tensor(OwnedTensor::new("output", vec![1], DType::FP32))
+    .push_operator(OwnedOperator::new(
+        OperatorKind::Identity,
+        vec!["input".into()],
+        vec!["output".into()],
+    ))
+    .push_input("input")
+    .push_output("output");
+let target = Target::new(
+    Version::TOSA_1_0,
+    ProfileSet::FLOATING_POINT,
+    Level::Level8K,
+    ExtensionSet::NONE,
+);
+let bytes = graph.build(target)?;
+# Ok::<(), virtio_accel_tosa_build::BuildError>(())
+```
+
 Compile-time shape operands use the separate typed `Shape` namespace and a `ConstShape` producer:
 
 ```rust
@@ -66,11 +98,13 @@ let bytes = Graph::new("main", &tensors, &operators, &["input"], &["output"])
 Inline tensor bytes are accepted only for a nonempty, exactly sized `Tensor::constant` produced by
 `OperatorKind::Const`; this prevents authoring data that ingestion would classify as nonconstant.
 
-The initial surface deliberately covers the static operator set exercised by
-current compiler frontends. Attribute-bearing operators use typed fields; an
-unsupported operator cannot be smuggled in as a raw number. Multi-block
+The surface deliberately covers the static operator set exercised by current compiler frontends.
+The borrowed and owned graph definitions feed one serializer and validator; the owned surface adds
+frontend-friendly metadata storage and incremental assembly, while constants can be either moved in
+or borrowed without copying. Attribute-bearing operators use typed fields, so an unsupported
+operator cannot be smuggled in as a raw number. Multi-block
 control flow, dynamic shapes, variables, external tensor data, and custom
-operators remain outside this first authoring boundary.
+operators remain outside this authoring boundary.
 
 ## License
 

--- a/crates/virtio-accel-tosa-build/src/lib.rs
+++ b/crates/virtio-accel-tosa-build/src/lib.rs
@@ -1,15 +1,18 @@
 //! Safe authoring of static, single-block TOSA 1.0 artifacts.
 //!
-//! The raw FlatBuffers layout is private to this crate. [`Graph::build`]
-//! round-trips every artifact through `virtio-accel-tosa`'s bounded parser and
-//! complete target validator before returning owned bytes.
+//! The raw FlatBuffers layout is private to this crate. Borrowed [`Graph`] definitions suit
+//! statically declared artifacts, while [`OwnedGraph`] supports frontends that discover names,
+//! shapes, constants, and operators incrementally. Both surfaces round-trip every artifact through
+//! `virtio-accel-tosa`'s bounded parser and complete target validator before returning owned bytes.
 
 #![no_std]
 #![forbid(unsafe_code)]
 
 extern crate alloc;
 
+use alloc::borrow::Cow;
 use alloc::collections::BTreeSet;
+use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use core::fmt;
 
@@ -203,6 +206,238 @@ impl<'a> Operator<'a> {
             kind,
             inputs,
             outputs,
+        }
+    }
+}
+
+/// An owned compile-time shape for incrementally assembled graphs.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OwnedShape {
+    pub name: String,
+    pub values: Vec<i64>,
+}
+
+impl OwnedShape {
+    pub fn new(name: impl Into<String>, values: Vec<i64>) -> Self {
+        Self {
+            name: name.into(),
+            values,
+        }
+    }
+}
+
+impl From<Shape<'_>> for OwnedShape {
+    fn from(shape: Shape<'_>) -> Self {
+        Self::new(shape.name, shape.values.to_vec())
+    }
+}
+
+/// An owned tensor definition for incrementally assembled graphs.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OwnedTensor<'a> {
+    pub name: String,
+    pub shape: Vec<i32>,
+    pub dtype: DType,
+    /// Inline constant bytes. Existing frontend storage may be borrowed to avoid a second copy;
+    /// newly transformed data can be moved into this field.
+    pub data: Option<Cow<'a, [u8]>>,
+}
+
+impl<'a> OwnedTensor<'a> {
+    /// Define a non-constant owned tensor.
+    pub fn new(name: impl Into<String>, shape: Vec<i32>, dtype: DType) -> Self {
+        Self {
+            name: name.into(),
+            shape,
+            dtype,
+            data: None,
+        }
+    }
+
+    /// Define an owned tensor with inline constant storage.
+    pub fn constant(
+        name: impl Into<String>,
+        shape: Vec<i32>,
+        dtype: DType,
+        data: impl Into<Cow<'a, [u8]>>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            shape,
+            dtype,
+            data: Some(data.into()),
+        }
+    }
+}
+
+impl<'a> From<Tensor<'a>> for OwnedTensor<'a> {
+    fn from(tensor: Tensor<'a>) -> Self {
+        match tensor.data {
+            Some(data) => Self::constant(tensor.name, tensor.shape.to_vec(), tensor.dtype, data),
+            None => Self::new(tensor.name, tensor.shape.to_vec(), tensor.dtype),
+        }
+    }
+}
+
+/// An owned typed operator for incrementally assembled graphs.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OwnedOperator {
+    pub kind: OperatorKind,
+    pub inputs: Vec<String>,
+    pub outputs: Vec<String>,
+}
+
+impl OwnedOperator {
+    /// Define an operator from owned operand names.
+    pub const fn new(kind: OperatorKind, inputs: Vec<String>, outputs: Vec<String>) -> Self {
+        Self {
+            kind,
+            inputs,
+            outputs,
+        }
+    }
+}
+
+impl From<Operator<'_>> for OwnedOperator {
+    fn from(operator: Operator<'_>) -> Self {
+        Self::new(
+            operator.kind,
+            operator
+                .inputs
+                .iter()
+                .map(|name| (*name).to_string())
+                .collect(),
+            operator
+                .outputs
+                .iter()
+                .map(|name| (*name).to_string())
+                .collect(),
+        )
+    }
+}
+
+/// An owned, incrementally assembled static TOSA graph.
+///
+/// This surface is intended for compiler frontends whose names, shapes, constants, and operator
+/// lists are discovered at runtime. It owns names and metadata while permitting explicit borrowing
+/// of existing constant storage. It creates borrowed [`Graph`] views only during [`Self::build`],
+/// so callers do not need parallel adapter structures. The same structural and target validation
+/// as [`Graph::build`] remains authoritative.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OwnedGraph<'a> {
+    pub name: String,
+    pub tensors: Vec<OwnedTensor<'a>>,
+    pub shapes: Vec<OwnedShape>,
+    pub operators: Vec<OwnedOperator>,
+    pub inputs: Vec<String>,
+    pub outputs: Vec<String>,
+}
+
+impl<'a> OwnedGraph<'a> {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            tensors: Vec::new(),
+            shapes: Vec::new(),
+            operators: Vec::new(),
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+        }
+    }
+
+    pub fn push_tensor(&mut self, tensor: OwnedTensor<'a>) -> &mut Self {
+        self.tensors.push(tensor);
+        self
+    }
+
+    pub fn push_shape(&mut self, shape: OwnedShape) -> &mut Self {
+        self.shapes.push(shape);
+        self
+    }
+
+    pub fn push_operator(&mut self, operator: OwnedOperator) -> &mut Self {
+        self.operators.push(operator);
+        self
+    }
+
+    pub fn push_input(&mut self, name: impl Into<String>) -> &mut Self {
+        self.inputs.push(name.into());
+        self
+    }
+
+    pub fn push_output(&mut self, name: impl Into<String>) -> &mut Self {
+        self.outputs.push(name.into());
+        self
+    }
+
+    /// Serialize and semantically validate this graph for `target`.
+    ///
+    /// The graph remains reusable after a build. All metadata views allocated here are transient;
+    /// the returned artifact bytes are the only allocation retained by the caller.
+    pub fn build(&self, target: Target) -> Result<Vec<u8>, BuildError> {
+        let tensors: Vec<_> = self
+            .tensors
+            .iter()
+            .map(|tensor| match &tensor.data {
+                Some(data) => {
+                    Tensor::constant(&tensor.name, &tensor.shape, tensor.dtype, data.as_ref())
+                }
+                None => Tensor::new(&tensor.name, &tensor.shape, tensor.dtype),
+            })
+            .collect();
+        let shapes: Vec<_> = self
+            .shapes
+            .iter()
+            .map(|shape| Shape::new(&shape.name, &shape.values))
+            .collect();
+        let operator_inputs: Vec<Vec<&str>> = self
+            .operators
+            .iter()
+            .map(|operator| operator.inputs.iter().map(String::as_str).collect())
+            .collect();
+        let operator_outputs: Vec<Vec<&str>> = self
+            .operators
+            .iter()
+            .map(|operator| operator.outputs.iter().map(String::as_str).collect())
+            .collect();
+        let operators: Vec<_> = self
+            .operators
+            .iter()
+            .enumerate()
+            .map(|(index, operator)| {
+                Operator::new(
+                    operator.kind,
+                    &operator_inputs[index],
+                    &operator_outputs[index],
+                )
+            })
+            .collect();
+        let inputs: Vec<_> = self.inputs.iter().map(String::as_str).collect();
+        let outputs: Vec<_> = self.outputs.iter().map(String::as_str).collect();
+
+        Graph::new(&self.name, &tensors, &operators, &inputs, &outputs)
+            .with_shapes(&shapes)
+            .build(target)
+    }
+}
+
+impl<'a> From<Graph<'a>> for OwnedGraph<'a> {
+    fn from(graph: Graph<'a>) -> Self {
+        Self {
+            name: graph.name.to_string(),
+            tensors: graph.tensors.iter().copied().map(Into::into).collect(),
+            shapes: graph.shapes.iter().copied().map(Into::into).collect(),
+            operators: graph.operators.iter().copied().map(Into::into).collect(),
+            inputs: graph
+                .inputs
+                .iter()
+                .map(|name| (*name).to_string())
+                .collect(),
+            outputs: graph
+                .outputs
+                .iter()
+                .map(|name| (*name).to_string())
+                .collect(),
         }
     }
 }
@@ -501,6 +736,7 @@ impl fmt::Display for BuildError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec;
     use virtio_accel_tosa::{ExtensionSet, Level, ProfileSet, Version};
 
     const FLOAT_TARGET: Target = Target::new(
@@ -558,6 +794,101 @@ mod tests {
         let model = virtio_accel_tosa::parse(&bytes).unwrap();
         let block = model.regions().next().unwrap().blocks().next().unwrap();
         assert_eq!(block.operators().len(), 2);
+    }
+
+    #[test]
+    fn incrementally_owned_graph_matches_borrowed_artifact_bytes() {
+        let one = 1.0_f32.to_le_bytes();
+        let tensors = [
+            Tensor::new("lhs", &[1], DType::FP32),
+            Tensor::constant("rhs", &[1], DType::FP32, &one),
+            Tensor::new("output", &[1], DType::FP32),
+        ];
+        let operators = [
+            Operator::new(OperatorKind::Const, &[], &["rhs"]),
+            Operator::new(OperatorKind::Add, &["lhs", "rhs"], &["output"]),
+        ];
+        let expected = Graph::new("main", &tensors, &operators, &["lhs"], &["output"])
+            .build(FLOAT_TARGET)
+            .unwrap();
+
+        let mut graph = OwnedGraph::new(String::from("main"));
+        graph
+            .push_tensor(OwnedTensor::new(String::from("lhs"), vec![1], DType::FP32))
+            .push_tensor(OwnedTensor::constant(
+                String::from("rhs"),
+                vec![1],
+                DType::FP32,
+                one.to_vec(),
+            ))
+            .push_tensor(OwnedTensor::new("output", vec![1], DType::FP32))
+            .push_operator(OwnedOperator::new(
+                OperatorKind::Const,
+                vec![],
+                vec![String::from("rhs")],
+            ))
+            .push_operator(OwnedOperator::new(
+                OperatorKind::Add,
+                vec![String::from("lhs"), String::from("rhs")],
+                vec![String::from("output")],
+            ))
+            .push_input(String::from("lhs"))
+            .push_output(String::from("output"));
+
+        let first = graph.build(FLOAT_TARGET).unwrap();
+        let second = graph.build(FLOAT_TARGET).unwrap();
+        assert_eq!(first, expected);
+        assert_eq!(second, expected);
+    }
+
+    #[test]
+    fn borrowed_graph_converts_to_an_incremental_graph() {
+        let tensors = [
+            Tensor::new("input", &[1, 4], DType::FP32),
+            Tensor::new("output", &[2, 2], DType::FP32),
+        ];
+        let shapes = [Shape::new("target", &[2, 2])];
+        let operators = [
+            Operator::new(OperatorKind::ConstShape, &[], &["target"]),
+            Operator::new(OperatorKind::Reshape, &["input", "target"], &["output"]),
+        ];
+        let borrowed =
+            Graph::new("main", &tensors, &operators, &["input"], &["output"]).with_shapes(&shapes);
+        let expected = borrowed.build(FLOAT_TARGET).unwrap();
+
+        let owned = OwnedGraph::from(borrowed);
+        assert_eq!(owned.build(FLOAT_TARGET).unwrap(), expected);
+        assert_eq!(owned.shapes, vec![OwnedShape::new("target", vec![2, 2])]);
+    }
+
+    #[test]
+    fn owned_tensor_can_reuse_existing_constant_storage() {
+        let data = 1.0_f32.to_le_bytes();
+        let tensor = OwnedTensor::constant("value", vec![1], DType::FP32, data.as_slice());
+
+        let Some(Cow::Borrowed(stored)) = tensor.data else {
+            panic!("borrowed constant data was copied");
+        };
+        assert!(core::ptr::eq(stored, data.as_slice()));
+    }
+
+    #[test]
+    fn owned_graph_uses_the_borrowed_validation_contract() {
+        let mut graph = OwnedGraph::new("main");
+        graph
+            .push_tensor(OwnedTensor::constant(
+                "value",
+                vec![1],
+                DType::FP32,
+                1.0_f32.to_le_bytes().to_vec(),
+            ))
+            .push_input("value")
+            .push_output("value");
+
+        assert!(matches!(
+            graph.build(FLOAT_TARGET),
+            Err(BuildError::TensorDataWithoutConst)
+        ));
     }
 
     #[test]

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -48,9 +48,10 @@ target-specific host descriptors for schedulers without adding TOSA concepts to 
 successful discovery never replaces authoritative program admission. Generated FlatBuffers tables
 and unchecked roots remain private.
 
-`virtio-accel-tosa-build` is the authoring companion, not a second ingestion path. It exposes only
-owned output bytes and typed static graph definitions, keeps raw table slots and union tags private,
-and invokes `virtio-accel-tosa` structural and target validation before returning success.
+`virtio-accel-tosa-build` is the authoring companion, not a second ingestion path. It exposes
+borrowed definitions for statically declared graphs and owned definitions for incremental compiler
+frontends, keeps raw table slots and union tags private, and invokes the same `virtio-accel-tosa`
+structural and target validation before either build surface returns owned output bytes.
 
 ## Runnable entry points
 


### PR DESCRIPTION
# Why

`axiom` builds TOSA graphs from runtime-discovered tensor and operator metadata. Even after adopting `virtio-accel-tosa-build` in MicroPerceptron/axiom#44, it still has to maintain local `OwnedTensor`, `OwnedOperator`, and owned-to-borrowed graph conversion types solely to satisfy the crate's borrowed `Graph` surface.

Add an incremental authoring surface that owns frontend metadata and feeds the existing borrowed serializer and validator. Constant storage uses `Cow<[u8]>`: existing AxGraph constants can remain borrowed without a second potentially large copy, while transformed constants can be moved in. Borrowed `Graph` artifacts and incremental `OwnedGraph` artifacts are tested to serialize to identical bytes.

This is intentionally one authoring path, not a second codec. `OwnedGraph::build` materializes transient borrowed views and delegates to `Graph::build`, preserving the existing static-surface checks, bounded parse, and target-semantic validation.

## Compatibility

- [x] **No wire effect.** This changes no accepted or emitted protocol bytes.

## Checklist

- [x] Does not alter payload lengths, ownership, reset, error, timeout, or feature-negotiation behavior.
- [x] `layout.json`, `vectors.json`, `scenarios.json`, `requirements.json`, and performance budgets remain unchanged and authoritative.
- [x] Adds public Rust authoring types in `virtio-accel-tosa-build`; existing borrowed APIs remain unchanged.
- [x] No dependency, Cargo feature, or target moves platform behavior into a portable crate.
- [x] No unsafe code was added; the crate continues to forbid unsafe code.
- [x] Deferred optional features remain unadvertised and out of scope.

## Performance posture

This is a cold artifact-authoring path. It allocates transient borrowed metadata views before calling the canonical serializer. Existing constant byte storage can be borrowed, avoiding an additional model-weight copy; generated or transformed constants can be moved into the graph.

## Verification

Passed locally:

```sh
cargo fmt --all -- --check
python3 ci/check-release-policy.py
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test -p virtio-accel-tosa-build
RUSTDOCFLAGS='-D warnings' cargo doc -p virtio-accel-tosa-build --no-deps
cargo check -p virtio-accel-tosa-build --target aarch64-unknown-none
cargo check -p virtio-accel-tosa-build --target riscv64gc-unknown-none-elf
cargo check -p virtio-accel-tosa-build --target wasm32-unknown-unknown
cargo package --allow-dirty -p virtio-accel-tosa-build
cargo run --example backend_conformance
cargo run --example reference_execution
```

`cargo test --workspace --all-targets --all-features` passed every portable suite reached, then failed 15 native Core ML integration tests with the same host runtime load error (`External { domain: 1923056564, code: 3 }`). The change does not touch Core ML. The full ordered publication dry run and native provider examples are left to Linux/provider CI because the dry run executes that same native all-target suite on this macOS host.
