### PR TITLE
Refine XDNA backend integration after review

### DIFF
--- a/crates/virtio-accel-xdna/README.md
+++ b/crates/virtio-accel-xdna/README.md
@@ -50,11 +50,11 @@ pin. Builds without the runtime still compile and unit-test the portable admissi
 
 ## Advertised numerical tier
 
-Per the numerical-tier decision (#82), the backend will advertise a BF16 floating-point tier (TOSA
-`EXT-BF16`) and a separate integer tier, and reject FP32/FP16 at admission rather than silently
-executing them as BF16. The two `Target` constants (`XDNA_TOSA_TARGET`, `XDNA_TOSA_INTEGER_TARGET`)
-are already declared in `src/lower.rs`; graph admission and execution wire onto them in later
-tickets.
+Per the numerical-tier decision (#82), the crate defines a BF16 floating-point target (TOSA
+`EXT-BF16`) and a separate future integer target, and rejects FP32/FP16 compute at admission rather
+than silently executing it as BF16. Native builds expose the implemented BF16 IDENTITY/MATMUL
+surface through `TosaCapabilityProvider`; placeholder builds expose an empty capability list, and
+the integer target is not advertised through the provider until its execution tier lands.
 
 ## Running
 

--- a/crates/virtio-accel-xdna/compiler/xdna_compile.py
+++ b/crates/virtio-accel-xdna/compiler/xdna_compile.py
@@ -33,16 +33,6 @@ import sys
 import traceback
 from pathlib import Path
 
-LINE_SIZE = 1024
-
-# The one tested MATMUL compute tile (m, k, n), matching `MATMUL_TILE_{M,K,N}` in `src/lower.rs`.
-# Every admitted dimension is a positive multiple of the matching tile. The FP32 output tile is
-# 4 B/element, so the tile is kept small enough that the double-buffered C tile plus the A/B tiles
-# fit the AIE2P compute core's ~64 KiB L1.
-MATMUL_TILE_M, MATMUL_TILE_K, MATMUL_TILE_N = 32, 64, 32
-MATMUL_MAX_DIM = 512
-
-
 def _fail(workdir: Path, stage: str, message: str) -> int:
     (workdir / "result.json").write_text(
         json.dumps({"schema": 2, "ok": False, "stage": stage, "message": message})
@@ -129,7 +119,7 @@ def _find_hrx_dir(prefix: Path) -> Path | None:
     return None
 
 
-def _build_identity(elements: int):
+def _build_identity(line_size: int):
     """Return the @iron.jit IDENTITY design (a bf16 DMA copy: shim -> memtile -> shim)."""
     import aie.iron as iron
     import ml_dtypes
@@ -138,9 +128,9 @@ def _build_identity(elements: int):
     from aie.iron.device import AnyShimTile
 
     @iron.jit
-    def identity_bf16(x_in: In, y_out: Out, *, n: CompileTime[int] = elements):
+    def identity_bf16(x_in: In, y_out: Out, *, n: CompileTime[int]):
         vector_ty = np.ndarray[(n,), np.dtype[ml_dtypes.bfloat16]]
-        line_ty = np.ndarray[(LINE_SIZE,), np.dtype[ml_dtypes.bfloat16]]
+        line_ty = np.ndarray[(line_size,), np.dtype[ml_dtypes.bfloat16]]
         of_in = ObjectFifo(line_ty, name="in")
         of_out = of_in.cons().forward()
 
@@ -162,7 +152,7 @@ def _build_identity(elements: int):
     return identity_bf16
 
 
-def _build_matmul(m: int, k: int, n: int):
+def _build_matmul(tile_m: int, tile_k: int, tile_n: int):
     """Return the @iron.jit BF16 -> FP32 single-core MATMUL design (`C[M,N] = A[M,K] . B[K,N]`).
 
     Structurally the fork's ``matrix_multiplication_single_core`` design, specialized to a bf16
@@ -179,7 +169,7 @@ def _build_matmul(m: int, k: int, n: int):
 
     in_ty = ml_dtypes.bfloat16
     out_ty = np.float32
-    tm, tk, tn = MATMUL_TILE_M, MATMUL_TILE_K, MATMUL_TILE_N
+    tm, tk, tn = tile_m, tile_k, tile_n
 
     @iron.jit
     def matmul_bf16_f32(
@@ -187,9 +177,9 @@ def _build_matmul(m: int, k: int, n: int):
         input1: In,
         output: Out,
         *,
-        M: CompileTime[int] = m,
-        K: CompileTime[int] = k,
-        N: CompileTime[int] = n,
+        M: CompileTime[int],
+        K: CompileTime[int],
+        N: CompileTime[int],
     ):
         matmul_kernel = kernels.mm(
             dim_m=tm, dim_k=tk, dim_n=tn,
@@ -272,35 +262,44 @@ def _compile(workdir: Path) -> int:
     if op == "IDENTITY":
         dtype = spec.get("dtype")
         elements = spec.get("elements")
+        line_size = spec.get("line_size")
         if dtype != "bf16":
             return _fail(workdir, "spec-rejected", f"unsupported dtype: {dtype}")
-        if not isinstance(elements, int) or elements <= 0 or elements % LINE_SIZE != 0:
+        if not isinstance(line_size, int) or line_size <= 0:
+            return _fail(workdir, "spec-rejected", f"invalid line_size: {line_size}")
+        if not isinstance(elements, int) or elements <= 0 or elements % line_size != 0:
             return _fail(
-                workdir, "spec-rejected", f"elements must be a positive multiple of {LINE_SIZE}"
+                workdir, "spec-rejected", f"elements must be a positive multiple of {line_size}"
             )
         # The binding plan: exact per-slot byte sizes (bf16 = 2 B/element).
         input_bytes, output_bytes = [elements * 2], [elements * 2]
 
         def build():
-            return _build_identity(elements).specialize(n=elements)
+            return _build_identity(line_size).specialize(n=elements)
     elif op == "MATMUL":
         in_dtype = spec.get("in_dtype")
         out_dtype = spec.get("out_dtype")
         m, k, n = spec.get("m"), spec.get("k"), spec.get("n")
+        tile_m, tile_k, tile_n = spec.get("tile_m"), spec.get("tile_k"), spec.get("tile_n")
+        max_dim = spec.get("max_dim")
         if in_dtype != "bf16" or out_dtype != "f32":
             return _fail(
                 workdir, "spec-rejected", f"unsupported dtype pair: {in_dtype}->{out_dtype}"
             )
-        for name, dim, tile in (("m", m, MATMUL_TILE_M), ("k", k, MATMUL_TILE_K), ("n", n, MATMUL_TILE_N)):
-            if not isinstance(dim, int) or dim <= 0 or dim % tile != 0 or dim > MATMUL_MAX_DIM:
+        if not isinstance(max_dim, int) or max_dim <= 0:
+            return _fail(workdir, "spec-rejected", f"invalid max_dim: {max_dim}")
+        for name, dim, tile in (("m", m, tile_m), ("k", k, tile_k), ("n", n, tile_n)):
+            if not isinstance(tile, int) or tile <= 0:
+                return _fail(workdir, "spec-rejected", f"invalid tile_{name}: {tile}")
+            if not isinstance(dim, int) or dim <= 0 or dim % tile != 0 or dim > max_dim:
                 return _fail(
-                    workdir, "spec-rejected", f"{name}={dim} must be a positive multiple of {tile} <= {MATMUL_MAX_DIM}"
+                    workdir, "spec-rejected", f"{name}={dim} must be a positive multiple of {tile} <= {max_dim}"
                 )
         # The binding plan: A[M,K] and B[K,N] are bf16 (2 B), C[M,N] is the fp32 accumulator (4 B).
         input_bytes, output_bytes = [m * k * 2, k * n * 2], [m * n * 4]
 
         def build():
-            return _build_matmul(m, k, n).specialize(M=m, K=k, N=n)
+            return _build_matmul(tile_m, tile_k, tile_n).specialize(M=m, K=k, N=n)
     else:
         return _fail(workdir, "spec-rejected", f"unsupported op: {op}")
 

--- a/crates/virtio-accel-xdna/src/compiler.rs
+++ b/crates/virtio-accel-xdna/src/compiler.rs
@@ -22,7 +22,9 @@ use virtio_accel_core::BackendError;
 
 use crate::XDNA_ERROR_DOMAIN;
 use crate::artifact;
-use crate::lower::CompilerSpec;
+use crate::lower::{
+    CompilerSpec, IDENTITY_LINE_SIZE, MATMUL_MAX_DIM, MATMUL_TILE_K, MATMUL_TILE_M, MATMUL_TILE_N,
+};
 
 /// The embedded compiler helper; written into each private workdir before invocation.
 const HELPER_SOURCE: &str = include_str!("../compiler/xdna_compile.py");
@@ -53,11 +55,16 @@ fn spec_json(spec: CompilerSpec) -> String {
     let device = "\"device\":\"npu2\",\"fold_ddr_addr_offset\":false";
     match spec {
         CompilerSpec::Identity { elements } => {
-            format!("{{\"op\":\"IDENTITY\",\"dtype\":\"bf16\",\"elements\":{elements},{device}}}")
+            format!(
+                "{{\"op\":\"IDENTITY\",\"dtype\":\"bf16\",\"elements\":{elements},\
+                 \"line_size\":{IDENTITY_LINE_SIZE},{device}}}"
+            )
         }
         CompilerSpec::Matmul { m, k, n } => format!(
             "{{\"op\":\"MATMUL\",\"in_dtype\":\"bf16\",\"out_dtype\":\"f32\",\
-             \"m\":{m},\"k\":{k},\"n\":{n},{device}}}"
+             \"m\":{m},\"k\":{k},\"n\":{n},\"tile_m\":{MATMUL_TILE_M},\
+             \"tile_k\":{MATMUL_TILE_K},\"tile_n\":{MATMUL_TILE_N},\
+             \"max_dim\":{MATMUL_MAX_DIM},{device}}}"
         ),
     }
 }
@@ -204,6 +211,7 @@ impl Compiler {
             .map_err(|_| external(code::SPAWN))?;
 
         let deadline = Instant::now() + self.timeout;
+        let mut poll_interval = Duration::from_millis(20);
         loop {
             match child.try_wait() {
                 Ok(Some(status)) => {
@@ -226,7 +234,9 @@ impl Compiler {
                         let _ = child.wait();
                         return Err(external(code::TIMEOUT));
                     }
-                    std::thread::sleep(Duration::from_millis(20));
+                    let remaining = deadline.saturating_duration_since(Instant::now());
+                    std::thread::sleep(poll_interval.min(remaining));
+                    poll_interval = (poll_interval + poll_interval).min(Duration::from_secs(1));
                 }
                 Err(_) => return Err(external(code::HELPER_FAILED)),
             }
@@ -290,4 +300,32 @@ fn cache_root() -> Result<PathBuf, BackendError> {
 fn unique_suffix() -> u64 {
     static COUNTER: AtomicU64 = AtomicU64::new(0);
     COUNTER.fetch_add(1, Ordering::Relaxed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identity_spec_carries_the_authoritative_line_size() {
+        let json = spec_json(CompilerSpec::Identity { elements: 4096 });
+        assert!(json.contains("\"line_size\":1024"));
+    }
+
+    #[test]
+    fn matmul_spec_carries_the_authoritative_tiling_envelope() {
+        let json = spec_json(CompilerSpec::Matmul {
+            m: 64,
+            k: 128,
+            n: 96,
+        });
+        for field in [
+            "\"tile_m\":32",
+            "\"tile_k\":64",
+            "\"tile_n\":32",
+            "\"max_dim\":512",
+        ] {
+            assert!(json.contains(field), "missing {field} in {json}");
+        }
+    }
 }

--- a/crates/virtio-accel-xdna/src/lib.rs
+++ b/crates/virtio-accel-xdna/src/lib.rs
@@ -29,9 +29,16 @@ mod lower;
 
 pub use artifact::{PrecompiledArtifact, XDNA_PRECOMPILED_FORMAT};
 pub use lower::{
-    AdmitError, CompilerSpec, IDENTITY_LINE_SIZE, MATMUL_MAX_DIM, MATMUL_TILE_K, MATMUL_TILE_M,
-    MATMUL_TILE_N, XDNA_TOSA_INTEGER_TARGET, XDNA_TOSA_TARGET, admit,
+    AdmitError, CompilerSpec, XDNA_TOSA_CAPABILITY, XDNA_TOSA_INTEGER_TARGET, XDNA_TOSA_TARGET,
+    admit,
 };
+
+use virtio_accel_tosa::{CapabilityDescriptor, TosaCapabilityProvider};
+
+#[cfg(va_xdna)]
+const TOSA_CAPABILITIES: &[CapabilityDescriptor] = &[XDNA_TOSA_CAPABILITY];
+#[cfg(not(va_xdna))]
+const TOSA_CAPABILITIES: &[CapabilityDescriptor] = &[];
 
 /// The HRX runtime publishes no finite upper bound for a loaded program's device residency.
 ///
@@ -103,5 +110,11 @@ impl XdnaAccelerator {
     /// Report that no HRX runtime was detected when this crate was built.
     pub fn new() -> Result<Self, InitError> {
         Err(InitError::RuntimeUnavailable)
+    }
+}
+
+impl TosaCapabilityProvider for XdnaAccelerator {
+    fn tosa_capabilities(&self) -> &'static [CapabilityDescriptor] {
+        TOSA_CAPABILITIES
     }
 }

--- a/crates/virtio-accel-xdna/src/lower.rs
+++ b/crates/virtio-accel-xdna/src/lower.rs
@@ -8,7 +8,9 @@
 //! the BF16 IDENTITY (a DMA copy) and the BF16 → FP32 MATMUL (issue #90).
 
 use virtio_accel_tosa::{
-    AnalyzedValueKind, DType, ExtensionSet, Level, Op, ProfileSet, Target, Version, parse,
+    AnalyzedValueKind, CapabilityDescriptor, DType, DTypeCapability, ExtensionSet,
+    GraphCapabilities, Level, Op, OperatorCapability, OperatorConstraints, ProfileSet,
+    RuntimeConditionSupport, Target, ValueRoles, Version, parse,
 };
 
 /// The BF16 floating-point tier: TOSA 1.0, floating-point profile, level 8K, BF16 extension.
@@ -33,9 +35,33 @@ pub const XDNA_TOSA_INTEGER_TARGET: Target = Target::new(
     ExtensionSet::NONE,
 );
 
+const BF16_DTYPES: &[DTypeCapability] = &[
+    DTypeCapability::new(DType::BF16, ValueRoles::ALL),
+    DTypeCapability::new(DType::FP32, ValueRoles::OUTPUT),
+];
+
+const BF16_OPERATORS: &[OperatorCapability] = &[
+    OperatorCapability::new(Op::CONST),
+    OperatorCapability::new(Op::IDENTITY),
+    OperatorCapability::constrained(Op::MATMUL, OperatorConstraints::ZERO_ZERO_POINTS),
+];
+
+/// Conservative capability boundary for the implemented XDNA BF16 execution tier.
+pub const XDNA_TOSA_CAPABILITY: CapabilityDescriptor = CapabilityDescriptor {
+    target: XDNA_TOSA_TARGET,
+    dtypes: BF16_DTYPES,
+    operators: BF16_OPERATORS,
+    graph: GraphCapabilities {
+        max_regions: 1,
+        max_blocks: 1,
+        dynamic_shapes: false,
+        runtime_conditions: RuntimeConditionSupport::None,
+    },
+};
+
 /// The DMA line size the IDENTITY template transfers in; an admitted element count must be a
-/// positive multiple of it. Kept in sync with `compiler/xdna_compile.py`.
-pub const IDENTITY_LINE_SIZE: usize = 1024;
+/// positive multiple of it. The Rust compiler driver carries this value into the helper spec.
+pub(crate) const IDENTITY_LINE_SIZE: usize = 1024;
 
 /// The one tested MATMUL compute tile (`m`, `k`, `n`), proven on npu2 (AIE2P).
 ///
@@ -43,26 +69,26 @@ pub const IDENTITY_LINE_SIZE: usize = 1024;
 /// and every admitted `(M, K, N)` is a positive multiple of this tile — the single tiling the
 /// helper compiles and the hardware tests exercise. Untested shapes are rejected (issue #90).
 /// The FP32 output is 4 B/element, so this tile is smaller than a same-shape bf16 tile would be, to
-/// keep the double-buffered C tile plus the A/B tiles inside the compute core's ~64 KiB L1. Kept in
-/// sync with `compiler/xdna_compile.py`.
-pub const MATMUL_TILE_M: usize = 32;
-pub const MATMUL_TILE_K: usize = 64;
-pub const MATMUL_TILE_N: usize = 32;
+/// keep the double-buffered C tile plus the A/B tiles inside the compute core's ~64 KiB L1. The
+/// Rust compiler driver carries this tested tile into the helper spec.
+pub(crate) const MATMUL_TILE_M: usize = 32;
+pub(crate) const MATMUL_TILE_K: usize = 64;
+pub(crate) const MATMUL_TILE_N: usize = 32;
 
 /// Largest admitted MATMUL dimension. The tested tiling generalizes across multiples of the tile,
 /// but only within this envelope; larger shapes are a later generalization and are rejected now.
-pub const MATMUL_MAX_DIM: usize = 512;
+pub(crate) const MATMUL_MAX_DIM: usize = 512;
 
 /// A validated operator specialization ready for the compiler helper. Each variant names its input
 /// and output dtypes; the closed shape is integers only, so no guest bytes cross the boundary.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum CompilerSpec {
     /// BF16 → BF16 elementwise copy of `elements` values (a positive multiple of
-    /// [`IDENTITY_LINE_SIZE`]).
+    /// 1,024 values).
     Identity { elements: usize },
     /// BF16 × BF16 → FP32 matrix multiply `C[M, N] = A[M, K] · B[K, N]` (batch 1). Each of `m`,
     /// `k`, `n` is a positive multiple of the corresponding MATMUL tile dimension and at most
-    /// [`MATMUL_MAX_DIM`]. The FP32 output is the TOSA-mandated accumulator (issue #82).
+    /// 512. The FP32 output is the TOSA-mandated accumulator (issue #82).
     Matmul { m: usize, k: usize, n: usize },
 }
 

--- a/crates/virtio-accel-xdna/src/native.rs
+++ b/crates/virtio-accel-xdna/src/native.rs
@@ -41,6 +41,9 @@ const MAX_TOSA_ARTIFACT_BYTES: u64 = 256 * 1024 * 1024;
 /// Default submission-ring depth (issue #85: one admitted request, matching the Hexagon backend).
 const DEFAULT_RING_DEPTH: usize = 1;
 
+/// Internal state-machine failure: a live event handle observed a free/unknown slot state.
+const INVALID_EVENT_STATE_CODE: i64 = 200;
+
 /// Consume an HRX status and map it to a `BackendError`.
 ///
 /// A non-NULL `hrx_status_t` is owned by the caller and must be consumed exactly once. This reads
@@ -302,7 +305,7 @@ pub struct XdnaAccelerator {
     lane: Arc<Lane>,
     worker: Option<JoinHandle<()>>,
     slots: Vec<Arc<EventSlot>>,
-    compiler: Option<Compiler>,
+    compiler: CompilerState,
     info: DeviceInfo,
     next_id: AtomicU64,
     /// Cumulative count of buffers admitted as direct bindings (no submission-time staging copy).
@@ -310,6 +313,12 @@ pub struct XdnaAccelerator {
     /// Cumulative bytes moved by explicit `write_buffer`/`read_buffer` transfers.
     explicit_transfer_bytes: AtomicU64,
     _not_send_sync: PhantomData<*mut u8>,
+}
+
+enum CompilerState {
+    Ready(Compiler),
+    Unconfigured,
+    Failed(BackendError),
 }
 
 impl XdnaAccelerator {
@@ -343,11 +352,19 @@ impl XdnaAccelerator {
             .spawn(move || worker_lane.run_worker())
             .map_err(|_| InitError::Initialization)?;
 
+        let compiler = match Compiler::from_env() {
+            Ok(compiler) => CompilerState::Ready(compiler),
+            Err(_error) if std::env::var_os("VIRTIO_ACCEL_AMDXDNA_TOOLCHAIN").is_none() => {
+                CompilerState::Unconfigured
+            }
+            Err(error) => CompilerState::Failed(error),
+        };
+
         Ok(Self {
             lane,
             worker: Some(worker),
             slots,
-            compiler: Compiler::from_env().ok(),
+            compiler,
             info: device_info(),
             next_id: AtomicU64::new(1),
             direct_binding_admissions: AtomicU64::new(0),
@@ -819,31 +836,39 @@ impl Accelerator for XdnaAccelerator {
         if artifact.resident_bytes != crate::REQUIRED_RESIDENT_BYTES {
             return Err(BackendError::ResourceLimit);
         }
-        let len =
-            usize::try_from(artifact.payload.len()).map_err(|_| BackendError::ResourceLimit)?;
-        let mut bytes = Vec::new();
-        bytes
-            .try_reserve_exact(len)
-            .map_err(|_| BackendError::OutOfMemory)?;
-        bytes.resize(len, 0);
-        artifact.payload.read_at(0, &mut bytes)?;
+        let mut owned = Vec::new();
+        let bytes = match artifact.payload.as_contiguous() {
+            Some(bytes) => bytes,
+            None => {
+                let len = usize::try_from(artifact.payload.len())
+                    .map_err(|_| BackendError::ResourceLimit)?;
+                owned
+                    .try_reserve_exact(len)
+                    .map_err(|_| BackendError::OutOfMemory)?;
+                owned.resize(len, 0);
+                artifact.payload.read_at(0, &mut owned)?;
+                &owned
+            }
+        };
 
         // The precompiled format loads directly; a TOSA artifact is admitted and compiled to one.
         let container = if artifact.format == artifact::XDNA_PRECOMPILED_FORMAT {
-            bytes
+            std::borrow::Cow::Borrowed(bytes)
         } else if artifact.format == virtio_accel_tosa::ARTIFACT_FORMAT {
             let target = virtio_accel_tosa::Target::from_identity(artifact.target)
                 .map_err(|_| BackendError::Incompatible)?;
             let spec = lower::admit(&bytes, target)?;
-            self.compiler
-                .as_ref()
-                .ok_or(BackendError::Unsupported)?
-                .compile(spec)?
+            let compiler = match &self.compiler {
+                CompilerState::Ready(compiler) => compiler,
+                CompilerState::Unconfigured => return Err(BackendError::Unsupported),
+                CompilerState::Failed(error) => return Err(*error),
+            };
+            std::borrow::Cow::Owned(compiler.compile(spec)?)
         } else {
             return Err(BackendError::Unsupported);
         };
 
-        let parsed = PrecompiledArtifact::parse(&container)?;
+        let parsed = PrecompiledArtifact::parse(container.as_ref())?;
         let device = shared_device().map_err(|_| BackendError::DeviceLost)?;
         build_executable(device, parsed, context.id)
     }
@@ -1035,7 +1060,10 @@ impl Accelerator for XdnaAccelerator {
                     });
                 Ok(EventState::Failed(error))
             }
-            _ => Ok(EventState::Pending),
+            _ => Err(BackendError::External {
+                domain: XDNA_ERROR_DOMAIN,
+                code: INVALID_EVENT_STATE_CODE,
+            }),
         }
     }
 

--- a/crates/virtio-accel-xdna/tests/common/mod.rs
+++ b/crates/virtio-accel-xdna/tests/common/mod.rs
@@ -1,0 +1,76 @@
+use std::time::{Duration, Instant};
+
+use virtio_accel_core::{Accelerator, BackendError, EventState};
+use virtio_accel_tosa::DType;
+use virtio_accel_tosa_build::{OperatorKind, OwnedGraph, OwnedOperator, OwnedTensor};
+use virtio_accel_xdna::XDNA_TOSA_TARGET;
+
+pub fn bf16_identity_tosa(elements: usize) -> Vec<u8> {
+    let shape = vec![1, 1, elements as i32];
+    let mut graph = OwnedGraph::new("main");
+    graph.push_tensor(OwnedTensor::new("x", shape.clone(), DType::BF16));
+    graph.push_tensor(OwnedTensor::new("y", shape, DType::BF16));
+    graph.push_operator(OwnedOperator::new(
+        OperatorKind::Identity,
+        vec!["x".into()],
+        vec!["y".into()],
+    ));
+    graph.push_input("x");
+    graph.push_output("y");
+    graph.build(XDNA_TOSA_TARGET).expect("build bf16 identity")
+}
+
+#[allow(dead_code)] // This shared module is compiled separately into conformance.rs, which uses only IDENTITY.
+pub fn bf16_matmul_tosa(m: i32, k: i32, n: i32) -> Vec<u8> {
+    let mut graph = OwnedGraph::new("main");
+    graph
+        .push_tensor(OwnedTensor::new("lhs", vec![1, m, k], DType::BF16))
+        .push_tensor(OwnedTensor::new("rhs", vec![1, k, n], DType::BF16))
+        .push_tensor(OwnedTensor::constant(
+            "lhs_zp",
+            vec![1],
+            DType::BF16,
+            vec![0u8; 2],
+        ))
+        .push_tensor(OwnedTensor::constant(
+            "rhs_zp",
+            vec![1],
+            DType::BF16,
+            vec![0u8; 2],
+        ))
+        .push_tensor(OwnedTensor::new("output", vec![1, m, n], DType::FP32))
+        .push_operator(OwnedOperator::new(
+            OperatorKind::Const,
+            vec![],
+            vec!["lhs_zp".into()],
+        ))
+        .push_operator(OwnedOperator::new(
+            OperatorKind::Const,
+            vec![],
+            vec!["rhs_zp".into()],
+        ))
+        .push_operator(OwnedOperator::new(
+            OperatorKind::MatMul,
+            vec!["lhs".into(), "rhs".into(), "lhs_zp".into(), "rhs_zp".into()],
+            vec!["output".into()],
+        ))
+        .push_input("lhs")
+        .push_input("rhs")
+        .push_output("output");
+    graph.build(XDNA_TOSA_TARGET).expect("build bf16 matmul")
+}
+
+pub fn poll_to_terminal<A: Accelerator>(
+    backend: &A,
+    event: &A::Event,
+    timeout: Duration,
+) -> Result<EventState, BackendError> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        match backend.poll_event(event)? {
+            EventState::Pending if Instant::now() < deadline => std::thread::yield_now(),
+            EventState::Pending => return Err(BackendError::DeadlineExpired),
+            terminal => return Ok(terminal),
+        }
+    }
+}

--- a/crates/virtio-accel-xdna/tests/conformance.rs
+++ b/crates/virtio-accel-xdna/tests/conformance.rs
@@ -7,15 +7,17 @@
 //! BF16 IDENTITY that `load_program` compiles); it skips cleanly when either is absent.
 #![cfg(va_xdna)]
 
-use std::time::{Duration, Instant};
+use std::time::Duration;
+
+mod common;
+use common::{bf16_identity_tosa, poll_to_terminal};
 
 use virtio_accel_conformance::{
     BindingFixture, ConformanceHooks, ProgramFixture, SubmissionPathDiagnostics, TargetDescription,
     run,
 };
-use virtio_accel_core::{Accelerator, AccessMode, BackendError, EventState, MemoryDomain};
-use virtio_accel_tosa::{ARTIFACT_FORMAT, DType};
-use virtio_accel_tosa_build::{OperatorKind, OwnedGraph, OwnedOperator, OwnedTensor};
+use virtio_accel_core::{AccessMode, BackendError, EventState, MemoryDomain};
+use virtio_accel_tosa::ARTIFACT_FORMAT;
 use virtio_accel_xdna::{
     InitError, REQUIRED_RESIDENT_BYTES, XDNA_TOSA_TARGET, XdnaAccelerator, XdnaEvent,
 };
@@ -37,22 +39,6 @@ fn device_present() -> bool {
     }
 }
 
-/// A BF16 IDENTITY TOSA artifact of `ELEMENTS` for the advertised target.
-fn bf16_identity_tosa() -> Vec<u8> {
-    let shape = vec![1, 1, ELEMENTS as i32];
-    let mut graph = OwnedGraph::new("main");
-    graph.push_tensor(OwnedTensor::new("x", shape.clone(), DType::BF16));
-    graph.push_tensor(OwnedTensor::new("y", shape, DType::BF16));
-    graph.push_operator(OwnedOperator::new(
-        OperatorKind::Identity,
-        vec!["x".into()],
-        vec!["y".into()],
-    ));
-    graph.push_input("x");
-    graph.push_output("y");
-    graph.build(XDNA_TOSA_TARGET).expect("build bf16 identity")
-}
-
 struct Hooks;
 
 impl ConformanceHooks<XdnaAccelerator> for Hooks {
@@ -62,19 +48,11 @@ impl ConformanceHooks<XdnaAccelerator> for Hooks {
         event: &XdnaEvent,
     ) -> Result<(), BackendError> {
         // The dispatch worker drives completion; poll the latched state to a terminal.
-        let deadline = Instant::now() + Duration::from_secs(30);
-        loop {
-            match backend.poll_event(event)? {
-                EventState::Pending => {
-                    if Instant::now() >= deadline {
-                        return Err(BackendError::DeadlineExpired);
-                    }
-                    std::thread::yield_now();
-                }
-                EventState::Complete => return Ok(()),
-                EventState::Failed(error) => return Err(error),
-                EventState::Cancelled => return Err(BackendError::Busy),
-            }
+        match poll_to_terminal(backend, event, Duration::from_secs(30))? {
+            EventState::Complete => Ok(()),
+            EventState::Failed(error) => Err(error),
+            EventState::Cancelled => Err(BackendError::Busy),
+            EventState::Pending => unreachable!("poll_to_terminal never returns Pending"),
         }
     }
 
@@ -99,7 +77,7 @@ fn conformance_target() -> TargetDescription {
     let program = ProgramFixture::new(
         ARTIFACT_FORMAT,
         XDNA_TOSA_TARGET.to_identity(),
-        bf16_identity_tosa(),
+        bf16_identity_tosa(ELEMENTS),
         REQUIRED_RESIDENT_BYTES,
     )
     .unwrap();

--- a/crates/virtio-accel-xdna/tests/hardware.rs
+++ b/crates/virtio-accel-xdna/tests/hardware.rs
@@ -6,14 +6,17 @@
 //! ticket.
 #![cfg(va_xdna)]
 
-use std::time::{Duration, Instant};
+use std::time::Duration;
+
+mod common;
+use common::{bf16_identity_tosa, bf16_matmul_tosa, poll_to_terminal};
 
 use virtio_accel_core::{
     Accelerator, AccessMode, ArtifactRef, BackendError, BindingRef, BufferDesc, BufferRange,
     BufferUsage, ByteSink, ByteSource, ContextDesc, EventState, MemoryDomain, QueueDesc,
     SubmitFailure, TargetIdentity, Timeout,
 };
-use virtio_accel_tosa::{ARTIFACT_FORMAT, DType};
+use virtio_accel_tosa::{ARTIFACT_FORMAT, DType, TosaCapabilityProvider};
 use virtio_accel_tosa_build::{OperatorKind, OwnedGraph, OwnedOperator, OwnedTensor};
 use virtio_accel_xdna::{
     InitError, XDNA_PRECOMPILED_FORMAT, XDNA_TOSA_TARGET, XdnaAccelerator, compile_artifact,
@@ -22,63 +25,6 @@ use virtio_accel_xdna::{
 /// Whether the pinned compiler toolchain is configured (the compiler tests need it, not a device).
 fn toolchain_present() -> bool {
     std::env::var_os("VIRTIO_ACCEL_AMDXDNA_TOOLCHAIN").is_some()
-}
-
-/// Author a BF16 IDENTITY TOSA artifact of `elements` for the advertised target.
-fn bf16_identity_tosa(elements: usize) -> Vec<u8> {
-    let shape = vec![1, 1, elements as i32];
-    let mut graph = OwnedGraph::new("main");
-    graph.push_tensor(OwnedTensor::new("x", shape.clone(), DType::BF16));
-    graph.push_tensor(OwnedTensor::new("y", shape, DType::BF16));
-    graph.push_operator(OwnedOperator::new(
-        OperatorKind::Identity,
-        vec!["x".into()],
-        vec!["y".into()],
-    ));
-    graph.push_input("x");
-    graph.push_output("y");
-    graph.build(XDNA_TOSA_TARGET).expect("build bf16 identity")
-}
-
-/// Author a batch-1 BF16 → FP32 MATMUL `C[1,M,N] = A[1,M,K] · B[1,K,N]` for the advertised target.
-/// The two zero-points are constant-zero (TOSA requires floating-point zero-points to be zero).
-fn bf16_matmul_tosa(m: i32, k: i32, n: i32) -> Vec<u8> {
-    let mut graph = OwnedGraph::new("main");
-    graph
-        .push_tensor(OwnedTensor::new("lhs", vec![1, m, k], DType::BF16))
-        .push_tensor(OwnedTensor::new("rhs", vec![1, k, n], DType::BF16))
-        .push_tensor(OwnedTensor::constant(
-            "lhs_zp",
-            vec![1],
-            DType::BF16,
-            vec![0u8; 2],
-        ))
-        .push_tensor(OwnedTensor::constant(
-            "rhs_zp",
-            vec![1],
-            DType::BF16,
-            vec![0u8; 2],
-        ))
-        .push_tensor(OwnedTensor::new("output", vec![1, m, n], DType::FP32))
-        .push_operator(OwnedOperator::new(
-            OperatorKind::Const,
-            vec![],
-            vec!["lhs_zp".into()],
-        ))
-        .push_operator(OwnedOperator::new(
-            OperatorKind::Const,
-            vec![],
-            vec!["rhs_zp".into()],
-        ))
-        .push_operator(OwnedOperator::new(
-            OperatorKind::MatMul,
-            vec!["lhs".into(), "rhs".into(), "lhs_zp".into(), "rhs_zp".into()],
-            vec!["output".into()],
-        ))
-        .push_input("lhs")
-        .push_input("rhs")
-        .push_output("output");
-    graph.build(XDNA_TOSA_TARGET).expect("build bf16 matmul")
 }
 
 /// Encode an exactly-representable value as a little-endian BF16 (truncate the FP32 low half; exact
@@ -119,6 +65,7 @@ impl ByteSource for Slice<'_> {
     fn len(&self) -> u64 {
         self.0.len() as u64
     }
+
     fn read_at(&self, offset: u64, target: &mut [u8]) -> Result<(), BackendError> {
         let start = usize::try_from(offset).map_err(|_| BackendError::OutOfBounds)?;
         let end = start
@@ -128,6 +75,7 @@ impl ByteSource for Slice<'_> {
         target.copy_from_slice(&self.0[start..end]);
         Ok(())
     }
+
     fn as_contiguous(&self) -> Option<&[u8]> {
         Some(self.0)
     }
@@ -140,6 +88,7 @@ impl ByteSink for SliceMut<'_> {
     fn len(&self) -> u64 {
         self.0.len() as u64
     }
+
     fn write_at(&mut self, offset: u64, source: &[u8]) -> Result<(), BackendError> {
         let start = usize::try_from(offset).map_err(|_| BackendError::OutOfBounds)?;
         let end = start
@@ -149,6 +98,7 @@ impl ByteSink for SliceMut<'_> {
         self.0[start..end].copy_from_slice(source);
         Ok(())
     }
+
     fn as_contiguous_mut(&mut self) -> Option<&mut [u8]> {
         Some(self.0)
     }
@@ -172,6 +122,8 @@ fn device_info_reports_the_npu() {
     let info = backend.device_info().expect("device info");
     assert_eq!(info.identity.vendor_id, 0x1022);
     assert_eq!(info.identity.device_id, 0x17f0);
+    assert_eq!(backend.tosa_capabilities().len(), 1);
+    assert_eq!(backend.tosa_capabilities()[0].target, XDNA_TOSA_TARGET);
 }
 
 #[test]
@@ -373,19 +325,8 @@ fn precompiled_passthrough_runs_the_full_lifecycle() {
     };
 
     // Poll to a terminal state (nonblocking poll; the worker bridges the blocking synchronize).
-    let deadline = Instant::now() + Duration::from_secs(10);
-    let state = loop {
-        match backend.poll_event(&event).expect("poll") {
-            EventState::Pending => {
-                assert!(
-                    Instant::now() < deadline,
-                    "dispatch did not complete in 10s"
-                );
-                std::thread::yield_now();
-            }
-            terminal => break terminal,
-        }
-    };
+    let state = poll_to_terminal(&backend, &event, Duration::from_secs(10))
+        .expect("dispatch did not complete in 10s");
     assert!(
         matches!(state, EventState::Complete),
         "expected Complete, got {state:?}"
@@ -526,16 +467,8 @@ fn tosa_bf16_identity_runs_on_the_npu() {
     let event = backend
         .submit(&queue, &program, &bindings, Timeout::Infinite)
         .expect("submit");
-    let deadline = Instant::now() + Duration::from_secs(10);
-    let state = loop {
-        match backend.poll_event(&event).expect("poll") {
-            EventState::Pending => {
-                assert!(Instant::now() < deadline, "identity did not complete");
-                std::thread::yield_now();
-            }
-            terminal => break terminal,
-        }
-    };
+    let state = poll_to_terminal(&backend, &event, Duration::from_secs(10))
+        .expect("identity did not complete");
     assert!(matches!(state, EventState::Complete), "got {state:?}");
 
     let mut result = vec![0u8; BYTES];
@@ -679,16 +612,8 @@ fn tosa_bf16_matmul_runs_on_the_npu() {
     let event = backend
         .submit(&queue, &program, &bindings, Timeout::Infinite)
         .expect("submit");
-    let deadline = Instant::now() + Duration::from_secs(30);
-    let state = loop {
-        match backend.poll_event(&event).expect("poll") {
-            EventState::Pending => {
-                assert!(Instant::now() < deadline, "matmul did not complete");
-                std::thread::yield_now();
-            }
-            terminal => break terminal,
-        }
-    };
+    let state = poll_to_terminal(&backend, &event, Duration::from_secs(30))
+        .expect("matmul did not complete");
     assert!(matches!(state, EventState::Complete), "got {state:?}");
 
     let mut result = vec![0u8; M * N * 4];
@@ -813,16 +738,8 @@ fn tosa_matmul_with_a_shared_input_buffer_runs_on_the_npu() {
     let event = backend
         .submit(&queue, &program, &bindings, Timeout::Infinite)
         .expect("submit with shared input");
-    let deadline = Instant::now() + Duration::from_secs(30);
-    let state = loop {
-        match backend.poll_event(&event).expect("poll") {
-            EventState::Pending => {
-                assert!(Instant::now() < deadline, "shared-input matmul stalled");
-                std::thread::yield_now();
-            }
-            terminal => break terminal,
-        }
-    };
+    let state = poll_to_terminal(&backend, &event, Duration::from_secs(30))
+        .expect("shared-input matmul stalled");
     assert!(matches!(state, EventState::Complete), "got {state:?}");
 
     let mut result = vec![0u8; OUT_BYTES];

--- a/crates/virtio-accel-xdna/tests/xdna.rs
+++ b/crates/virtio-accel-xdna/tests/xdna.rs
@@ -2,8 +2,14 @@
 //!
 //! Native lifecycle tests arrive with the HRX FFI and hardware tickets. These run on every host.
 
-use virtio_accel_tosa::{ExtensionSet, ProfileSet, Target};
-use virtio_accel_xdna::{REQUIRED_RESIDENT_BYTES, XDNA_TOSA_INTEGER_TARGET, XDNA_TOSA_TARGET};
+#[cfg(not(va_xdna))]
+use virtio_accel_tosa::TosaCapabilityProvider;
+use virtio_accel_tosa::{ExtensionSet, Op, ProfileSet, Target};
+#[cfg(not(va_xdna))]
+use virtio_accel_xdna::XdnaAccelerator;
+use virtio_accel_xdna::{
+    REQUIRED_RESIDENT_BYTES, XDNA_TOSA_CAPABILITY, XDNA_TOSA_INTEGER_TARGET, XDNA_TOSA_TARGET,
+};
 
 #[test]
 fn required_resident_bytes_is_maximal() {
@@ -45,6 +51,20 @@ fn targets_survive_an_identity_round_trip() {
     for target in [XDNA_TOSA_TARGET, XDNA_TOSA_INTEGER_TARGET] {
         assert_eq!(Target::from_identity(target.to_identity()), Ok(target));
     }
+}
+
+#[test]
+fn bf16_capability_matches_the_implemented_surface() {
+    assert_eq!(XDNA_TOSA_CAPABILITY.target, XDNA_TOSA_TARGET);
+    assert!(XDNA_TOSA_CAPABILITY.supports_operator(Op::IDENTITY));
+    assert!(XDNA_TOSA_CAPABILITY.supports_operator(Op::MATMUL));
+    assert!(!XDNA_TOSA_CAPABILITY.supports_operator(Op::MAX_POOL2D));
+}
+
+#[cfg(not(va_xdna))]
+#[test]
+fn placeholder_advertises_no_runtime_capabilities() {
+    assert!(XdnaAccelerator.tosa_capabilities().is_empty());
 }
 
 /// The offline / catalog-population path works without HRX: `compile_artifact` is available in

--- a/docs/release-policy.md
+++ b/docs/release-policy.md
@@ -94,14 +94,19 @@ tier of an existing crate.
 
 Project-authored code in portable crates, reference crates, and fuzz harness support code forbids or
 denies unsafe code at the crate root. This is an intentional v1 invariant, not incidental linting.
-There are three reviewed, confined exceptions. The host-native `virtio-accel-coreml` adapter's Rust
+There are five reviewed, confined exceptions. The host-native `virtio-accel-coreml` adapter's Rust
 FFI and aligned-allocation code is documented in `crates/virtio-accel-coreml/SAFETY.md`; non-macOS
 builds still forbid unsafe code. The host-native `virtio-accel-openvino` adapter's OpenVINO C API
 FFI and aligned-allocation code is documented in `crates/virtio-accel-openvino/SAFETY.md`; builds
 without a detected OpenVINO runtime still forbid unsafe code. `virtio-accel-tosa` denies unsafe
 code globally but locally permits its private, checked-in official FlatBuffers bindings after
 bounded verification; the boundary and regeneration procedure are documented in
-`crates/virtio-accel-tosa/SAFETY.md`.
+`crates/virtio-accel-tosa/SAFETY.md`. The host-native `virtio-accel-hexagon` adapter's QNN C API
+boundary is documented in `crates/virtio-accel-hexagon/SAFETY.md`; builds without a detected QNN
+runtime still forbid unsafe code. The host-native `virtio-accel-xdna` adapter's HRX C ABI,
+persistent mappings, and dispatch ownership are documented in
+`crates/virtio-accel-xdna/SAFETY.md`; builds without a detected HRX runtime still forbid unsafe
+code.
 
 A future unsafe exception requires all of the following in one reviewed change:
 


### PR DESCRIPTION
Closes #138.

## Stack

This cleanup PR is intentionally based on `task/xdna-matmul-tier` / #137. It does not move the next operator ticket forward; it tightens the completed #87-#90 stack first.

## What changed

- Mirrors OpenVINO by implementing `TosaCapabilityProvider`: native HRX builds advertise only the implemented BF16 IDENTITY/MATMUL tier, while placeholder builds advertise no executable runtime capabilities.
- Makes shape/tile constants crate-private and sends their values through the Rust-authored compiler spec, removing duplicated Rust/Python sources of truth and duplicate JIT specialization defaults.
- Preserves explicit toolchain-configuration failures instead of collapsing them into `Unsupported`, uses the contiguous artifact fast path, adds bounded subprocess polling backoff, and makes impossible event-slot states fail loudly.
- Consolidates integration-test TOSA builders and poll loops, and updates capability/release-policy documentation.

## Review dispositions

- Kept the small `Slice`/`SliceMut` test adapters: direct coercion from the unsized `[u8]` implementations to `dyn ByteSource`/`dyn ByteSink` does not compile, so removing them would not be a valid simplification.
- Kept the bounded result JSON reader rather than adding a runtime serde dependency; the helper output is private and schema-controlled.
- Per-submit scratch recycling remains tracked by #121; the pending-event race and shared BF16 oracle remain tracked by #92.

## Verification

- `cargo fmt --all -- --check`
- `python3 ci/check-release-policy.py`
- workspace Clippy with warnings denied (local Rust 1.96 additionally requires allowing its new unrelated `nonminimal_bool` warning in `virtio-accel-tosa`; project CI uses the Rust 1.85 MSRV)
- `cargo test --workspace --all-targets --all-features`
- all required runnable examples
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps`
- `python3 ci/publish-dry-run.py` (all 17 crates)
- XDNA native suite on the AMD NPU after the substantive compiler/runtime changes: 18 library tests, shared conformance, 13 hardware tests, and 7 portable tests passed