### PR TITLE
Implement the HRX FFI surface, buffer primitives, and SAFETY.md (#87)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,6 +298,7 @@ dependencies = [
 name = "virtio-accel-xdna"
 version = "0.3.3"
 dependencies = [
+ "virtio-accel-core",
  "virtio-accel-tosa",
 ]
 

--- a/ci/check-release-policy.py
+++ b/ci/check-release-policy.py
@@ -76,6 +76,11 @@ CRATE_ROOTS = (
 )
 
 UNSAFE_AUDITS = {
+    ROOT / "crates" / "virtio-accel-xdna" / "src" / "lib.rs": (
+        ROOT / "crates" / "virtio-accel-xdna" / "SAFETY.md",
+        "cfg_attr(not(va_xdna), forbid(unsafe_code))",
+        ("HRX C ABI", "persistent mapping", "hrx_status_t"),
+    ),
     ROOT / "crates" / "virtio-accel-coreml" / "src" / "lib.rs": (
         ROOT / "crates" / "virtio-accel-coreml" / "SAFETY.md",
         'cfg_attr(not(target_os = "macos"), forbid(unsafe_code))',

--- a/crates/virtio-accel-xdna/Cargo.toml
+++ b/crates/virtio-accel-xdna/Cargo.toml
@@ -12,4 +12,5 @@ description = "AMD XDNA (Ryzen AI NPU) host backend for virtio-accel"
 readme = "README.md"
 
 [dependencies]
+virtio-accel-core.workspace = true
 virtio-accel-tosa.workspace = true

--- a/crates/virtio-accel-xdna/README.md
+++ b/crates/virtio-accel-xdna/README.md
@@ -8,12 +8,15 @@ bounded subprocess (never a Cargo dependency, never in-process Python).
 **Portability tier:** `host-native` — the amdxdna-native HRX runtime (`libhrx`) when detected at
 build time; a compile-only unsupported-runtime placeholder elsewhere.
 
-**This crate is currently the scaffold.** It ships the portable admission surface and a
-placeholder; the HRX FFI, the native `Accelerator` implementation, the compiler helper, and the
-executing numerical tiers land in subsequent tickets of the
-[AMD XDNA wayfinder map](https://github.com/MicroPerceptron/virtio-accel/issues/78). The design
-decisions live on their ticket branches: crate layout (#83), compiler helper (#84), execution
-model (#85), and the advertised numerical tier (#82).
+**This crate is under construction.** In a `va_xdna` build it now provides the HRX device/stream
+owner and the `hrx_buffer` primitives — allocation with a persistent host mapping, range
+flush/invalidate, and release — validated on-device by the `tests/hardware.rs` suite. Program
+loading and dispatch report `Unsupported`; the compiler helper and executing numerical tiers land
+in subsequent tickets of the
+[AMD XDNA wayfinder map](https://github.com/MicroPerceptron/virtio-accel/issues/78). Hosts without
+HRX build the portable admission surface plus a placeholder and compile no `unsafe`. The design
+decisions live on their ticket branches: crate layout (#83), FFI/buffers (#87), compiler helper
+(#84), execution model (#85), and the advertised numerical tier (#82).
 
 ## Build-time probe
 
@@ -45,8 +48,9 @@ cargo run -p virtio-accel-xdna --example tosa_xdna
 cargo test -p virtio-accel-xdna
 ```
 
-The example reports the scaffold state and exits successfully; the tests exercise the advertised
-targets on every host.
+Without HRX the example reports the placeholder state; in a `va_xdna` build it initializes the
+device and stream. The portable tests exercise the advertised targets on every host; the
+`va_xdna` `tests/hardware.rs` suite exercises the buffer primitives against a live NPU.
 
 Part of the [`virtio-accel`](https://github.com/MicroPerceptron/virtio-accel) workspace: an
 experimental native-Rust protocol and implementation stack for a transport-neutral virtual

--- a/crates/virtio-accel-xdna/SAFETY.md
+++ b/crates/virtio-accel-xdna/SAFETY.md
@@ -1,32 +1,67 @@
 # Unsafe-code audit
 
-This crate will become a host-native exception to the portable workspace's `forbid(unsafe_code)`
-rule, on the same terms as `virtio-accel-openvino`: unsafe Rust confined to the `va_xdna` build
-configuration — `src/ffi.rs` (HRX C ABI declarations only) and `src/native.rs` (the calls) — with
-the crate root relaxed to `cfg_attr(not(va_xdna), forbid(unsafe_code))` and this file registered
-as the audited exception in `ci/check-release-policy.py`.
+This crate is a host-native exception to the portable workspace's `forbid(unsafe_code)` rule, on
+the same terms as `virtio-accel-openvino`. Unsafe Rust is confined to the `va_xdna` build
+configuration — `src/ffi.rs` (HRX C ABI declarations only) and `src/native.rs` (the calls) — and
+the crate root carries `cfg_attr(not(va_xdna), forbid(unsafe_code))`. Builds without a detected HRX
+runtime compile no `unsafe` at all: only the portable admission surface (`src/lower.rs`) and a
+placeholder.
 
-**Scaffold state.** The native modules do not exist yet. This build compiles **no `unsafe` at
-all** — only the portable admission surface (`src/lower.rs`) and a placeholder — so the crate root
-still forbids unsafe outright. The full audit is authored with the FFI and hardware tickets. Its
-planned structure, transcribed from §4 of the crate-layout design record (issue #83), is:
+Scope implemented so far: the device/stream owner and `hrx_buffer` primitives. Program loading and
+dispatch report `Unsupported`; their FFI and audit land with the execution path (at which point the
+uninhabited `XdnaProgram`/`XdnaEvent` become real types and this file gains their sections).
 
-1. **Boundary statement** — safe admission (`lower.rs`) and safe compiler subprocess
-   (`compiler.rs`); unsafe confined to `ffi.rs` declarations and `native.rs` call sites.
-2. **ABI and runtime lifetime** — refcounted HRX handles with one Rust owner each; construction
-   stores each handle before the next fallible step and releases the initialized prefix on error;
-   every non-NULL `hrx_status_t` is consumed exactly once (`hrx_status_to_string` →
-   `hrx_status_free_message` → `hrx_status_ignore` for both statuses); one process-lifetime HRX
-   context through a single audited shared owner, never shut down.
-3. **Buffers and mappings** — one persistent mapping per buffer, valid until buffer release;
-   mapped access bounded by the allocation; `hrx_buffer_flush_range` after every host write and
-   `hrx_buffer_invalidate_range` before every host read; zero-size allocations rejected before FFI;
-   all `hrx_amdxdna_executable_create` input storage borrowed only for the call.
-4. **Concurrency and the dispatch worker** — all dispatch/synchronize serialized on one worker;
-   device loss is two-tier (kernel TDR yields a terminal `Failed` with buffers safely releasable;
-   a longer worker watchdog covers a true wedge with a never-terminal event whose guards leak until
-   process exit). No cancellation is advertised.
-5. **Teardown ordering** — events terminal → executables released → buffers released → stream →
-   device.
-6. **Audited unsafe operations** — every `unsafe` block carries a local `SAFETY:` comment; the
-   native test inventory is listed here.
+## ABI and status ownership
+
+`src/ffi.rs` declares the HRX C ABI transcribed from the pinned release headers
+(`include/hrx/hrx_runtime.h`, `libhrx.so.0.1.0`, version 0.1.0): opaque refcounted handles, the
+`uint32`/`uint16` bitmask constants, and the `extern "C"` functions this ticket calls. No struct
+layout is invented; handles are opaque pointers.
+
+Every fallible HRX call returns an `hrx_status_t` — an owned, opaque pointer that is `NULL` on
+success and must be consumed exactly once on failure. The single `check` helper in `native.rs`
+enforces this: on a non-NULL status it reads the code, renders the message with
+`hrx_status_to_string` (freeing that message with `hrx_status_free_message`), then `hrx_status_ignore`s
+both the string-status and the original status. No status escapes unconsumed, so none leaks.
+
+## Handle lifetime and teardown
+
+Each HRX handle has exactly one Rust owner with a `Drop`:
+
+- The process-wide device is initialized once through a `OnceLock` (`hrx_gpu_initialize` →
+  `hrx_gpu_device_count` → `hrx_gpu_device_get`) and held in `SharedDevice`. Per the fork's model
+  (one device per process) it is never shut down; `hrx_gpu_shutdown` is never called. `SharedDevice`
+  is `unsafe impl Send + Sync` because it is used only as a read-only factory for per-instance
+  streams and the amdxdna HAL exposes the device as a process-wide singleton.
+- Each `XdnaAccelerator` owns one `hrx_stream_t`, released exactly once in `Drop`. The instance is
+  `!Send`/`!Sync` (a `PhantomData<*mut u8>`): one stream is not safe for concurrent dispatch, so the
+  instance stays single-threaded until the execution path introduces the serialized worker.
+- Each `XdnaBuffer` owns one `hrx_buffer_t` and its persistent mapping, released exactly once in
+  `Drop` (the mapping is released together with the buffer; the fork never unmaps first). Buffers
+  are `!Send`/`!Sync`. Allocation releases the buffer on any post-allocation error path (a failed
+  map or a rejected `BufferInfo`), so no handle leaks on error.
+
+## Buffers and mappings
+
+`allocate_buffer` requests `HOST_LOCAL | DEVICE_VISIBLE` memory with
+`DEFAULT | MAPPING_PERSISTENT` usage, then establishes one persistent `READ | WRITE` mapping over
+the whole buffer (`hrx_buffer_map_with_mode`). The reported alignment is the largest power of two
+dividing the mapping address, which `BufferInfo::new` checks against the requested alignment. Sizes
+are `usize`-checked; `BufferDesc` guarantees a nonzero size (HRX rejects zero).
+
+Host access to the mapping is bounded: `checked_range` validates `[offset, offset+len)` against the
+mapped length before any `slice::from_raw_parts[_mut]`, and every raw slice is confined to that
+validated range. `write_buffer` copies into the mapping then `hrx_buffer_flush_range`s the range
+device-ward; `read_buffer` `hrx_buffer_invalidate_range`s the range then copies out — the explicit
+cache management the persistent mapping requires. An `in_flight` gate (always zero until the
+dispatch path sets it) rejects host access and release while the device may be touching the buffer;
+`free_buffer` returns the live handle via `ReleaseFailure::Rejected` when the gate is set.
+
+## Audited unsafe operations
+
+Every `unsafe` block in `src/native.rs` carries a local `SAFETY:` comment naming the invariant it
+relies on (handle validity, out-pointer locality, status consumption, mapped-range bounds, and
+single-drop ownership). The on-hardware integration tests (`tests/hardware.rs`, `va_xdna` only)
+exercise device info, the allocate / map / write+flush / read+invalidate / release round trip,
+out-of-bounds rejection, and context/queue lifecycle against a live NPU. Unsupported hosts compile
+no native module.

--- a/crates/virtio-accel-xdna/examples/tosa_xdna.rs
+++ b/crates/virtio-accel-xdna/examples/tosa_xdna.rs
@@ -1,13 +1,16 @@
-//! Scaffold example: the native TOSA-to-XDNA execution path is not implemented yet.
+//! Scaffold example: report backend availability.
 //!
-//! It arrives with the HRX FFI, native `Accelerator`, and compiler-helper tickets. For now this
-//! example reports the placeholder state and exits successfully, keeping the example lane green.
+//! Without a detected HRX runtime this prints the placeholder state. With one, it initializes the
+//! device/stream and reports the enumerated NPU. The TOSA execution path (program loading and
+//! dispatch) lands in a later ticket.
 
 fn main() {
     match virtio_accel_xdna::XdnaAccelerator::new() {
-        Ok(_) => unreachable!("the scaffold placeholder never initializes a backend"),
+        Ok(_backend) => {
+            eprintln!("virtio-accel-xdna initialized the HRX device and stream");
+        }
         Err(error) => {
-            eprintln!("virtio-accel-xdna is scaffolded but not yet executing: {error}");
+            eprintln!("virtio-accel-xdna backend unavailable: {error}");
         }
     }
 }

--- a/crates/virtio-accel-xdna/src/ffi.rs
+++ b/crates/virtio-accel-xdna/src/ffi.rs
@@ -1,0 +1,123 @@
+//! Hand-written declarations for the HRX C ABI (`libhrx`).
+//!
+//! This module is the crate's only foreign ABI boundary. Every declaration is transcribed from the
+//! pinned release headers (`include/hrx/hrx_runtime.h`, `libhrx.so.0.1.0`, version 0.1.0) and is
+//! audited in `SAFETY.md`. It contains type, constant, and `extern` declarations only; ownership
+//! rules and every call live in `native.rs`.
+//!
+//! Scope is the buffer/device/stream subset this ticket implements; the executable and dispatch
+//! entry points are declared with the native execution path in a later ticket.
+
+#![allow(non_camel_case_types)]
+
+use core::ffi::{c_char, c_int, c_void};
+use core::marker::{PhantomData, PhantomPinned};
+
+/// `hrx_status_code_t` (`hrx_runtime.h`); mirrors IREE's status codes. `0` is success.
+pub(crate) type hrx_status_code_t = c_int;
+
+/// Memory-type bitmask (`typedef uint32_t hrx_memory_type_t`).
+pub(crate) type hrx_memory_type_t = u32;
+pub(crate) const HRX_MEMORY_TYPE_HOST_LOCAL: hrx_memory_type_t = 0x0000_0046;
+pub(crate) const HRX_MEMORY_TYPE_DEVICE_VISIBLE: hrx_memory_type_t = 0x0000_0010;
+
+/// Buffer-usage bitmask (`typedef uint32_t hrx_buffer_usage_t`).
+pub(crate) type hrx_buffer_usage_t = u32;
+pub(crate) const HRX_BUFFER_USAGE_DEFAULT: hrx_buffer_usage_t = 0x0000_0C03;
+pub(crate) const HRX_BUFFER_USAGE_MAPPING_PERSISTENT: hrx_buffer_usage_t = 0x0200_0000;
+
+/// Mapping-mode value (`typedef uint32_t hrx_mapping_mode_t`).
+pub(crate) type hrx_mapping_mode_t = u32;
+pub(crate) const HRX_MAPPING_MODE_PERSISTENT: hrx_mapping_mode_t = 0x0000_0002;
+
+/// Map-access flags (`typedef uint16_t hrx_map_flags_t`), from `HRX_MEMORY_ACCESS_*`.
+pub(crate) type hrx_map_flags_t = u16;
+pub(crate) const HRX_MAP_READ: hrx_map_flags_t = 0x01;
+pub(crate) const HRX_MAP_WRITE: hrx_map_flags_t = 0x02;
+
+macro_rules! opaque_handle {
+    ($(#[$doc:meta] $name:ident),* $(,)?) => {
+        $(
+            #[$doc]
+            #[repr(C)]
+            pub(crate) struct $name {
+                _unconstructable: [u8; 0],
+                _not_send_sync: PhantomData<(*mut u8, PhantomPinned)>,
+            }
+        )*
+    };
+}
+
+opaque_handle! {
+    /// Opaque status object (`hrx_status_s`); a non-NULL `*mut` is an error the caller owns.
+    hrx_status_s,
+    /// Opaque device handle target (`hrx_device_s`).
+    hrx_device_s,
+    /// Opaque stream handle target (`hrx_stream_s`).
+    hrx_stream_s,
+    /// Opaque buffer handle target (`hrx_buffer_s`).
+    hrx_buffer_s,
+}
+
+/// `hrx_status_t` — opaque owned pointer; `NULL` means OK (`hrx_runtime.h`).
+pub(crate) type hrx_status_t = *mut hrx_status_s;
+/// `hrx_device_t` — refcounted device handle.
+pub(crate) type hrx_device_t = *mut hrx_device_s;
+/// `hrx_stream_t` — refcounted stream handle.
+pub(crate) type hrx_stream_t = *mut hrx_stream_s;
+/// `hrx_buffer_t` — refcounted buffer handle.
+pub(crate) type hrx_buffer_t = *mut hrx_buffer_s;
+
+unsafe extern "C" {
+    // Status.
+    pub(crate) fn hrx_status_code(status: hrx_status_t) -> hrx_status_code_t;
+    pub(crate) fn hrx_status_to_string(
+        status: hrx_status_t,
+        out_message: *mut *mut c_char,
+        out_length: *mut usize,
+    ) -> hrx_status_t;
+    pub(crate) fn hrx_status_free_message(message: *mut c_char);
+    pub(crate) fn hrx_status_ignore(status: hrx_status_t);
+
+    // Device lifecycle. `hrx_gpu_initialize` is process-wide; the NPU appears under the "gpu"
+    // accelerator namespace (the amdxdna HAL). No shutdown is called: the process owns it.
+    pub(crate) fn hrx_gpu_initialize(flags: u32) -> hrx_status_t;
+    pub(crate) fn hrx_gpu_device_count(count: *mut c_int) -> hrx_status_t;
+    pub(crate) fn hrx_gpu_device_get(index: c_int, device: *mut hrx_device_t) -> hrx_status_t;
+
+    // Stream lifecycle.
+    pub(crate) fn hrx_stream_create(
+        device: hrx_device_t,
+        flags: u32,
+        stream: *mut hrx_stream_t,
+    ) -> hrx_status_t;
+    pub(crate) fn hrx_stream_release(stream: hrx_stream_t);
+
+    // Buffers: stream-ordered allocation, persistent host mapping, explicit cache management.
+    pub(crate) fn hrx_buffer_allocate(
+        stream: hrx_stream_t,
+        size: usize,
+        mem_type: hrx_memory_type_t,
+        usage: hrx_buffer_usage_t,
+        buffer: *mut hrx_buffer_t,
+    ) -> hrx_status_t;
+    pub(crate) fn hrx_buffer_release(buffer: hrx_buffer_t);
+    pub(crate) fn hrx_buffer_map_with_mode(
+        buffer: hrx_buffer_t,
+        mapping_mode: hrx_mapping_mode_t,
+        flags: hrx_map_flags_t,
+        offset: usize,
+        size: usize,
+        mapped_ptr: *mut *mut c_void,
+    ) -> hrx_status_t;
+    pub(crate) fn hrx_buffer_flush_range(
+        buffer: hrx_buffer_t,
+        offset: usize,
+        size: usize,
+    ) -> hrx_status_t;
+    pub(crate) fn hrx_buffer_invalidate_range(
+        buffer: hrx_buffer_t,
+        offset: usize,
+        size: usize,
+    ) -> hrx_status_t;
+}

--- a/crates/virtio-accel-xdna/src/lib.rs
+++ b/crates/virtio-accel-xdna/src/lib.rs
@@ -1,24 +1,22 @@
 //! AMD XDNA (Ryzen AI NPU) host backend for `virtio-accel`.
 //!
-//! This crate will execute device-neutral TOSA 1.0 programs on an AMD XDNA2 NPU through the HRX
+//! This crate executes device-neutral TOSA 1.0 programs on an AMD XDNA2 NPU through the HRX
 //! runtime (`libhrx`), compiling admitted graphs with the pinned aiecc toolchain as a bounded
 //! subprocess. The design is recorded across the AMD XDNA wayfinder map (issue #78) and its
 //! decision tickets (#82 numerical tier, #83 crate layout, #84 compiler helper, #85 execution
 //! model), whose resolution records live on their respective ticket branches.
 //!
-//! **This is the scaffold.** It ships the always-compiled admission surface (`lower`) and a
-//! compile-only placeholder; the HRX FFI, native `Accelerator` implementation, and compiler helper
-//! land in later tickets. The build script sets the `va_xdna` cfg only when it finds a complete
+//! The native modules (`ffi`, `native`) compile only when the build script finds a complete
 //! amdxdna-native HRX prefix (`VIRTIO_ACCEL_HRX_DIR`/`HRX_DIR`, or the `VIRTIO_ACCEL_HRX_LIB_DIR`
-//! escape hatch); `VIRTIO_ACCEL_XDNA` forces the probe on (`1`, failing loudly) or off (`0`).
-//! Hosts without HRX build and unit-test the portable surface plus the placeholder.
+//! escape hatch) and sets the `va_xdna` cfg; `VIRTIO_ACCEL_XDNA` forces the probe on (`1`, failing
+//! loudly) or off (`0`). Hosts without HRX build and unit-test the portable admission surface
+//! (`lower`) plus a compile-only placeholder, and compile no `unsafe` at all.
 //!
-//! The scaffold contains no `unsafe` at all, so the crate root forbids it outright. When the HRX
-//! FFI and native `Accelerator` land, that ticket relaxes this to
-//! `cfg_attr(not(va_xdna), forbid(unsafe_code))` and registers the audited exception in
-//! `ci/check-release-policy.py`, exactly as the OpenVINO and Hexagon backends do.
+//! **Scope today:** the HRX device/stream owner and `hrx_buffer` primitives (allocate with a
+//! persistent host mapping, range flush/invalidate, release). Program loading and dispatch land
+//! with the execution path; they currently report `Unsupported`.
 
-#![forbid(unsafe_code)]
+#![cfg_attr(not(va_xdna), forbid(unsafe_code))]
 
 mod lower;
 
@@ -37,6 +35,10 @@ pub const REQUIRED_RESIDENT_BYTES: u64 = u64::MAX;
 pub enum InitError {
     /// The crate was built without a detected HRX runtime (`libhrx`).
     RuntimeUnavailable,
+    /// HRX initialized but enumerated no NPU device on this host.
+    DeviceUnavailable,
+    /// The HRX device or stream could not be initialized.
+    Initialization,
 }
 
 impl core::fmt::Display for InitError {
@@ -47,16 +49,23 @@ impl core::fmt::Display for InitError {
 
 impl std::error::Error for InitError {}
 
-// Scaffold placeholder. It is compiled unconditionally today because no native module exists yet;
-// when the native `Accelerator` implementation lands it becomes `cfg(not(va_xdna))` and the real
-// type is exported under `cfg(va_xdna)`, exactly as the OpenVINO and Core ML crates are shaped.
+#[cfg(va_xdna)]
+mod ffi;
+#[cfg(va_xdna)]
+mod native;
+#[cfg(va_xdna)]
+pub use native::{
+    XDNA_ERROR_DOMAIN, XdnaAccelerator, XdnaBuffer, XdnaContext, XdnaEvent, XdnaProgram, XdnaQueue,
+};
 
-/// Placeholder that keeps workspace consumers portable until the native backend lands.
+/// Placeholder that keeps workspace consumers portable when no HRX runtime was detected.
+#[cfg(not(va_xdna))]
 #[derive(Clone, Copy, Debug, Default)]
 pub struct XdnaAccelerator;
 
+#[cfg(not(va_xdna))]
 impl XdnaAccelerator {
-    /// Report that no HRX runtime and native backend are available in this build.
+    /// Report that no HRX runtime was detected when this crate was built.
     pub fn new() -> Result<Self, InitError> {
         Err(InitError::RuntimeUnavailable)
     }

--- a/crates/virtio-accel-xdna/src/native.rs
+++ b/crates/virtio-accel-xdna/src/native.rs
@@ -1,0 +1,449 @@
+//! Native XDNA backend over the HRX runtime (`libhrx`).
+//!
+//! This module owns every call across the `ffi` boundary. `SAFETY.md` is the audit of record; each
+//! `unsafe` block below carries a local `SAFETY:` note. Scope for this ticket: one audited
+//! process-wide device owner, a per-instance stream, and `hrx_buffer` primitives (allocate with a
+//! persistent host mapping, range flush/invalidate, release). Program loading and dispatch return
+//! `Unsupported`; they land with the execution path in a later ticket, at which point the
+//! uninhabited `XdnaProgram`/`XdnaEvent` become real types.
+
+use core::marker::PhantomData;
+use core::ptr::{self, NonNull};
+use core::sync::atomic::{AtomicU64, Ordering};
+use std::ffi::c_void;
+use std::sync::OnceLock;
+
+use virtio_accel_core::{
+    Accelerator, AcceleratorClass, AllocatedBuffer, ArtifactRef, BackendError, BindingRef,
+    BufferDesc, BufferInfo, BufferProperties, ByteSink, ByteSource, Capabilities, ContextDesc,
+    DeviceIdentity, DeviceInfo, DeviceLimits, EventState, MemoryDomain, QueueDesc, ReleaseFailure,
+    SubmitFailure, Timeout,
+};
+
+use crate::InitError;
+use crate::ffi;
+
+/// `BackendError::External` domain tag for HRX failures ("XDNA" in ASCII).
+pub const XDNA_ERROR_DOMAIN: u32 = 0x5844_4e41;
+
+/// Consume an HRX status and map it to a `BackendError`.
+///
+/// A non-NULL `hrx_status_t` is owned by the caller and must be consumed exactly once. This reads
+/// its code, then ignores it (freeing it); on error it also renders and frees the message for
+/// host-side context before discarding it. `NULL` is success.
+fn check(status: ffi::hrx_status_t) -> Result<(), BackendError> {
+    if status.is_null() {
+        return Ok(());
+    }
+    // SAFETY: `status` is a non-NULL status just returned by an HRX call; reading its code and
+    // ignoring it are the documented consume operations and are valid exactly once.
+    let code = unsafe { ffi::hrx_status_code(status) };
+    // Render the message for host-side logging, then free both the message and the status.
+    // SAFETY: out-pointers are valid locals; `hrx_status_to_string` returns its own status which we
+    // ignore, and any produced message is freed with `hrx_status_free_message`.
+    unsafe {
+        let mut message: *mut core::ffi::c_char = ptr::null_mut();
+        let mut length: usize = 0;
+        let string_status = ffi::hrx_status_to_string(status, &mut message, &mut length);
+        if !message.is_null() {
+            ffi::hrx_status_free_message(message);
+        }
+        ffi::hrx_status_ignore(string_status);
+        ffi::hrx_status_ignore(status);
+    }
+    Err(backend_error_from_code(code))
+}
+
+/// Map an HRX status code (`hrx_status_code_t`, mirroring IREE) to a `BackendError`.
+fn backend_error_from_code(code: ffi::hrx_status_code_t) -> BackendError {
+    match code {
+        3 => BackendError::InvalidArgument,  // INVALID_ARGUMENT
+        4 => BackendError::DeadlineExpired,  // DEADLINE_EXCEEDED
+        7 => BackendError::PermissionDenied, // PERMISSION_DENIED
+        8 => BackendError::OutOfMemory,      // OUT_OF_MEMORY (RESOURCE_EXHAUSTED)
+        11 => BackendError::OutOfBounds,     // OUT_OF_RANGE
+        12 => BackendError::Unsupported,     // UNIMPLEMENTED
+        14 => BackendError::DeviceLost,      // UNAVAILABLE
+        other => BackendError::External {
+            domain: XDNA_ERROR_DOMAIN,
+            code: other as i64,
+        },
+    }
+}
+
+/// The process-wide HRX device, initialized once and never shut down (the fork's model: one
+/// device per process, `hrx_gpu_shutdown` is never called).
+struct SharedDevice(NonNull<ffi::hrx_device_s>);
+
+// SAFETY: the device handle is refcounted and, in HRX's amdxdna HAL, is a process-wide singleton
+// reachable from any thread. This module uses it only to create per-instance streams
+// (`hrx_stream_create`), never mutating it; sharing the pointer across threads for that read-only
+// factory use is sound. Concurrency hazards live on the stream (not concurrency-safe), which is
+// per-instance and not shared here.
+unsafe impl Send for SharedDevice {}
+unsafe impl Sync for SharedDevice {}
+
+fn shared_device() -> Result<&'static SharedDevice, InitError> {
+    static DEVICE: OnceLock<Result<SharedDevice, InitError>> = OnceLock::new();
+    DEVICE
+        .get_or_init(|| {
+            // SAFETY: HRX GPU initialization is process-wide and idempotent under the OnceLock;
+            // the out-pointers are valid locals and every returned status is consumed by `check`.
+            unsafe {
+                check(ffi::hrx_gpu_initialize(0)).map_err(|_| InitError::Initialization)?;
+                let mut count: core::ffi::c_int = 0;
+                check(ffi::hrx_gpu_device_count(&mut count))
+                    .map_err(|_| InitError::Initialization)?;
+                if count < 1 {
+                    return Err(InitError::DeviceUnavailable);
+                }
+                let mut device: ffi::hrx_device_t = ptr::null_mut();
+                check(ffi::hrx_gpu_device_get(0, &mut device))
+                    .map_err(|_| InitError::Initialization)?;
+                NonNull::new(device)
+                    .map(SharedDevice)
+                    .ok_or(InitError::Initialization)
+            }
+        })
+        .as_ref()
+        .map_err(|error| *error)
+}
+
+/// One HRX backend instance: a serialized dispatch lane (one stream) over the shared device.
+pub struct XdnaAccelerator {
+    stream: NonNull<ffi::hrx_stream_s>,
+    info: DeviceInfo,
+    next_id: AtomicU64,
+    // One stream is not safe for concurrent dispatch; the instance stays single-threaded until the
+    // execution path introduces the serialized worker.
+    _not_send_sync: PhantomData<*mut u8>,
+}
+
+impl XdnaAccelerator {
+    /// Initialize the shared device (once per process) and create this instance's stream.
+    pub fn new() -> Result<Self, InitError> {
+        let device = shared_device()?;
+        let mut stream: ffi::hrx_stream_t = ptr::null_mut();
+        // SAFETY: `device.0` is the live process-wide device; the out-pointer is a valid local and
+        // the returned status is consumed by `check`.
+        let status = unsafe { ffi::hrx_stream_create(device.0.as_ptr(), 0, &mut stream) };
+        check(status).map_err(|_| InitError::Initialization)?;
+        let stream = NonNull::new(stream).ok_or(InitError::Initialization)?;
+        Ok(Self {
+            stream,
+            info: device_info(),
+            next_id: AtomicU64::new(1),
+            _not_send_sync: PhantomData,
+        })
+    }
+
+    fn next_id(&self) -> u64 {
+        self.next_id.fetch_add(1, Ordering::Relaxed)
+    }
+}
+
+impl Drop for XdnaAccelerator {
+    fn drop(&mut self) {
+        // SAFETY: this instance owns exactly one reference to the stream and is dropped once.
+        unsafe { ffi::hrx_stream_release(self.stream.as_ptr()) };
+    }
+}
+
+/// A device-neutral description of the XDNA NPU.
+fn device_info() -> DeviceInfo {
+    DeviceInfo {
+        identity: DeviceIdentity {
+            uuid: *b"amd.xdna.npu\0\0\0\0",
+            class: AcceleratorClass::NPU,
+            vendor_id: 0x1022,
+            device_id: 0x17f0,
+        },
+        capabilities: Capabilities::HOST_VISIBLE_MEMORY | Capabilities::SHARED_MEMORY,
+        limits: DeviceLimits {
+            max_contexts: u32::MAX,
+            max_buffers_per_context: u32::MAX,
+            max_programs_per_context: u32::MAX,
+            max_queues_per_context: u32::MAX,
+            max_events_per_context: u32::MAX,
+            max_bindings_per_submission: 256,
+            max_buffer_bytes: u64::MAX,
+            max_artifact_bytes: u64::MAX,
+        },
+    }
+}
+
+/// A logical execution context. HRX holds no per-context state; the id supports accounting.
+#[derive(Debug)]
+pub struct XdnaContext {
+    _id: u64,
+}
+
+/// A logical execution queue funnelling into the instance's single stream lane.
+#[derive(Debug)]
+pub struct XdnaQueue {
+    _id: u64,
+}
+
+/// Program loading lands with the execution path; no program is constructed in this ticket.
+pub enum XdnaProgram {}
+
+/// Dispatch lands with the execution path; no event is constructed in this ticket.
+pub enum XdnaEvent {}
+
+/// An HRX buffer with its persistent host mapping.
+#[derive(Debug)]
+pub struct XdnaBuffer {
+    buffer: NonNull<ffi::hrx_buffer_s>,
+    mapped: NonNull<u8>,
+    len: usize,
+    desc: BufferDesc,
+    /// Set while the device may be reading or writing this buffer; guards release and host access.
+    /// Always zero until the dispatch path sets it.
+    in_flight: AtomicU64,
+    _not_send_sync: PhantomData<*mut u8>,
+}
+
+impl XdnaBuffer {
+    /// Byte range `[offset, offset+len)` checked against the mapping, returning `(start, end)`.
+    fn checked_range(&self, offset: u64, len: usize) -> Result<(usize, usize), BackendError> {
+        let start = usize::try_from(offset).map_err(|_| BackendError::OutOfBounds)?;
+        let end = start
+            .checked_add(len)
+            .filter(|end| *end <= self.len)
+            .ok_or(BackendError::OutOfBounds)?;
+        Ok((start, end))
+    }
+}
+
+impl Drop for XdnaBuffer {
+    fn drop(&mut self) {
+        // SAFETY: this handle owns one buffer reference and is dropped once. The persistent mapping
+        // is released together with the buffer (the fork never unmaps first).
+        unsafe { ffi::hrx_buffer_release(self.buffer.as_ptr()) };
+    }
+}
+
+impl Accelerator for XdnaAccelerator {
+    type Context = XdnaContext;
+    type Buffer = XdnaBuffer;
+    type Program = XdnaProgram;
+    type Queue = XdnaQueue;
+    type Event = XdnaEvent;
+
+    fn device_info(&self) -> Result<DeviceInfo, BackendError> {
+        Ok(self.info)
+    }
+
+    fn create_context(&self, desc: ContextDesc) -> Result<Self::Context, BackendError> {
+        self.info.validate_context_desc(desc)?;
+        Ok(XdnaContext {
+            _id: self.next_id(),
+        })
+    }
+
+    fn destroy_context(
+        &self,
+        _context: Self::Context,
+    ) -> Result<(), ReleaseFailure<Self::Context>> {
+        Ok(())
+    }
+
+    fn allocate_buffer(
+        &self,
+        _context: &Self::Context,
+        desc: BufferDesc,
+    ) -> Result<AllocatedBuffer<Self::Buffer>, BackendError> {
+        self.info.validate_buffer_desc(desc)?;
+        // HRX host-mapped buffers are device-visible shared memory; device-local-only is not a
+        // separate path here.
+        if desc.domain == MemoryDomain::Device {
+            return Err(BackendError::Unsupported);
+        }
+        let size = usize::try_from(desc.bytes()).map_err(|_| BackendError::OutOfMemory)?;
+        // HRX rejects zero-size allocations; `BufferDesc` already guarantees a nonzero size.
+
+        let mut buffer: ffi::hrx_buffer_t = ptr::null_mut();
+        // SAFETY: the stream is live; the out-pointer is a valid local; the status is consumed.
+        let status = unsafe {
+            ffi::hrx_buffer_allocate(
+                self.stream.as_ptr(),
+                size,
+                ffi::HRX_MEMORY_TYPE_HOST_LOCAL | ffi::HRX_MEMORY_TYPE_DEVICE_VISIBLE,
+                ffi::HRX_BUFFER_USAGE_DEFAULT | ffi::HRX_BUFFER_USAGE_MAPPING_PERSISTENT,
+                &mut buffer,
+            )
+        };
+        check(status)?;
+        let buffer = NonNull::new(buffer).ok_or(BackendError::External {
+            domain: XDNA_ERROR_DOMAIN,
+            code: 0,
+        })?;
+
+        // Establish the persistent read/write mapping for the whole buffer. On any failure the
+        // buffer is released before returning so no handle leaks.
+        let mut mapped: *mut c_void = ptr::null_mut();
+        // SAFETY: `buffer` is the just-allocated live buffer; the out-pointer is a valid local; the
+        // status is consumed.
+        let status = unsafe {
+            ffi::hrx_buffer_map_with_mode(
+                buffer.as_ptr(),
+                ffi::HRX_MAPPING_MODE_PERSISTENT,
+                ffi::HRX_MAP_READ | ffi::HRX_MAP_WRITE,
+                0,
+                size,
+                &mut mapped,
+            )
+        };
+        let mapped = match check(status).and_then(|()| {
+            NonNull::new(mapped.cast::<u8>()).ok_or(BackendError::External {
+                domain: XDNA_ERROR_DOMAIN,
+                code: 0,
+            })
+        }) {
+            Ok(mapped) => mapped,
+            Err(error) => {
+                // SAFETY: `buffer` is live and owned here; releasing it on the error path drops the
+                // only reference before the handle is discarded.
+                unsafe { ffi::hrx_buffer_release(buffer.as_ptr()) };
+                return Err(error);
+            }
+        };
+
+        // Report the mapping's actual alignment (the largest power of two dividing its address),
+        // which must satisfy the requested alignment.
+        let alignment = 1u64 << (mapped.as_ptr() as usize).trailing_zeros().min(63);
+        let info = BufferInfo::new(
+            desc,
+            size as u64,
+            alignment,
+            BufferProperties::HOST_VISIBLE | BufferProperties::DIRECT_BINDING,
+        )
+        .inspect_err(|_| {
+            // SAFETY: the buffer is live and owned; release its only reference before returning.
+            unsafe { ffi::hrx_buffer_release(buffer.as_ptr()) };
+        })?;
+
+        Ok(AllocatedBuffer::new(
+            XdnaBuffer {
+                buffer,
+                mapped,
+                len: size,
+                desc,
+                in_flight: AtomicU64::new(0),
+                _not_send_sync: PhantomData,
+            },
+            info,
+        ))
+    }
+
+    fn write_buffer(
+        &self,
+        buffer: &mut Self::Buffer,
+        offset: u64,
+        data: &dyn ByteSource,
+    ) -> Result<(), BackendError> {
+        if !buffer
+            .desc
+            .usage
+            .contains(virtio_accel_core::BufferUsage::TRANSFER_DESTINATION)
+        {
+            return Err(BackendError::PermissionDenied);
+        }
+        if buffer.in_flight.load(Ordering::Acquire) != 0 {
+            return Err(BackendError::Busy);
+        }
+        let len = usize::try_from(data.len()).map_err(|_| BackendError::OutOfBounds)?;
+        let (start, end) = buffer.checked_range(offset, len)?;
+        // SAFETY: the mapping is valid for `buffer.len` bytes and `[start,end)` is within it; the
+        // exclusive borrow and the in-flight gate rule out concurrent device or host access.
+        let dst =
+            unsafe { core::slice::from_raw_parts_mut(buffer.mapped.as_ptr().add(start), len) };
+        data.read_at(0, dst)?;
+        // Push the host writes device-ward.
+        // SAFETY: the buffer is live and currently mapped; the range is validated; status consumed.
+        check(unsafe { ffi::hrx_buffer_flush_range(buffer.buffer.as_ptr(), start, end - start) })
+    }
+
+    fn read_buffer(
+        &self,
+        buffer: &Self::Buffer,
+        offset: u64,
+        data: &mut dyn ByteSink,
+    ) -> Result<(), BackendError> {
+        if buffer.in_flight.load(Ordering::Acquire) != 0 {
+            return Err(BackendError::Busy);
+        }
+        let len = usize::try_from(data.len()).map_err(|_| BackendError::OutOfBounds)?;
+        let (start, end) = buffer.checked_range(offset, len)?;
+        // Make device writes visible to the host before reading.
+        // SAFETY: the buffer is live and currently mapped; the range is validated; status consumed.
+        check(unsafe {
+            ffi::hrx_buffer_invalidate_range(buffer.buffer.as_ptr(), start, end - start)
+        })?;
+        // SAFETY: the mapping is valid for `buffer.len` bytes and `[start,end)` is within it; the
+        // shared borrow with the in-flight gate rules out concurrent device writes.
+        let src = unsafe { core::slice::from_raw_parts(buffer.mapped.as_ptr().add(start), len) };
+        data.write_at(0, src)
+    }
+
+    fn free_buffer(&self, buffer: Self::Buffer) -> Result<(), ReleaseFailure<Self::Buffer>> {
+        if buffer.in_flight.load(Ordering::Acquire) != 0 {
+            return Err(ReleaseFailure::Rejected {
+                error: BackendError::Busy,
+                resource: buffer,
+            });
+        }
+        // The buffer's `Drop` releases the HRX handle (and its persistent mapping).
+        drop(buffer);
+        Ok(())
+    }
+
+    fn load_program(
+        &self,
+        _context: &Self::Context,
+        _artifact: ArtifactRef<'_>,
+    ) -> Result<Self::Program, BackendError> {
+        // Program compilation and loading land with the execution path.
+        Err(BackendError::Unsupported)
+    }
+
+    fn unload_program(&self, program: Self::Program) -> Result<(), ReleaseFailure<Self::Program>> {
+        match program {}
+    }
+
+    fn create_queue(
+        &self,
+        _context: &Self::Context,
+        desc: QueueDesc,
+    ) -> Result<Self::Queue, BackendError> {
+        if !desc.flags.is_empty() {
+            return Err(BackendError::Unsupported);
+        }
+        Ok(XdnaQueue {
+            _id: self.next_id(),
+        })
+    }
+
+    fn destroy_queue(&self, _queue: Self::Queue) -> Result<(), ReleaseFailure<Self::Queue>> {
+        Ok(())
+    }
+
+    fn submit(
+        &self,
+        _queue: &Self::Queue,
+        _program: &Self::Program,
+        _bindings: &[BindingRef<'_, Self::Buffer>],
+        _timeout: Timeout,
+    ) -> Result<Self::Event, SubmitFailure<Self::Event>> {
+        // Dispatch lands with the execution path.
+        Err(SubmitFailure::Rejected(BackendError::Unsupported))
+    }
+
+    fn poll_event(&self, event: &Self::Event) -> Result<EventState, BackendError> {
+        match *event {}
+    }
+
+    fn destroy_event(&self, event: Self::Event) -> Result<(), ReleaseFailure<Self::Event>> {
+        match event {}
+    }
+}

--- a/crates/virtio-accel-xdna/src/native.rs
+++ b/crates/virtio-accel-xdna/src/native.rs
@@ -26,6 +26,9 @@ use crate::ffi;
 /// `BackendError::External` domain tag for HRX failures ("XDNA" in ASCII).
 pub const XDNA_ERROR_DOMAIN: u32 = 0x5844_4e41;
 
+/// Upper bound advertised for a loaded TOSA artifact (mirrors the OpenVINO backend).
+const MAX_TOSA_ARTIFACT_BYTES: u64 = 256 * 1024 * 1024;
+
 /// Consume an HRX status and map it to a `BackendError`.
 ///
 /// A non-NULL `hrx_status_t` is owned by the caller and must be consumed exactly once. This reads
@@ -159,15 +162,18 @@ fn device_info() -> DeviceInfo {
             device_id: 0x17f0,
         },
         capabilities: Capabilities::HOST_VISIBLE_MEMORY | Capabilities::SHARED_MEMORY,
+        // Finite aggregate bounds: the device-state layer checked-multiplies `max_contexts` by each
+        // per-context limit, so `u32::MAX` would overflow and reject the backend. These mirror the
+        // OpenVINO backend's advertised limits.
         limits: DeviceLimits {
-            max_contexts: u32::MAX,
-            max_buffers_per_context: u32::MAX,
-            max_programs_per_context: u32::MAX,
-            max_queues_per_context: u32::MAX,
-            max_events_per_context: u32::MAX,
+            max_contexts: 64,
+            max_buffers_per_context: 1_024,
+            max_programs_per_context: 64,
+            max_queues_per_context: 64,
+            max_events_per_context: 4_096,
             max_bindings_per_submission: 256,
-            max_buffer_bytes: u64::MAX,
-            max_artifact_bytes: u64::MAX,
+            max_buffer_bytes: 16 * 1024 * 1024 * 1024,
+            max_artifact_bytes: MAX_TOSA_ARTIFACT_BYTES,
         },
     }
 }
@@ -370,6 +376,13 @@ impl Accelerator for XdnaAccelerator {
         offset: u64,
         data: &mut dyn ByteSink,
     ) -> Result<(), BackendError> {
+        if !buffer
+            .desc
+            .usage
+            .contains(virtio_accel_core::BufferUsage::TRANSFER_SOURCE)
+        {
+            return Err(BackendError::PermissionDenied);
+        }
         if buffer.in_flight.load(Ordering::Acquire) != 0 {
             return Err(BackendError::Busy);
         }

--- a/crates/virtio-accel-xdna/tests/hardware.rs
+++ b/crates/virtio-accel-xdna/tests/hardware.rs
@@ -1,0 +1,162 @@
+//! On-hardware tests for the HRX buffer primitives.
+//!
+//! These compile and run only in a `va_xdna` build (a detected HRX prefix) and require an
+//! accessible NPU. They cover the allocate / map / write+flush / read+invalidate / release cycle
+//! plus context and queue lifecycle. Program loading and dispatch are covered by the execution
+//! ticket.
+#![cfg(va_xdna)]
+
+use virtio_accel_core::{
+    Accelerator, BackendError, BufferDesc, BufferUsage, ByteSink, ByteSource, ContextDesc,
+    MemoryDomain, QueueDesc,
+};
+use virtio_accel_xdna::{InitError, XdnaAccelerator};
+
+/// Construct a backend, or skip the test when no NPU is accessible on this host.
+fn backend() -> Option<XdnaAccelerator> {
+    match XdnaAccelerator::new() {
+        Ok(backend) => Some(backend),
+        Err(InitError::DeviceUnavailable) => {
+            eprintln!("no XDNA NPU device accessible; skipping hardware test");
+            None
+        }
+        Err(error) => panic!("unexpected initialization failure: {error}"),
+    }
+}
+
+#[derive(Debug)]
+struct Slice<'a>(&'a [u8]);
+
+impl ByteSource for Slice<'_> {
+    fn len(&self) -> u64 {
+        self.0.len() as u64
+    }
+    fn read_at(&self, offset: u64, target: &mut [u8]) -> Result<(), BackendError> {
+        let start = usize::try_from(offset).map_err(|_| BackendError::OutOfBounds)?;
+        let end = start
+            .checked_add(target.len())
+            .filter(|end| *end <= self.0.len())
+            .ok_or(BackendError::OutOfBounds)?;
+        target.copy_from_slice(&self.0[start..end]);
+        Ok(())
+    }
+    fn as_contiguous(&self) -> Option<&[u8]> {
+        Some(self.0)
+    }
+}
+
+#[derive(Debug)]
+struct SliceMut<'a>(&'a mut [u8]);
+
+impl ByteSink for SliceMut<'_> {
+    fn len(&self) -> u64 {
+        self.0.len() as u64
+    }
+    fn write_at(&mut self, offset: u64, source: &[u8]) -> Result<(), BackendError> {
+        let start = usize::try_from(offset).map_err(|_| BackendError::OutOfBounds)?;
+        let end = start
+            .checked_add(source.len())
+            .filter(|end| *end <= self.0.len())
+            .ok_or(BackendError::OutOfBounds)?;
+        self.0[start..end].copy_from_slice(source);
+        Ok(())
+    }
+    fn as_contiguous_mut(&mut self) -> Option<&mut [u8]> {
+        Some(self.0)
+    }
+}
+
+fn shared_desc(bytes: u64) -> BufferDesc {
+    BufferDesc::new(
+        bytes,
+        4096,
+        MemoryDomain::Shared,
+        BufferUsage::TRANSFER_DESTINATION
+            | BufferUsage::TRANSFER_SOURCE
+            | BufferUsage::PROGRAM_INPUT,
+    )
+    .expect("valid buffer descriptor")
+}
+
+#[test]
+fn device_info_reports_the_npu() {
+    let Some(backend) = backend() else { return };
+    let info = backend.device_info().expect("device info");
+    assert_eq!(info.identity.vendor_id, 0x1022);
+    assert_eq!(info.identity.device_id, 0x17f0);
+}
+
+#[test]
+fn buffer_write_flush_invalidate_read_roundtrips() {
+    let Some(backend) = backend() else { return };
+    let context = backend
+        .create_context(ContextDesc::default())
+        .expect("context");
+    let (mut buffer, info) = backend
+        .allocate_buffer(&context, shared_desc(256))
+        .expect("allocate")
+        .into_parts();
+    assert!(info.allocation_bytes() >= 256);
+
+    let payload: Vec<u8> = (0..256u32).map(|i| (i * 7) as u8).collect();
+    backend
+        .write_buffer(&mut buffer, 0, &Slice(&payload))
+        .expect("write + flush");
+
+    let mut readback = vec![0u8; 256];
+    backend
+        .read_buffer(&buffer, 0, &mut SliceMut(&mut readback))
+        .expect("invalidate + read");
+    assert_eq!(readback, payload, "device-visible mapping must round-trip");
+
+    // A sub-range write is observable at its offset and nowhere else.
+    backend
+        .write_buffer(&mut buffer, 64, &Slice(&[0xAB; 16]))
+        .expect("sub-range write");
+    let mut window = vec![0u8; 16];
+    backend
+        .read_buffer(&buffer, 64, &mut SliceMut(&mut window))
+        .expect("sub-range read");
+    assert_eq!(window, [0xAB; 16]);
+
+    backend.free_buffer(buffer).expect("free");
+    backend.destroy_context(context).expect("destroy context");
+}
+
+#[test]
+fn out_of_bounds_transfers_are_rejected() {
+    let Some(backend) = backend() else { return };
+    let context = backend
+        .create_context(ContextDesc::default())
+        .expect("context");
+    let (mut buffer, _) = backend
+        .allocate_buffer(&context, shared_desc(64))
+        .expect("allocate")
+        .into_parts();
+
+    let too_big = vec![0u8; 128];
+    assert!(matches!(
+        backend.write_buffer(&mut buffer, 0, &Slice(&too_big)),
+        Err(BackendError::OutOfBounds)
+    ));
+    assert!(matches!(
+        backend.write_buffer(&mut buffer, 60, &Slice(&[0u8; 8])),
+        Err(BackendError::OutOfBounds)
+    ));
+
+    backend.free_buffer(buffer).expect("free");
+    backend.destroy_context(context).expect("destroy context");
+}
+
+#[test]
+fn context_and_queue_lifecycle() {
+    let Some(backend) = backend() else { return };
+    let context = backend
+        .create_context(ContextDesc::default())
+        .expect("context");
+    let queue = backend
+        .create_queue(&context, QueueDesc::default())
+        .expect("queue");
+    backend.destroy_queue(queue).expect("destroy queue");
+    backend.destroy_context(context).expect("destroy context");
+}

--- a/crates/virtio-accel-xdna/tests/hardware.rs
+++ b/crates/virtio-accel-xdna/tests/hardware.rs
@@ -149,6 +149,56 @@ fn out_of_bounds_transfers_are_rejected() {
 }
 
 #[test]
+fn read_requires_transfer_source_permission() {
+    let Some(backend) = backend() else { return };
+    let context = backend
+        .create_context(ContextDesc::default())
+        .expect("context");
+    // A write-only buffer (no TRANSFER_SOURCE) must reject readback with PermissionDenied.
+    let desc = BufferDesc::new(
+        64,
+        4096,
+        MemoryDomain::Shared,
+        BufferUsage::TRANSFER_DESTINATION | BufferUsage::PROGRAM_INPUT,
+    )
+    .expect("valid descriptor");
+    let (buffer, _) = backend
+        .allocate_buffer(&context, desc)
+        .expect("allocate")
+        .into_parts();
+    let mut out = vec![0u8; 8];
+    assert!(matches!(
+        backend.read_buffer(&buffer, 0, &mut SliceMut(&mut out)),
+        Err(BackendError::PermissionDenied)
+    ));
+    backend.free_buffer(buffer).expect("free");
+    backend.destroy_context(context).expect("destroy context");
+}
+
+#[test]
+fn advertised_limits_are_aggregation_safe() {
+    let Some(backend) = backend() else { return };
+    // The device-state layer checked-multiplies `max_contexts` by each per-context limit and
+    // `max_events_per_context` by `max_bindings_per_submission`; the advertised limits must not
+    // overflow those u32 products, or the backend is unusable through the command processor.
+    let limits = backend.device_info().expect("device info").limits;
+    for per_context in [
+        limits.max_buffers_per_context,
+        limits.max_programs_per_context,
+        limits.max_queues_per_context,
+        limits.max_events_per_context,
+    ] {
+        assert!(limits.max_contexts.checked_mul(per_context).is_some());
+    }
+    assert!(
+        limits
+            .max_events_per_context
+            .checked_mul(limits.max_bindings_per_submission)
+            .is_some()
+    );
+}
+
+#[test]
 fn context_and_queue_lifecycle() {
     let Some(backend) = backend() else { return };
     let context = backend

--- a/docs/release-policy.md
+++ b/docs/release-policy.md
@@ -164,7 +164,7 @@ source.
 | 10 | `virtio-accel-device` | `core`, `proto`, `transport` | `mock` |
 | 11 | `virtio-accel-conformance` | `core` | `mock`, `tosa` |
 | 12 | `virtio-accel-vaccel` | `core` | `conformance` |
-| 13 | `virtio-accel-xdna` | `tosa` | — |
+| 13 | `virtio-accel-xdna` | `core`, `tosa` | — |
 | 14 | `virtio-accel-coreml` | `core`, `tosa` | `conformance` |
 | 15 | `virtio-accel-openvino` | `core`, `tosa` | `conformance` |
 | 16 | `virtio-accel-hexagon` | `core`, `tosa` | `conformance` |


### PR DESCRIPTION
# Why

Second code ticket of the AMD XDNA wayfinder map ([#78](https://github.com/MicroPerceptron/virtio-accel/issues/78)), implementing the audited FFI boundary and buffer primitives per the crate-layout decision (#83). This turns on the `va_xdna` native path: the HRX device/stream owner and `hrx_buffer` allocation with a persistent host mapping, range flush/invalidate, and release — the foundation the execution path (#88) builds dispatch on. It is the first `unsafe` in this crate; hosts without HRX still compile only the portable admission surface plus the placeholder, with no `unsafe`.

Structure mirrors `virtio-accel-openvino` (FFI declarations in `ffi.rs`, calls + ownership in `native.rs`, `SAFETY.md` audit, `cfg_attr(not(va_xdna), forbid(unsafe_code))` root) per the standing alignment rule.

Highlights:
- **`src/ffi.rs`** — the HRX C ABI transcribed byte-exact from the pinned release headers (`libhrx.so.0.1.0`, v0.1.0): opaque refcounted handles, the `uint32`/`uint16` bitmask constants, and exactly the `extern "C"` functions this ticket calls (status, gpu/device, stream, buffer).
- **`src/native.rs`** — one audited process-wide device owner (`OnceLock`, `hrx_gpu_initialize`→`device_get`, never shut down), a per-instance stream, and the buffer primitives. A single `check` helper consumes every `hrx_status_t` exactly once (`to_string`→`free_message`→`ignore` on both statuses). Every `unsafe` block carries a local `SAFETY:` note; host access is bounds-checked against the mapped range; allocation releases on every error path. Program loading and dispatch return `Unsupported` (uninhabited `XdnaProgram`/`XdnaEvent`) — they land in #88.
- **`SAFETY.md`** — the real audit (ABI/status ownership, handle lifetime and teardown, buffers and mappings, per-block unsafe inventory), registered in `ci/check-release-policy.py`.
- **`tests/hardware.rs`** (`va_xdna` only) — the allocate / map / write+flush / read+invalidate / release round trip, out-of-bounds rejection, device info, and context/queue lifecycle, **validated on the reference NPU** (Krackan `1022:17f0`).
- Re-adds the `virtio-accel-core` dependency (dropped from the scaffold when unused; the trait impl needs it now).

## Compatibility

- [x] **No wire effect.** This changes no accepted or emitted protocol bytes.

## Checklist

- [x] Does not alter payload lengths, ownership, reset, error, timeout, or feature-negotiation behavior.
- [x] `layout.json`, `vectors.json`, `scenarios.json`, `requirements.json`, and performance budgets untouched.
- [x] Public Rust API: adds the native `XdnaAccelerator` `Accelerator` impl, `XdnaBuffer`/`XdnaContext`/`XdnaQueue`, uninhabited `XdnaProgram`/`XdnaEvent`, `XDNA_ERROR_DOMAIN`, and two `InitError` variants under `va_xdna`. No changes to core/guest/device/transport APIs.
- [x] No dependency/feature/target moves platform behavior into a portable crate — the native path is gated behind the `va_xdna` build-probe cfg, off by default.
- [x] **Unsafe added under audit**: confined to `ffi.rs`/`native.rs` in `va_xdna` builds, every block has a local safety argument, `SAFETY.md` documents the boundary, on-hardware tests exercise it, and the release-policy entry is registered.
- [x] Deferred features remain unadvertised: program loading and dispatch report `Unsupported`; nothing new is claimed in the support table.

## Verification

On the reference machine (Fedora 44, Krackan NPU, pinned HRX toolchain):

```
# va_xdna (HRX present): on-hardware buffer round trip
cargo test -p virtio-accel-xdna            # 4 hardware tests + portable tests pass on the NPU
cargo run  -p virtio-accel-xdna --example tosa_xdna   # initializes the HRX device and stream

# placeholder path (no HRX — the CI default)
cargo fmt --all -- --check
python3 ci/check-release-policy.py          # 17 published packages OK (unsafe audit registered)
cargo test -p virtio-accel-xdna             # portable tests pass; hardware suite cfg'd out
RUSTDOCFLAGS=-D warnings cargo doc -p virtio-accel-xdna --no-deps
python3 ci/publish-dry-run.py               # ordered dry run passed for all 17 crates
```

`cargo clippy` on this crate's files is clean under `-D warnings`. (A local clippy newer than CI's pinned stable flags a pre-existing `nonminimal_bool` in `virtio-accel-tosa`, unrelated to this change; `main`'s clippy lane is green.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)