### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ execution. “Not implemented” describes this repository, not necessarily the 
 | ------------------------------------------- | ---------------------- | ------------------------------------- | --------------- | --------------- | --------------- | --------------- | --------------- | --------------------------- |
 | Apple Core ML / ANE (`virtio-accel-coreml`) | Implemented; macOS 14+ | Static TOSA 1.0 FP; INT8 tier on macOS 26+ | Supported       | Supported       | Not implemented | Identity + MATMUL | Not implemented | Direct host/shared bindings |
 | Intel OpenVINO (`virtio-accel-openvino`)    | Implemented; OpenVINO 2026.x | Static TOSA 1.0 FP + INT8 tier | Supported       | Supported       | Not implemented | Identity + MATMUL | Not implemented | Direct host/shared bindings |
-| AMD XDNA (`virtio-accel-amdxdna`)           | Scaffolded (probe + placeholder) | Not implemented             | Not implemented | Not implemented | Not implemented | Not implemented | Not implemented | Not implemented             |
+| AMD XDNA (`virtio-accel-amdxdna`)           | In Progress | In Progress             | In Progress | In Progress | In Progress | In Progress | In Progress | In Progress             |
 | Qualcomm Hexagon (`virtio-accel-hexagon`)  | Experimental; QAIRT 2.49 on Windows ARM64 | Static TOSA 1.0 FP16 + BOOL/INT32 auxiliaries; INT8 tier | Blocked by v73 precision evidence | 41/42 shared operators (`ERF` blocked) | Blocked: ambiguous encoding | Identity + MATMUL | Not implemented | Direct host/shared bindings |
 
 The Core ML row describes model-boundary support; restricted INT32 outputs are also available.


### PR DESCRIPTION
Change `Not Implemented` -> `In Progress` for XDNA which is accurate.

# Why

<!-- What problem does this solve? The diff shows the "what" — explain the reasoning. -->

## Compatibility

<!-- Delete the line that does not apply. -->

- [x] **No wire effect.** This changes no accepted or emitted protocol bytes.
- [ ] **Wire effect.** Classified under [docs/wire-abi.md §9](../docs/wire-abi.md) as: <!-- erratum / compatible extension / breaking --> and linked to a protocol change proposal.

## Checklist

Derived from the [release review checklist](../docs/release-policy.md). Answer honestly — "not
sure" in the description is more useful than a wrong tick.

- [x] Does not alter payload lengths, ownership, reset, error, timeout, or feature-negotiation
      behavior — or does, and says so above.
- [x] `layout.json`, `vectors.json`, `scenarios.json`, `requirements.json`, and performance budgets
      are still authoritative inputs, not regenerated by accident.
- [x] Public Rust API changes affecting backend, guest, device, or transport authors are called out.
- [x] No dependency, Cargo feature, or target moves platform behavior into a portable crate.
- [x] No unaudited `unsafe` code was added; any confined exception has a local safety argument,
      tests, and release-policy entry.
- [x] Deferred optional features remain unadvertised and documented as out of scope.

## Verification

<!-- Paste the results, or note which you could not run and why. -->

```sh
cargo fmt --all -- --check
python3 ci/check-release-policy.py
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test --workspace --all-targets --all-features
cargo run --example backend_conformance
cargo run --example reference_execution
cargo run -p virtio-accel-coreml --example tosa_coreml
cargo run -p virtio-accel-openvino --example tosa_openvino
cargo run -p virtio-accel-hexagon --example tosa_hexagon
cargo run -p virtio-accel-hexagon --example mock_classifier
python3 ci/publish-dry-run.py
```

<!--
By opening this pull request you agree that your contribution is licensed under
MIT OR Apache-2.0, matching the project. See CONTRIBUTING.md.
-->
