### PR TITLE
Wire TOSA admission and the compiler helper for IDENTITY (#89)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,6 +300,7 @@ version = "0.3.3"
 dependencies = [
  "virtio-accel-core",
  "virtio-accel-tosa",
+ "virtio-accel-tosa-build",
 ]
 
 [[package]]

--- a/crates/virtio-accel-xdna/Cargo.toml
+++ b/crates/virtio-accel-xdna/Cargo.toml
@@ -14,3 +14,6 @@ readme = "README.md"
 [dependencies]
 virtio-accel-core.workspace = true
 virtio-accel-tosa.workspace = true
+
+[dev-dependencies]
+virtio-accel-tosa-build.workspace = true

--- a/crates/virtio-accel-xdna/README.md
+++ b/crates/virtio-accel-xdna/README.md
@@ -9,16 +9,24 @@ bounded subprocess (never a Cargo dependency, never in-process Python).
 build time; a compile-only unsupported-runtime placeholder elsewhere.
 
 **This crate is under construction.** In a `va_xdna` build it runs the full `Accelerator`
-lifecycle for a *precompiled* artifact — device/stream owner, `hrx_buffer` primitives (persistent
-mapping, range flush/invalidate, release), and a serialized dispatch worker bridging
-`hrx_stream_dispatch`/`synchronize` to a latched nonblocking `poll_event` — validated on-device by
-the `tests/hardware.rs` suite (an end-to-end DMA passthrough on the NPU). `load_program` accepts
-the crate-local precompiled artifact format; TOSA compilation via the aiecc compiler helper, and
-the executing numerical tiers, land in subsequent tickets of the
-[AMD XDNA wayfinder map](https://github.com/MicroPerceptron/virtio-accel/issues/78). Hosts without
-HRX build the portable admission surface plus a placeholder and compile no `unsafe`. The design
+lifecycle — device/stream owner, `hrx_buffer` primitives (persistent mapping, range
+flush/invalidate, release), and a serialized dispatch worker bridging
+`hrx_stream_dispatch`/`synchronize` to a latched nonblocking `poll_event`. `load_program` accepts
+the crate-local precompiled artifact format directly, and a TOSA artifact by admitting it and
+compiling it with the bounded aiecc helper subprocess (`compiler/xdna_compile.py`, run under the
+pinned toolchain venv in a cleared environment, content-addressed in a cache). The compilable TOSA
+subset today is the BF16 IDENTITY (a DMA copy); the compute tiers grow on top of it. All of this is
+validated on-device by `tests/hardware.rs` (a DMA passthrough and a compiled TOSA IDENTITY on the
+NPU). Hosts without HRX build the portable admission surface plus a placeholder, compile no
+`unsafe`, and still unit-test admission and the artifact codec. The remaining executing numerical
+tiers land in subsequent tickets of the
+[AMD XDNA wayfinder map](https://github.com/MicroPerceptron/virtio-accel/issues/78); the design
 decisions live on their ticket branches: crate layout (#83), FFI/buffers (#87), execution model
 (#85), compiler helper (#84), and the advertised numerical tier (#82).
+
+The compiler is never a Cargo dependency and never runs in-process. `compile_artifact` exposes the
+admit-then-compile path without a device (the offline / catalog-population use), so a build host can
+produce precompiled artifacts that a device-less serving host later loads.
 
 ## Build-time probe
 

--- a/crates/virtio-accel-xdna/SAFETY.md
+++ b/crates/virtio-accel-xdna/SAFETY.md
@@ -3,12 +3,14 @@
 This crate is a host-native exception to the portable workspace's `forbid(unsafe_code)` rule, on
 the same terms as `virtio-accel-openvino`. Unsafe Rust is confined to the `va_xdna` build
 configuration — `src/ffi.rs` (HRX C ABI declarations only) and `src/native.rs` (the calls) — and
-the crate root carries `cfg_attr(not(va_xdna), forbid(unsafe_code))`. Builds without a detected HRX
-runtime compile no `unsafe` at all: only the portable admission surface (`src/lower.rs`), the
-portable precompiled-artifact codec (`src/artifact.rs`), and a placeholder.
+the crate root carries `cfg_attr(not(va_xdna), forbid(unsafe_code))`. The compiler-helper driver
+(`src/compiler.rs`) is safe code — it spawns the aiecc helper as a subprocess and touches no FFI.
+Builds without a detected HRX runtime compile no `unsafe` at all: only the portable admission
+surface (`src/lower.rs`), the portable precompiled-artifact codec (`src/artifact.rs`), and a
+placeholder.
 
-Scope: the device/stream owner, `hrx_buffer` primitives, the amdxdna executable lifecycle, and the
-serialized dispatch worker. TOSA compilation is a later ticket.
+Scope: the device/stream owner, `hrx_buffer` primitives, the amdxdna executable lifecycle (for both
+the precompiled and compiled paths), and the serialized dispatch worker.
 
 ## ABI and status ownership
 

--- a/crates/virtio-accel-xdna/compiler/xdna_compile.py
+++ b/crates/virtio-accel-xdna/compiler/xdna_compile.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""virtio-accel-xdna compiler helper.
+
+Invoked as a bounded subprocess by the backend's ``load_program`` (never imported in-process,
+never a Cargo dependency). It compiles one admitted TOSA operator specialization to the amdxdna
+artifacts HRX consumes (``final.xclbin`` + unfolded ``insts.bin``), using the pinned IRON toolchain.
+
+Two modes:
+
+* ``compile <workdir>`` — read ``<workdir>/spec.json``, compile, and write ``final.xclbin``,
+  ``insts.bin`` and ``result.json`` into the workdir.
+* ``identity`` — print the installed toolchain identity as JSON (for the cache key).
+
+``spec.json`` (all fields validated integers or closed enums; no guest bytes reach this process):
+
+    {"op": "IDENTITY", "dtype": "bf16", "elements": <n>, "device": "npu2",
+     "fold_ddr_addr_offset": false}
+
+``result.json``: ``{"schema": 1, "ok": true, "stage": "...", "entry": "MLIR_AIE",
+"inputs": 1, "outputs": 1}`` or ``{"schema": 1, "ok": false, "stage": "...", "message": "..."}``.
+
+The environment is pinned by the caller (cleared, with PEANO_INSTALL_DIR / AIE_XCLBINUTIL / PATH
+and a private HOME/TMPDIR/NPU_CACHE_HOME); this script sets no ambient state and never dispatches.
+"""
+
+import json
+import sys
+import traceback
+from pathlib import Path
+
+LINE_SIZE = 1024
+
+
+def _fail(workdir: Path, stage: str, message: str) -> int:
+    (workdir / "result.json").write_text(
+        json.dumps({"schema": 1, "ok": False, "stage": stage, "message": message})
+    )
+    print(f"xdna_compile: {stage}: {message}", file=sys.stderr)
+    return 1
+
+
+def _identity() -> int:
+    import importlib.metadata as md
+
+    def version(pkg: str) -> str:
+        try:
+            return md.version(pkg)
+        except md.PackageNotFoundError:
+            return "unknown"
+
+    print(
+        json.dumps(
+            {
+                "schema": 1,
+                "helper": 1,
+                "mlir_aie": version("mlir_aie"),
+                "llvm_aie": version("llvm-aie"),
+            }
+        )
+    )
+    return 0
+
+
+def _configure_toolchain_env() -> None:
+    """Pin the aiecc toolchain env from the prefix, reconstructing what `utils/env_setup.sh` sets.
+
+    The caller runs us under a cleared environment with only the prefix and a private workdir. We
+    resolve tool paths from the venv's `site-packages` (via `sysconfig`) and the prefix, add the
+    IRON python package to this process's path, and set the variables aiecc's subprocesses need.
+    `NPU_RUNTIME=hrx` selects the unfolded DDR ABI HRX requires; the tensor factory locates
+    `libhrx.so` through `HRX_DIR`.
+    """
+    import os
+    import sys
+    import sysconfig
+
+    site_packages = Path(sysconfig.get_paths()["purelib"])
+    mlir_dir = site_packages / "mlir_aie"
+    peano = site_packages / "llvm-aie"
+
+    # `aie` lives under `mlir_aie/python`; make it importable in this process and its children.
+    aie_python = mlir_dir / "python"
+    sys.path.insert(0, str(aie_python))
+
+    os.environ["MLIR_AIE_INSTALL_DIR"] = str(mlir_dir)
+    if peano.is_dir():
+        os.environ["PEANO_INSTALL_DIR"] = str(peano)
+    os.environ["NPU_RUNTIME"] = "hrx"
+    os.environ["NPU2"] = "1"
+
+    prefix = os.environ.get("VIRTIO_ACCEL_AMDXDNA_TOOLCHAIN")
+    if prefix:
+        xclbinutil = Path(prefix) / "amd-npu-compiler/bld-xclbinutil/tools/hrx-xclbinutil"
+        if xclbinutil.is_file():
+            os.environ["AIE_XCLBINUTIL"] = str(xclbinutil)
+        hrx_dir = _find_hrx_dir(Path(prefix))
+        if hrx_dir is not None:
+            os.environ["HRX_DIR"] = str(hrx_dir)
+
+    def prepend(var: str, value: str) -> None:
+        current = os.environ.get(var, "")
+        os.environ[var] = f"{value}{':' + current if current else ''}"
+
+    prepend("PYTHONPATH", str(aie_python))
+    prepend("PATH", f"{mlir_dir / 'bin'}:{peano / 'bin'}")
+    prepend("LD_LIBRARY_PATH", str(mlir_dir / "lib"))
+
+
+def _find_hrx_dir(prefix: Path) -> Path | None:
+    """Locate the extracted HRX release prefix (the dir holding `lib/libhrx.so`) under the prefix."""
+    root = prefix / "amd-npu-compiler/third_party/.hrx-release"
+    if not root.is_dir():
+        return None
+    for candidate in sorted(root.iterdir()):
+        if (candidate / "lib/libhrx.so").is_file():
+            return candidate
+    return None
+
+
+def _build_identity(elements: int):
+    """Return the @iron.jit IDENTITY design (a bf16 DMA copy: shim -> memtile -> shim)."""
+    import aie.iron as iron
+    import ml_dtypes
+    import numpy as np
+    from aie.iron import CompileTime, In, ObjectFifo, Out, Program, Runtime
+    from aie.iron.device import AnyShimTile
+
+    @iron.jit
+    def identity_bf16(x_in: In, y_out: Out, *, n: CompileTime[int] = elements):
+        vector_ty = np.ndarray[(n,), np.dtype[ml_dtypes.bfloat16]]
+        line_ty = np.ndarray[(LINE_SIZE,), np.dtype[ml_dtypes.bfloat16]]
+        of_in = ObjectFifo(line_ty, name="in")
+        of_out = of_in.cons().forward()
+
+        def sequence(x, y, in_h, out_h):
+            in_h.fill(x)
+            out_h.drain(y, wait=True)
+
+        rt = Runtime(
+            sequence,
+            [
+                vector_ty,
+                vector_ty,
+                of_in.prod(tile=AnyShimTile),
+                of_out.cons(tile=AnyShimTile),
+            ],
+        )
+        return Program(iron.get_current_device(), rt).resolve_program()
+
+    return identity_bf16
+
+
+def _compile(workdir: Path) -> int:
+    try:
+        spec = json.loads((workdir / "spec.json").read_text())
+    except (OSError, ValueError) as error:
+        return _fail(workdir, "spec-rejected", f"unreadable spec.json: {error}")
+
+    op = spec.get("op")
+    dtype = spec.get("dtype")
+    elements = spec.get("elements")
+    device = spec.get("device")
+    if op != "IDENTITY" or dtype != "bf16":
+        return _fail(workdir, "spec-rejected", f"unsupported op/dtype: {op}/{dtype}")
+    if not isinstance(elements, int) or elements <= 0 or elements % LINE_SIZE != 0:
+        return _fail(
+            workdir, "spec-rejected", f"elements must be a positive multiple of {LINE_SIZE}"
+        )
+    if device != "npu2":
+        return _fail(workdir, "spec-rejected", f"unsupported device: {device}")
+
+    try:
+        _configure_toolchain_env()
+        import aie.iron as iron
+        from aie.iron.device import from_name
+
+        iron.set_current_device(from_name("npu2"))
+    except Exception as error:  # noqa: BLE001 - report any toolchain import/setup failure
+        return _fail(workdir, "template", f"toolchain setup failed: {error}")
+
+    try:
+        design = _build_identity(elements)
+        design.specialize(n=elements).compile(
+            xclbin_path=str(workdir / "final.xclbin"),
+            inst_path=str(workdir / "insts.bin"),
+        )
+    except Exception as error:  # noqa: BLE001 - aiecc/Peano failures are reported as a stage
+        return _fail(workdir, "compile", f"{error}\n{traceback.format_exc()}")
+
+    if not (workdir / "final.xclbin").is_file() or not (workdir / "insts.bin").is_file():
+        return _fail(workdir, "package", "compiler produced no artifacts")
+
+    (workdir / "result.json").write_text(
+        json.dumps(
+            {
+                "schema": 1,
+                "ok": True,
+                "stage": "done",
+                "entry": "MLIR_AIE",
+                "inputs": 1,
+                "outputs": 1,
+            }
+        )
+    )
+    return 0
+
+
+def main() -> int:
+    args = sys.argv[1:]
+    if len(args) == 1 and args[0] == "identity":
+        return _identity()
+    if len(args) == 2 and args[0] == "compile":
+        return _compile(Path(args[1]))
+    print("usage: xdna_compile.py (identity | compile <workdir>)", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/crates/virtio-accel-xdna/src/compiler.rs
+++ b/crates/virtio-accel-xdna/src/compiler.rs
@@ -1,0 +1,221 @@
+//! The bounded aiecc compiler-helper subprocess (compiler-helper contract, issue #84).
+//!
+//! `load_program` calls [`Compiler::compile`] with a validated [`CompilerSpec`] (integers and
+//! closed enums only — no guest bytes cross the boundary). The result is the precompiled artifact
+//! container (`src/artifact.rs`) HRX consumes, content-addressed in a cache so a repeated program
+//! shape never recompiles.
+//!
+//! The helper (`compiler/xdna_compile.py`, embedded here) runs under the pinned toolchain's venv
+//! interpreter with a **cleared environment** plus only the toolchain prefix and a private workdir;
+//! it self-configures the aiecc toolchain from the prefix. The compiler is never a Cargo dependency
+//! and never runs in-process.
+
+use std::fs;
+use std::hash::{Hash, Hasher};
+use std::os::unix::process::CommandExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use virtio_accel_core::BackendError;
+
+use crate::artifact;
+use crate::lower::{CompilerSpec, SpecDType, SpecOp};
+use crate::native::XDNA_ERROR_DOMAIN;
+
+/// The embedded compiler helper; written into each private workdir before invocation.
+const HELPER_SOURCE: &str = include_str!("../compiler/xdna_compile.py");
+
+/// Default wall-clock bound for one compile (reference-machine compiles run ~1 min).
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(600);
+
+/// Error-code offsets within [`XDNA_ERROR_DOMAIN`] for compiler failures.
+mod code {
+    pub const TOOLCHAIN_MISSING: i64 = 100;
+    pub const SPAWN: i64 = 101;
+    pub const TIMEOUT: i64 = 102;
+    pub const HELPER_FAILED: i64 = 103;
+    pub const BAD_OUTPUT: i64 = 104;
+    pub const IO: i64 = 105;
+}
+
+fn external(code: i64) -> BackendError {
+    BackendError::External {
+        domain: XDNA_ERROR_DOMAIN,
+        code,
+    }
+}
+
+/// The `spec.json` the helper reads: integers and closed enums only.
+fn spec_json(spec: CompilerSpec) -> String {
+    let op = match spec.op {
+        SpecOp::Identity => "IDENTITY",
+    };
+    let dtype = match spec.dtype {
+        SpecDType::Bf16 => "bf16",
+    };
+    format!(
+        "{{\"op\":\"{op}\",\"dtype\":\"{dtype}\",\"elements\":{},\"device\":\"npu2\",\
+         \"fold_ddr_addr_offset\":false}}",
+        spec.elements,
+    )
+}
+
+/// The compiler-helper driver: a pinned toolchain prefix and a content-addressed artifact cache.
+pub struct Compiler {
+    toolchain: PathBuf,
+    interpreter: PathBuf,
+    cache_dir: PathBuf,
+    timeout: Duration,
+}
+
+impl Compiler {
+    /// Resolve the toolchain prefix (`VIRTIO_ACCEL_AMDXDNA_TOOLCHAIN`) and the cache directory
+    /// (`VIRTIO_ACCEL_XDNA_CACHE`, else `$XDG_CACHE_HOME`/`$HOME`-derived).
+    pub fn from_env() -> Result<Self, BackendError> {
+        let toolchain = std::env::var_os("VIRTIO_ACCEL_AMDXDNA_TOOLCHAIN")
+            .map(PathBuf::from)
+            .ok_or_else(|| external(code::TOOLCHAIN_MISSING))?;
+        let interpreter = toolchain.join("ironenv/bin/python3");
+        if !interpreter.is_file() {
+            return Err(external(code::TOOLCHAIN_MISSING));
+        }
+        let cache_dir = cache_root()?;
+        Ok(Self {
+            toolchain,
+            interpreter,
+            cache_dir,
+            timeout: DEFAULT_TIMEOUT,
+        })
+    }
+
+    /// Compile `spec` to a precompiled-artifact container, using the cache when warm.
+    pub fn compile(&self, spec: CompilerSpec) -> Result<Vec<u8>, BackendError> {
+        let key = self.cache_key(spec);
+        let cached = self.cache_dir.join(format!("{key}.xdnp"));
+        if let Ok(bytes) = fs::read(&cached) {
+            if artifact::PrecompiledArtifact::parse(&bytes).is_ok() {
+                return Ok(bytes);
+            }
+        }
+        let bytes = self.run_helper(spec)?;
+        // Validate before caching, then write atomically (temp + rename) so a concurrent reader
+        // never observes a partial file.
+        artifact::PrecompiledArtifact::parse(&bytes).map_err(|_| external(code::BAD_OUTPUT))?;
+        fs::create_dir_all(&self.cache_dir).map_err(|_| external(code::IO))?;
+        let staging = self
+            .cache_dir
+            .join(format!("{key}.{}.tmp", unique_suffix()));
+        if fs::write(&staging, &bytes).is_ok() {
+            let _ = fs::rename(&staging, &cached);
+        }
+        Ok(bytes)
+    }
+
+    /// Content-address the artifact: spec ‖ toolchain prefix ‖ embedded helper source. Two graphs
+    /// with the same op/dtype/element count compile to the same artifact, so the spec is a complete
+    /// key; the prefix and helper source invalidate on a toolchain or helper change.
+    fn cache_key(&self, spec: CompilerSpec) -> String {
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        1u32.hash(&mut hasher); // key schema version
+        spec.hash(&mut hasher);
+        self.toolchain.hash(&mut hasher);
+        HELPER_SOURCE.hash(&mut hasher);
+        format!("{:016x}", hasher.finish())
+    }
+
+    fn run_helper(&self, spec: CompilerSpec) -> Result<Vec<u8>, BackendError> {
+        let workdir =
+            self.cache_dir
+                .join(format!(".wk-{}-{}", std::process::id(), unique_suffix()));
+        let result = self.run_helper_in(spec, &workdir);
+        let _ = fs::remove_dir_all(&workdir);
+        result
+    }
+
+    fn run_helper_in(&self, spec: CompilerSpec, workdir: &Path) -> Result<Vec<u8>, BackendError> {
+        let cache = workdir.join("cache");
+        fs::create_dir_all(&cache).map_err(|_| external(code::IO))?;
+        fs::write(workdir.join("spec.json"), spec_json(spec)).map_err(|_| external(code::IO))?;
+        let helper = workdir.join("xdna_compile.py");
+        fs::write(&helper, HELPER_SOURCE).map_err(|_| external(code::IO))?;
+
+        // Cleared environment plus only the pins the helper self-configures from.
+        let mut child = Command::new(&self.interpreter)
+            .arg(&helper)
+            .arg("compile")
+            .arg(workdir)
+            .env_clear()
+            .env("VIRTIO_ACCEL_AMDXDNA_TOOLCHAIN", &self.toolchain)
+            .env("PATH", "/usr/bin:/bin")
+            .env("HOME", workdir)
+            .env("TMPDIR", workdir)
+            .env("NPU_CACHE_HOME", &cache)
+            .process_group(0)
+            .spawn()
+            .map_err(|_| external(code::SPAWN))?;
+
+        let deadline = Instant::now() + self.timeout;
+        loop {
+            match child.try_wait() {
+                Ok(Some(status)) => {
+                    if !status.success() {
+                        return Err(external(code::HELPER_FAILED));
+                    }
+                    break;
+                }
+                Ok(None) => {
+                    if Instant::now() >= deadline {
+                        let _ = child.kill();
+                        let _ = child.wait();
+                        return Err(external(code::TIMEOUT));
+                    }
+                    std::thread::sleep(Duration::from_millis(20));
+                }
+                Err(_) => return Err(external(code::HELPER_FAILED)),
+            }
+        }
+
+        // The helper reports its I/O plan in result.json; read the artifacts and package them.
+        let xclbin =
+            fs::read(workdir.join("final.xclbin")).map_err(|_| external(code::BAD_OUTPUT))?;
+        let insts = fs::read(workdir.join("insts.bin")).map_err(|_| external(code::BAD_OUTPUT))?;
+        let (inputs, outputs) = read_io_counts(&workdir.join("result.json"))?;
+        Ok(artifact::encode(
+            "MLIR_AIE", inputs, outputs, &xclbin, &insts,
+        ))
+    }
+}
+
+/// Parse `inputs`/`outputs` from the helper's `result.json` (a tiny, helper-authored file).
+fn read_io_counts(path: &Path) -> Result<(u32, u32), BackendError> {
+    let text = fs::read_to_string(path).map_err(|_| external(code::BAD_OUTPUT))?;
+    let field = |name: &str| -> Option<u32> {
+        let needle = format!("\"{name}\"");
+        let start = text.find(&needle)? + needle.len();
+        let rest = text[start..].trim_start().strip_prefix(':')?.trim_start();
+        let digits: String = rest.chars().take_while(char::is_ascii_digit).collect();
+        digits.parse().ok()
+    };
+    match (field("inputs"), field("outputs")) {
+        (Some(inputs), Some(outputs)) if inputs > 0 => Ok((inputs, outputs)),
+        _ => Err(external(code::BAD_OUTPUT)),
+    }
+}
+
+fn cache_root() -> Result<PathBuf, BackendError> {
+    if let Some(dir) = std::env::var_os("VIRTIO_ACCEL_XDNA_CACHE") {
+        return Ok(PathBuf::from(dir));
+    }
+    if let Some(dir) = std::env::var_os("XDG_CACHE_HOME") {
+        return Ok(PathBuf::from(dir).join("virtio-accel-xdna"));
+    }
+    let home = std::env::var_os("HOME").ok_or_else(|| external(code::IO))?;
+    Ok(PathBuf::from(home).join(".cache/virtio-accel-xdna"))
+}
+
+fn unique_suffix() -> u64 {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    COUNTER.fetch_add(1, Ordering::Relaxed)
+}

--- a/crates/virtio-accel-xdna/src/lib.rs
+++ b/crates/virtio-accel-xdna/src/lib.rs
@@ -12,12 +12,13 @@
 //! loudly) or off (`0`). Hosts without HRX build and unit-test the portable admission surface
 //! (`lower`) plus a compile-only placeholder, and compile no `unsafe` at all.
 //!
-//! **Scope today:** the full `Accelerator` lifecycle for a *precompiled* artifact — the HRX
-//! device/stream owner, `hrx_buffer` primitives (persistent mapping, range flush/invalidate,
-//! release), and the serialized dispatch worker bridging `hrx_stream_dispatch`/`synchronize` to a
-//! latched nonblocking `poll_event` (execution-model spec, issue #85). `load_program` accepts the
-//! crate-local precompiled format ([`artifact`]); TOSA compilation is a later ticket, so a
-//! TOSA-format artifact is rejected with `Unsupported`.
+//! **Scope today:** the full `Accelerator` lifecycle — the HRX device/stream owner, `hrx_buffer`
+//! primitives (persistent mapping, range flush/invalidate, release), and the serialized dispatch
+//! worker bridging `hrx_stream_dispatch`/`synchronize` to a latched nonblocking `poll_event`
+//! (execution-model spec, issue #85). `load_program` accepts the crate-local precompiled format
+//! ([`artifact`]) directly, and a TOSA artifact by admitting it and compiling it with the bounded
+//! aiecc helper subprocess (issue #84). The compilable TOSA subset today is the BF16 IDENTITY (a
+//! DMA copy); the compute tiers grow on top of it. Admission (`lower`) unit-tests on every host.
 
 #![cfg_attr(not(va_xdna), forbid(unsafe_code))]
 
@@ -55,6 +56,8 @@ impl core::fmt::Display for InitError {
 impl std::error::Error for InitError {}
 
 #[cfg(va_xdna)]
+mod compiler;
+#[cfg(va_xdna)]
 mod ffi;
 #[cfg(va_xdna)]
 mod native;
@@ -62,6 +65,26 @@ mod native;
 pub use native::{
     XDNA_ERROR_DOMAIN, XdnaAccelerator, XdnaBuffer, XdnaContext, XdnaEvent, XdnaProgram, XdnaQueue,
 };
+
+/// Admit a TOSA artifact and compile it to a precompiled-artifact container ([`artifact`]) with
+/// the pinned toolchain, without touching the device.
+///
+/// This is the offline / catalog-population path (compiler-helper contract, issue #84): a build
+/// host produces artifacts that a device-less serving host later loads through the precompiled
+/// format. Requires the toolchain (`VIRTIO_ACCEL_AMDXDNA_TOOLCHAIN`); it never initializes HRX.
+#[cfg(va_xdna)]
+pub fn compile_artifact(
+    tosa: &[u8],
+    target: virtio_accel_tosa::Target,
+) -> Result<Vec<u8>, virtio_accel_core::BackendError> {
+    use virtio_accel_core::BackendError;
+    let spec = lower::admit(tosa, target).map_err(|error| match error {
+        lower::AdmitError::Parse => BackendError::InvalidArgument,
+        lower::AdmitError::Analysis => BackendError::Incompatible,
+        lower::AdmitError::Unsupported => BackendError::Unsupported,
+    })?;
+    compiler::Compiler::from_env()?.compile(spec)
+}
 
 /// Placeholder that keeps workspace consumers portable when no HRX runtime was detected.
 #[cfg(not(va_xdna))]

--- a/crates/virtio-accel-xdna/src/lib.rs
+++ b/crates/virtio-accel-xdna/src/lib.rs
@@ -26,7 +26,10 @@ pub mod artifact;
 mod lower;
 
 pub use artifact::{PrecompiledArtifact, XDNA_PRECOMPILED_FORMAT};
-pub use lower::{XDNA_TOSA_INTEGER_TARGET, XDNA_TOSA_TARGET};
+pub use lower::{
+    AdmitError, CompilerSpec, IDENTITY_LINE_SIZE, SpecDType, SpecOp, XDNA_TOSA_INTEGER_TARGET,
+    XDNA_TOSA_TARGET, admit,
+};
 
 /// The HRX runtime publishes no finite upper bound for a loaded program's device residency.
 ///

--- a/crates/virtio-accel-xdna/src/lower.rs
+++ b/crates/virtio-accel-xdna/src/lower.rs
@@ -1,12 +1,15 @@
-//! Portable TOSA admission surface for the XDNA backend.
+//! Portable TOSA admission for the XDNA backend.
 //!
-//! This module compiles on every host (no HRX, no `unsafe`) and declares the backend's public
-//! numerical promise: the two `Target` constants decided in the numerical-tier ticket (issue #82).
-//! Graph-level admission (target-equality gating, the per-operator dtype sweep, and emission of the
-//! compiler-helper input) lands with the TOSA-admission ticket on top of these constants; keeping
-//! the targets here now lets the placeholder and the future native path name one authority.
+//! This module compiles on every host (no HRX, no `unsafe`). It declares the backend's advertised
+//! `Target` constants (issue #82) and [`admit`]s a TOSA artifact into a [`CompilerSpec`] — the
+//! validated, integers-and-enums-only description the compiler helper (issue #84) turns into an
+//! amdxdna artifact. Anything outside the advertised subset is rejected here, before any subprocess
+//! runs. Graph lowering for compute tiers grows on top of this; today the compilable op is the
+//! BF16 IDENTITY (a DMA copy).
 
-use virtio_accel_tosa::{ExtensionSet, Level, ProfileSet, Target, Version};
+use virtio_accel_tosa::{
+    AnalyzedValueKind, DType, ExtensionSet, Level, Op, ProfileSet, Target, Version, parse,
+};
 
 /// The BF16 floating-point tier: TOSA 1.0, floating-point profile, level 8K, BF16 extension.
 ///
@@ -30,35 +33,178 @@ pub const XDNA_TOSA_INTEGER_TARGET: Target = Target::new(
     ExtensionSet::NONE,
 );
 
+/// The DMA line size the IDENTITY template transfers in; an admitted element count must be a
+/// positive multiple of it. Kept in sync with `compiler/xdna_compile.py`.
+pub const IDENTITY_LINE_SIZE: usize = 1024;
+
+/// A validated operator specialization ready for the compiler helper.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct CompilerSpec {
+    pub op: SpecOp,
+    pub dtype: SpecDType,
+    /// Total element count (a positive multiple of [`IDENTITY_LINE_SIZE`]).
+    pub elements: usize,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum SpecOp {
+    Identity,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum SpecDType {
+    Bf16,
+}
+
+/// Why a TOSA artifact is not admissible to the compilable subset.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AdmitError {
+    /// The bytes are not a valid TOSA artifact.
+    Parse,
+    /// The graph is valid TOSA but not for the requested target.
+    Analysis,
+    /// The graph is admissible TOSA but outside the compilable subset.
+    Unsupported,
+}
+
+/// Admit a TOSA artifact for `target`, returning the specialization the helper compiles.
+///
+/// Only the BF16 IDENTITY subset is compilable today: one region and block, a single BF16 input
+/// and output, IDENTITY operators only, every tensor BF16, and an element count that is a positive
+/// multiple of [`IDENTITY_LINE_SIZE`]. Everything else is rejected without running the compiler.
+pub fn admit(bytes: &[u8], target: Target) -> Result<CompilerSpec, AdmitError> {
+    if target != XDNA_TOSA_TARGET {
+        // The integer tier and other targets are later tickets.
+        return Err(AdmitError::Unsupported);
+    }
+    let model = parse(bytes).map_err(|_| AdmitError::Parse)?;
+    let analysis = model
+        .analyze_for(target)
+        .map_err(|_| AdmitError::Analysis)?;
+
+    if analysis.regions().len() != 1
+        || analysis.blocks().len() != 1
+        || !analysis.conditions().is_empty()
+    {
+        return Err(AdmitError::Unsupported);
+    }
+    let block = analysis.blocks()[0].id();
+    let inputs = analysis.block_inputs(block);
+    let outputs = analysis.block_outputs(block);
+    if inputs.len() != 1 || outputs.len() != 1 {
+        return Err(AdmitError::Unsupported);
+    }
+
+    // Only IDENTITY operators, and every tensor value BF16.
+    for operator in analysis.execution_order(block) {
+        if analysis.operator(*operator).op() != Op::IDENTITY {
+            return Err(AdmitError::Unsupported);
+        }
+    }
+    for value in analysis.values() {
+        if let AnalyzedValueKind::Tensor(tensor) = value.kind() {
+            if tensor.dtype() != DType::BF16 {
+                return Err(AdmitError::Unsupported);
+            }
+        }
+    }
+
+    let AnalyzedValueKind::Tensor(output) = analysis.value(outputs[0]).kind() else {
+        return Err(AdmitError::Unsupported);
+    };
+    output.rank().ok_or(AdmitError::Unsupported)?;
+    let mut elements: usize = 1;
+    for dimension in output.dimensions() {
+        elements = elements
+            .checked_mul(dimension as usize)
+            .ok_or(AdmitError::Unsupported)?;
+    }
+    if elements == 0 || elements % IDENTITY_LINE_SIZE != 0 {
+        return Err(AdmitError::Unsupported);
+    }
+
+    Ok(CompilerSpec {
+        op: SpecOp::Identity,
+        dtype: SpecDType::Bf16,
+        elements,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use virtio_accel_tosa::Target;
+    use virtio_accel_tosa_build::{OperatorKind, OwnedGraph, OwnedOperator, OwnedTensor};
+
+    fn identity_graph(dtype: DType, shape: Vec<i32>) -> OwnedGraph<'static> {
+        let mut graph = OwnedGraph::new("main");
+        graph.push_tensor(OwnedTensor::new("x", shape.clone(), dtype));
+        graph.push_tensor(OwnedTensor::new("y", shape, dtype));
+        graph.push_operator(OwnedOperator::new(
+            OperatorKind::Identity,
+            vec!["x".into()],
+            vec!["y".into()],
+        ));
+        graph.push_input("x");
+        graph.push_output("y");
+        graph
+    }
 
     #[test]
-    fn both_targets_are_coherent() {
-        // `validate` rejects an extension without its base profile; BF16 requires the
-        // floating-point profile, so this proves the tier targets are self-consistent.
+    fn both_targets_are_coherent_and_distinct() {
         assert_eq!(XDNA_TOSA_TARGET.validate(), Ok(XDNA_TOSA_TARGET));
         assert_eq!(
             XDNA_TOSA_INTEGER_TARGET.validate(),
             Ok(XDNA_TOSA_INTEGER_TARGET)
         );
-    }
-
-    #[test]
-    fn targets_round_trip_through_their_identity() {
+        assert_ne!(XDNA_TOSA_TARGET, XDNA_TOSA_INTEGER_TARGET);
         for target in [XDNA_TOSA_TARGET, XDNA_TOSA_INTEGER_TARGET] {
             assert_eq!(Target::from_identity(target.to_identity()), Ok(target));
         }
     }
 
     #[test]
-    fn the_two_tiers_are_distinct() {
-        assert_ne!(XDNA_TOSA_TARGET, XDNA_TOSA_INTEGER_TARGET);
-        assert_ne!(
-            XDNA_TOSA_TARGET.to_identity(),
-            XDNA_TOSA_INTEGER_TARGET.to_identity()
+    fn admits_bf16_identity() {
+        let bytes = identity_graph(DType::BF16, vec![1, 4, 1024])
+            .build(XDNA_TOSA_TARGET)
+            .expect("build bf16 identity");
+        let spec = admit(&bytes, XDNA_TOSA_TARGET).expect("admit");
+        assert_eq!(spec.op, SpecOp::Identity);
+        assert_eq!(spec.dtype, SpecDType::Bf16);
+        assert_eq!(spec.elements, 4 * 1024);
+    }
+
+    #[test]
+    fn rejects_fp32_identity() {
+        // FP32 is admissible TOSA under the floating-point profile but outside the BF16 tier.
+        let bytes = identity_graph(DType::FP32, vec![1, 4, 1024])
+            .build(XDNA_TOSA_TARGET)
+            .expect("build fp32 identity");
+        assert_eq!(
+            admit(&bytes, XDNA_TOSA_TARGET),
+            Err(AdmitError::Unsupported)
+        );
+    }
+
+    #[test]
+    fn rejects_non_multiple_of_line_size() {
+        let bytes = identity_graph(DType::BF16, vec![1, 1, 100])
+            .build(XDNA_TOSA_TARGET)
+            .expect("build small identity");
+        assert_eq!(
+            admit(&bytes, XDNA_TOSA_TARGET),
+            Err(AdmitError::Unsupported)
+        );
+    }
+
+    #[test]
+    fn rejects_wrong_target() {
+        let bytes = identity_graph(DType::BF16, vec![1, 4, 1024])
+            .build(XDNA_TOSA_TARGET)
+            .expect("build");
+        assert_eq!(
+            admit(&bytes, XDNA_TOSA_INTEGER_TARGET),
+            Err(AdmitError::Unsupported)
         );
     }
 }

--- a/crates/virtio-accel-xdna/src/native.rs
+++ b/crates/virtio-accel-xdna/src/native.rs
@@ -6,9 +6,10 @@
 //! serialized dispatch worker, a bounded preallocated submission ring and event-slot pool, and the
 //! `hrx_buffer` primitives (persistent host mapping, range flush/invalidate, release).
 //!
-//! Program loading accepts the crate-local precompiled artifact format (`load_program`), builds an
-//! `hrx_amdxdna_executable`, and dispatches it through the worker. TOSA compilation is a later
-//! ticket; a TOSA-format artifact is rejected with `Unsupported`. Finite timeouts are rejected
+//! `load_program` accepts the crate-local precompiled artifact format directly, and a TOSA
+//! artifact by admitting it (`lower`) and compiling it with the bounded helper subprocess
+//! (`compiler`); it builds an `hrx_amdxdna_executable` and dispatches it through the worker.
+//! Finite timeouts are rejected
 //! before admission (no cancellation exists); a synchronize error latches the event `Failed` and
 //! poisons the instance (device-loss tier 1). The tier-2 wedge watchdog is the fault-paths ticket.
 
@@ -30,7 +31,9 @@ use virtio_accel_core::{
 
 use crate::InitError;
 use crate::artifact::{self, PrecompiledArtifact};
+use crate::compiler::Compiler;
 use crate::ffi;
+use crate::lower;
 
 /// `BackendError::External` domain tag for HRX failures ("XDNA" in ASCII).
 pub const XDNA_ERROR_DOMAIN: u32 = 0x5844_4e41;
@@ -297,6 +300,7 @@ pub struct XdnaAccelerator {
     lane: Arc<Lane>,
     worker: Option<JoinHandle<()>>,
     slots: Vec<Arc<EventSlot>>,
+    compiler: Option<Compiler>,
     info: DeviceInfo,
     next_id: AtomicU64,
     _not_send_sync: PhantomData<*mut u8>,
@@ -337,6 +341,7 @@ impl XdnaAccelerator {
             lane,
             worker: Some(worker),
             slots,
+            compiler: Compiler::from_env().ok(),
             info: device_info(),
             next_id: AtomicU64::new(1),
             _not_send_sync: PhantomData,
@@ -403,6 +408,104 @@ fn device_info() -> DeviceInfo {
             max_artifact_bytes: MAX_TOSA_ARTIFACT_BYTES,
         },
     }
+}
+
+/// Create and load an amdxdna executable from a parsed precompiled artifact.
+fn build_executable(
+    device: &SharedDevice,
+    parsed: PrecompiledArtifact<'_>,
+) -> Result<XdnaProgram, BackendError> {
+    // Build the borrowed create-params (valid only for the duration of the create call).
+    let xclbin_span = ffi::hrx_const_byte_span_t {
+        data: parsed.xclbin.as_ptr().cast(),
+        data_length: parsed.xclbin.len(),
+    };
+    let run = ffi::hrx_amdxdna_executable_run_t {
+        record_length: size_of::<ffi::hrx_amdxdna_executable_run_t>() as u32,
+        abi_version: ffi::HRX_AMDXDNA_EXECUTABLE_RUN_ABI_VERSION_0,
+        transaction: ffi::hrx_const_byte_span_t {
+            data: parsed.insts.as_ptr().cast(),
+            data_length: parsed.insts.len(),
+        },
+        data_payload: ffi::hrx_const_byte_span_t {
+            data: ptr::null(),
+            data_length: 0,
+        },
+    };
+    let entry = ffi::hrx_amdxdna_executable_entry_point_t {
+        record_length: size_of::<ffi::hrx_amdxdna_executable_entry_point_t>() as u32,
+        abi_version: ffi::HRX_AMDXDNA_EXECUTABLE_ENTRY_POINT_ABI_VERSION_0,
+        name: ffi::hrx_string_view_t {
+            data: parsed.entry.as_ptr().cast(),
+            size: parsed.entry.len(),
+        },
+        context_mode: ffi::HRX_AMDXDNA_CONTEXT_MODE_CREATE,
+        xclbin_ordinal: 0,
+        pdi_ordinal: 0,
+        source_line: 0,
+        source_file: ffi::hrx_string_view_t {
+            data: ptr::null(),
+            size: 0,
+        },
+        runs: &run,
+        run_count: 1,
+    };
+    let params = ffi::hrx_amdxdna_executable_create_params_t {
+        record_length: size_of::<ffi::hrx_amdxdna_executable_create_params_t>() as u32,
+        abi_version: ffi::HRX_AMDXDNA_EXECUTABLE_CREATE_PARAMS_ABI_VERSION_0,
+        flags: 0,
+        reserved: 0,
+        xclbins: &xclbin_span,
+        xclbin_count: 1,
+        entry_points: &entry,
+        entry_point_count: 1,
+    };
+
+    let mut executable: ffi::hrx_executable_t = ptr::null_mut();
+    // SAFETY: the device is live; every span/record referenced by `params` is borrowed from
+    // `parsed`, which outlives this call; the out-pointer is a valid local; status consumed. HRX
+    // copies what it needs and the borrows may be released after return.
+    let status =
+        unsafe { ffi::hrx_amdxdna_executable_create(device.0.as_ptr(), &params, &mut executable) };
+    check(status)?;
+    let executable = NonNull::new(executable).ok_or(BackendError::External {
+        domain: XDNA_ERROR_DOMAIN,
+        code: 0,
+    })?;
+
+    // Resolve the export ordinal by entry-point name.
+    let ordinal = CString::new(parsed.entry)
+        .map_err(|_| BackendError::InvalidArgument)
+        .and_then(|entry_c| {
+            let mut ordinal: u32 = 0;
+            // SAFETY: the executable is live; `entry_c` is a valid NUL-terminated string; the
+            // out-pointer is a valid local; status consumed.
+            let status = unsafe {
+                ffi::hrx_executable_lookup_export_by_name(
+                    executable.as_ptr(),
+                    entry_c.as_ptr(),
+                    &mut ordinal,
+                )
+            };
+            check(status).map(|()| ordinal)
+        });
+    let ordinal = match ordinal {
+        Ok(ordinal) => ordinal,
+        Err(error) => {
+            // SAFETY: the executable is live and owned here; release it before returning.
+            unsafe { ffi::hrx_executable_release(executable.as_ptr()) };
+            return Err(error);
+        }
+    };
+
+    Ok(XdnaProgram {
+        inner: Arc::new(ProgramInner {
+            executable,
+            ordinal,
+            inputs: parsed.inputs,
+            outputs: parsed.outputs,
+        }),
+    })
 }
 
 /// A logical execution context. HRX holds no per-context state; the id supports accounting.
@@ -668,10 +771,6 @@ impl Accelerator for XdnaAccelerator {
         if self.lane.is_poisoned() {
             return Err(BackendError::DeviceLost);
         }
-        // TOSA compilation is a later ticket; only the crate-local precompiled format loads today.
-        if artifact.format != artifact::XDNA_PRECOMPILED_FORMAT {
-            return Err(BackendError::Unsupported);
-        }
         if artifact.payload.len() > self.info.limits.max_artifact_bytes {
             return Err(BackendError::ResourceLimit);
         }
@@ -684,100 +783,28 @@ impl Accelerator for XdnaAccelerator {
         bytes.resize(len, 0);
         artifact.payload.read_at(0, &mut bytes)?;
 
-        let parsed = PrecompiledArtifact::parse(&bytes)?;
+        // The precompiled format loads directly; a TOSA artifact is admitted and compiled to one.
+        let container = if artifact.format == artifact::XDNA_PRECOMPILED_FORMAT {
+            bytes
+        } else if artifact.format == virtio_accel_tosa::ARTIFACT_FORMAT {
+            let target = virtio_accel_tosa::Target::from_identity(artifact.target)
+                .map_err(|_| BackendError::Incompatible)?;
+            let spec = lower::admit(&bytes, target).map_err(|error| match error {
+                lower::AdmitError::Parse => BackendError::InvalidArgument,
+                lower::AdmitError::Analysis => BackendError::Incompatible,
+                lower::AdmitError::Unsupported => BackendError::Unsupported,
+            })?;
+            self.compiler
+                .as_ref()
+                .ok_or(BackendError::Unsupported)?
+                .compile(spec)?
+        } else {
+            return Err(BackendError::Unsupported);
+        };
+
+        let parsed = PrecompiledArtifact::parse(&container)?;
         let device = shared_device().map_err(|_| BackendError::DeviceLost)?;
-
-        // Build the borrowed create-params (valid only for the duration of the create call).
-        let xclbin_span = ffi::hrx_const_byte_span_t {
-            data: parsed.xclbin.as_ptr().cast(),
-            data_length: parsed.xclbin.len(),
-        };
-        let run = ffi::hrx_amdxdna_executable_run_t {
-            record_length: size_of::<ffi::hrx_amdxdna_executable_run_t>() as u32,
-            abi_version: ffi::HRX_AMDXDNA_EXECUTABLE_RUN_ABI_VERSION_0,
-            transaction: ffi::hrx_const_byte_span_t {
-                data: parsed.insts.as_ptr().cast(),
-                data_length: parsed.insts.len(),
-            },
-            data_payload: ffi::hrx_const_byte_span_t {
-                data: ptr::null(),
-                data_length: 0,
-            },
-        };
-        let entry = ffi::hrx_amdxdna_executable_entry_point_t {
-            record_length: size_of::<ffi::hrx_amdxdna_executable_entry_point_t>() as u32,
-            abi_version: ffi::HRX_AMDXDNA_EXECUTABLE_ENTRY_POINT_ABI_VERSION_0,
-            name: ffi::hrx_string_view_t {
-                data: parsed.entry.as_ptr().cast(),
-                size: parsed.entry.len(),
-            },
-            context_mode: ffi::HRX_AMDXDNA_CONTEXT_MODE_CREATE,
-            xclbin_ordinal: 0,
-            pdi_ordinal: 0,
-            source_line: 0,
-            source_file: ffi::hrx_string_view_t {
-                data: ptr::null(),
-                size: 0,
-            },
-            runs: &run,
-            run_count: 1,
-        };
-        let params = ffi::hrx_amdxdna_executable_create_params_t {
-            record_length: size_of::<ffi::hrx_amdxdna_executable_create_params_t>() as u32,
-            abi_version: ffi::HRX_AMDXDNA_EXECUTABLE_CREATE_PARAMS_ABI_VERSION_0,
-            flags: 0,
-            reserved: 0,
-            xclbins: &xclbin_span,
-            xclbin_count: 1,
-            entry_points: &entry,
-            entry_point_count: 1,
-        };
-
-        let mut executable: ffi::hrx_executable_t = ptr::null_mut();
-        // SAFETY: the device is live; every span/record referenced by `params` is borrowed from
-        // `bytes`/`parsed`, which outlive this call; the out-pointer is a valid local; status
-        // consumed. HRX copies what it needs and the borrows may be released after return.
-        let status = unsafe {
-            ffi::hrx_amdxdna_executable_create(device.0.as_ptr(), &params, &mut executable)
-        };
-        check(status)?;
-        let executable = NonNull::new(executable).ok_or(BackendError::External {
-            domain: XDNA_ERROR_DOMAIN,
-            code: 0,
-        })?;
-
-        // Resolve the export ordinal by entry-point name.
-        let entry_c = CString::new(parsed.entry).map_err(|_| BackendError::InvalidArgument);
-        let ordinal = entry_c.and_then(|entry_c| {
-            let mut ordinal: u32 = 0;
-            // SAFETY: the executable is live; `entry_c` is a valid NUL-terminated string; the
-            // out-pointer is a valid local; status consumed.
-            let status = unsafe {
-                ffi::hrx_executable_lookup_export_by_name(
-                    executable.as_ptr(),
-                    entry_c.as_ptr(),
-                    &mut ordinal,
-                )
-            };
-            check(status).map(|()| ordinal)
-        });
-        let ordinal = match ordinal {
-            Ok(ordinal) => ordinal,
-            Err(error) => {
-                // SAFETY: the executable is live and owned here; release it before returning.
-                unsafe { ffi::hrx_executable_release(executable.as_ptr()) };
-                return Err(error);
-            }
-        };
-
-        Ok(XdnaProgram {
-            inner: Arc::new(ProgramInner {
-                executable,
-                ordinal,
-                inputs: parsed.inputs,
-                outputs: parsed.outputs,
-            }),
-        })
+        build_executable(device, parsed)
     }
 
     fn unload_program(&self, program: Self::Program) -> Result<(), ReleaseFailure<Self::Program>> {

--- a/crates/virtio-accel-xdna/tests/hardware.rs
+++ b/crates/virtio-accel-xdna/tests/hardware.rs
@@ -13,7 +13,32 @@ use virtio_accel_core::{
     BufferUsage, ByteSink, ByteSource, ContextDesc, EventState, MemoryDomain, QueueDesc,
     TargetIdentity, Timeout,
 };
-use virtio_accel_xdna::{InitError, XDNA_PRECOMPILED_FORMAT, XdnaAccelerator};
+use virtio_accel_tosa::{ARTIFACT_FORMAT, DType};
+use virtio_accel_tosa_build::{OperatorKind, OwnedGraph, OwnedOperator, OwnedTensor};
+use virtio_accel_xdna::{
+    InitError, XDNA_PRECOMPILED_FORMAT, XDNA_TOSA_TARGET, XdnaAccelerator, compile_artifact,
+};
+
+/// Whether the pinned compiler toolchain is configured (the compiler tests need it, not a device).
+fn toolchain_present() -> bool {
+    std::env::var_os("VIRTIO_ACCEL_AMDXDNA_TOOLCHAIN").is_some()
+}
+
+/// Author a BF16 IDENTITY TOSA artifact of `elements` for the advertised target.
+fn bf16_identity_tosa(elements: usize) -> Vec<u8> {
+    let shape = vec![1, 1, elements as i32];
+    let mut graph = OwnedGraph::new("main");
+    graph.push_tensor(OwnedTensor::new("x", shape.clone(), DType::BF16));
+    graph.push_tensor(OwnedTensor::new("y", shape, DType::BF16));
+    graph.push_operator(OwnedOperator::new(
+        OperatorKind::Identity,
+        vec!["x".into()],
+        vec!["y".into()],
+    ));
+    graph.push_input("x");
+    graph.push_output("y");
+    graph.build(XDNA_TOSA_TARGET).expect("build bf16 identity")
+}
 
 /// Precompiled DMA passthrough for npu2, built with the pinned toolchain from
 /// `programming_examples/basic/passthrough_dmas` (n=4096 int32; entry `MLIR_AIE`) and packaged with
@@ -324,6 +349,151 @@ fn precompiled_passthrough_runs_the_full_lifecycle() {
     backend.destroy_event(event).expect("destroy event");
     backend.free_buffer(input).expect("free input");
     backend.free_buffer(unused).expect("free unused");
+    backend.free_buffer(output).expect("free output");
+    backend.unload_program(program).expect("unload");
+    backend.destroy_queue(queue).expect("destroy queue");
+    backend.destroy_context(context).expect("destroy context");
+}
+
+#[test]
+fn tosa_bf16_identity_compiles_to_a_wellformed_artifact() {
+    // Hardware-free: needs the compiler toolchain but never initializes a device.
+    if !toolchain_present() {
+        eprintln!("no XDNA toolchain configured; skipping compiler test");
+        return;
+    }
+    let tosa = bf16_identity_tosa(4096);
+    let container = compile_artifact(&tosa, XDNA_TOSA_TARGET).expect("compile TOSA identity");
+    let parsed =
+        virtio_accel_xdna::PrecompiledArtifact::parse(&container).expect("valid container");
+    // The packaged xclbin is an AMD xclbin container; its instruction stream is TXN words.
+    assert!(
+        parsed.xclbin.starts_with(b"xclbin2"),
+        "expected xclbin2 magic"
+    );
+    assert!(!parsed.insts.is_empty() && parsed.insts.len() % 4 == 0);
+    assert_eq!((parsed.inputs, parsed.outputs), (1, 1));
+    assert_eq!(parsed.entry, "MLIR_AIE");
+
+    // Non-subset graphs are rejected before any compile runs.
+    let fp32 = {
+        let shape = vec![1, 1, 4096];
+        let mut g = OwnedGraph::new("main");
+        g.push_tensor(OwnedTensor::new("x", shape.clone(), DType::FP32));
+        g.push_tensor(OwnedTensor::new("y", shape, DType::FP32));
+        g.push_operator(OwnedOperator::new(
+            OperatorKind::Identity,
+            vec!["x".into()],
+            vec!["y".into()],
+        ));
+        g.push_input("x");
+        g.push_output("y");
+        g.build(XDNA_TOSA_TARGET).expect("build fp32 identity")
+    };
+    assert!(matches!(
+        compile_artifact(&fp32, XDNA_TOSA_TARGET),
+        Err(BackendError::Unsupported)
+    ));
+}
+
+#[test]
+fn tosa_bf16_identity_runs_on_the_npu() {
+    let Some(backend) = backend() else { return };
+    if !toolchain_present() {
+        eprintln!("no XDNA toolchain configured; skipping TOSA execution test");
+        return;
+    }
+    const ELEMENTS: usize = 4096;
+    const BYTES: usize = ELEMENTS * 2; // bf16
+
+    let context = backend
+        .create_context(ContextDesc::default())
+        .expect("context");
+    let queue = backend
+        .create_queue(&context, QueueDesc::default())
+        .expect("queue");
+    let tosa = bf16_identity_tosa(ELEMENTS);
+    let program = backend
+        .load_program(
+            &context,
+            ArtifactRef {
+                format: ARTIFACT_FORMAT,
+                target: XDNA_TOSA_TARGET.to_identity(),
+                payload: &Slice(&tosa),
+                resident_bytes: u64::MAX,
+            },
+        )
+        .expect("load + compile TOSA identity");
+
+    let (mut input, _) = backend
+        .allocate_buffer(
+            &context,
+            BufferDesc::new(
+                BYTES as u64,
+                4096,
+                MemoryDomain::Shared,
+                BufferUsage::TRANSFER_DESTINATION | BufferUsage::PROGRAM_INPUT,
+            )
+            .unwrap(),
+        )
+        .expect("input")
+        .into_parts();
+    let (output, _) = backend
+        .allocate_buffer(
+            &context,
+            BufferDesc::new(
+                BYTES as u64,
+                4096,
+                MemoryDomain::Shared,
+                BufferUsage::TRANSFER_SOURCE | BufferUsage::PROGRAM_OUTPUT,
+            )
+            .unwrap(),
+        )
+        .expect("output")
+        .into_parts();
+
+    let payload: Vec<u8> = (0..BYTES).map(|i| (i * 13 + 5) as u8).collect();
+    backend
+        .write_buffer(&mut input, 0, &Slice(&payload))
+        .expect("write input");
+    let range = BufferRange::new(0, BYTES as u64).unwrap();
+    let bindings = [
+        BindingRef {
+            slot: 0,
+            buffer: &input,
+            range,
+            access: AccessMode::Read,
+        },
+        BindingRef {
+            slot: 1,
+            buffer: &output,
+            range,
+            access: AccessMode::Write,
+        },
+    ];
+    let event = backend
+        .submit(&queue, &program, &bindings, Timeout::Infinite)
+        .expect("submit");
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let state = loop {
+        match backend.poll_event(&event).expect("poll") {
+            EventState::Pending => {
+                assert!(Instant::now() < deadline, "identity did not complete");
+                std::thread::yield_now();
+            }
+            terminal => break terminal,
+        }
+    };
+    assert!(matches!(state, EventState::Complete), "got {state:?}");
+
+    let mut result = vec![0u8; BYTES];
+    backend
+        .read_buffer(&output, 0, &mut SliceMut(&mut result))
+        .expect("read output");
+    assert_eq!(result, payload, "TOSA IDENTITY must copy input to output");
+
+    backend.destroy_event(event).expect("destroy event");
+    backend.free_buffer(input).expect("free input");
     backend.free_buffer(output).expect("free output");
     backend.unload_program(program).expect("unload");
     backend.destroy_queue(queue).expect("destroy queue");

--- a/docs/portability.md
+++ b/docs/portability.md
@@ -70,16 +70,20 @@ advertised operators plus INT8 identity and zero-point-aware INT8 MATMUL through
 by the reusable semantic suite. A public hardware CI lane remains unavailable, so the README
 publishes the exact manual replacement commands.
 
-The AMD XDNA crate is currently the scaffold: portable CI compiles and unit-tests its admission
-surface (the two advertised `Target` constants) and a placeholder. HRX exposes a plain C ABI, so
-its build script has no `cc`/CMake step; it enables the native modules only when an amdxdna-native
-HRX prefix (`VIRTIO_ACCEL_HRX_DIR`/`HRX_DIR`) carries both HRX headers — the amdxdna header must
-declare `hrx_amdxdna_executable_create`, whose absence marks an older, incompatible libhrx
-generation — and `lib/libhrx.so`. `VIRTIO_ACCEL_XDNA=0` forces the placeholder,
+The AMD XDNA crate compiles its portable admission surface (`lower`, including the TOSA IDENTITY
+admission and the two advertised `Target` constants), the portable precompiled-artifact codec, and
+a placeholder on every host; portable CI unit-tests admission. HRX exposes a plain C ABI, so its
+build script has no `cc`/CMake step; it enables the native modules (HRX FFI, the `Accelerator`
+implementation with its serialized dispatch worker, and the compiler-helper subprocess) only when
+an amdxdna-native HRX prefix (`VIRTIO_ACCEL_HRX_DIR`/`HRX_DIR`) carries both HRX headers — the
+amdxdna header must declare `hrx_amdxdna_executable_create`, whose absence marks an older,
+incompatible libhrx generation — and `lib/libhrx.so`. `VIRTIO_ACCEL_XDNA=0` forces the placeholder,
 `VIRTIO_ACCEL_XDNA=1` makes a missing or incomplete runtime a build failure, and
 `VIRTIO_ACCEL_HRX_LIB_DIR` links a bare lib directory. No standard locations are scanned, keeping
-the toolchain pin authoritative. The native `Accelerator`, HRX FFI, and compiler helper land in
-later tickets of the AMD XDNA wayfinder map.
+the toolchain pin authoritative. On the reference machine with the pinned toolchain
+(`VIRTIO_ACCEL_AMDXDNA_TOOLCHAIN`) and an NPU, backend-local tests run a DMA passthrough and a
+compiled TOSA BF16 IDENTITY end to end; compilation invokes the aiecc helper as a bounded
+subprocess (never a Cargo dependency). A public hardware CI lane remains unavailable.
 
 Concrete VMM, kernel, OS, and vendor adapters are outside the portable-v1 milestone and must not
 become default dependencies of a portable crate.

--- a/docs/release-policy.md
+++ b/docs/release-policy.md
@@ -164,7 +164,7 @@ source.
 | 10 | `virtio-accel-device` | `core`, `proto`, `transport` | `mock` |
 | 11 | `virtio-accel-conformance` | `core` | `mock`, `tosa` |
 | 12 | `virtio-accel-vaccel` | `core` | `conformance` |
-| 13 | `virtio-accel-xdna` | `core`, `tosa` | — |
+| 13 | `virtio-accel-xdna` | `core`, `tosa` | `tosa-build` |
 | 14 | `virtio-accel-coreml` | `core`, `tosa` | `conformance` |
 | 15 | `virtio-accel-openvino` | `core`, `tosa` | `conformance` |
 | 16 | `virtio-accel-hexagon` | `core`, `tosa` | `conformance` |


### PR DESCRIPTION
# Why

Fourth code ticket of the AMD XDNA wayfinder map ([#78](https://github.com/MicroPerceptron/virtio-accel/issues/78)): TOSA graphs now **compile and run on the NPU**. Implements the compiler-helper contract (#84) and TOSA admission (#83) for the first tier operator — BF16 IDENTITY — end to end.

> **Stacked:** based on `task/xdna-execution-lifecycle` (PR #134), which is based on `task/xdna-ffi-buffers` (PR #127). Review #127 → #134 → this. Rebases onto `main` as they land.

Highlights:
- **`src/lower.rs`** — portable TOSA admission: parse + `analyze_for` + a strict subset check that turns an artifact into a validated `CompilerSpec` (integers and enums only) and rejects anything outside the BF16 IDENTITY subset *before any subprocess runs*. Unit-tested on **every host** (CI): admits BF16 identity; rejects FP32, non-line-size shapes, and the wrong target.
- **`compiler/xdna_compile.py`** — the embedded aiecc helper: an IDENTITY IRON template + spec-driven compile + a toolchain-identity mode, self-configuring the pinned toolchain (`NPU_RUNTIME=hrx` for the unfolded ABI, Peano/xclbinutil/HRX paths) under a cleared environment.
- **`src/compiler.rs`** — the bounded subprocess driver: cleared env + pinned prefix + private workdir, wall-clock timeout, own process group, and a content-addressed artifact cache (spec ‖ toolchain ‖ helper source). Never a Cargo dependency, never in-process.
- **`src/native.rs` `load_program`** — precompiled artifacts load directly; a TOSA artifact is admitted, compiled, and built into an executable (shared `build_executable`). `compile_artifact` exposes the admit-then-compile path **without a device** — the offline / catalog-population use from #84.
- **Tests** — CI admission unit tests; a hardware-free golden artifact test (compile IDENTITY, assert xclbin magic + FP32 rejection); and the on-NPU test compiling a TOSA BF16 IDENTITY through the helper and asserting output == input.

Deferred: MATMUL (#90), MAX_POOL2D (#91), full conformance + device-loss tier-2 (#92). The compute tiers add IRON templates to the same helper and dtype/op arms to admission.

## Compatibility

- [x] **No wire effect.** No accepted or emitted protocol bytes change.

## Checklist

- [x] Does not alter payload lengths, ownership, reset, error, timeout, or feature-negotiation behavior.
- [x] Authoritative conformance inputs untouched.
- [x] Public Rust API: adds `compile_artifact` and the portable `lower::{admit, CompilerSpec, ...}`; the TOSA path in `load_program`. No core/guest/device/transport changes.
- [x] No dependency/feature/target moves platform behavior into a portable crate — native path and compiler gated behind `va_xdna`; the compiler is a subprocess, not a linked dependency.
- [x] Unsafe under audit: no new `unsafe` (the compiler driver is safe code); `SAFETY.md` notes `compiler.rs` is safe; the FFI/native audit and release-policy entry stand.
- [x] Deferred features unadvertised: only BF16 IDENTITY compiles; other ops/dtypes and the integer target are rejected at admission.

## Verification

On the reference machine (Fedora 44, Krackan NPU, pinned toolchain):

```
cargo test -p virtio-accel-xdna            # incl. on-NPU TOSA IDENTITY compile+run (output == input)
# placeholder path (no HRX — the CI default): admission unit tests run here
cargo fmt --all -- --check
cargo clippy -p virtio-accel-xdna --all-targets --all-features -- -D warnings
RUSTDOCFLAGS=-D warnings cargo doc -p virtio-accel-xdna --no-deps
python3 ci/check-release-policy.py         # 17 published packages OK
python3 ci/publish-dry-run.py              # ordered dry run passed for all 17 crates
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)