### PR TITLE
Implement exact XDNA INT8 identity and matmul tier

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The project claims no Virtio device ID (_yet_). For guest environments, use the 
 | ------------------------------------------- | ----------------------------------------- | -------------------------------------------------------- | --------------------------------- | -------------------------------------- | --------------------------- | ----------------- | --------------- | --------------------------- |
 | Apple Core ML / ANE (`virtio-accel-coreml`) | Implemented; macOS 14+                    | Static TOSA 1.0 FP; INT8 tier on macOS 26+               | Supported                         | Supported                              | Not implemented             | Identity + MATMUL | Not implemented | Direct host/shared bindings |
 | Intel OpenVINO (`virtio-accel-openvino`)    | Implemented; OpenVINO 2026.x              | Static TOSA 1.0 FP + INT8 tier                           | Supported                         | Supported                              | Not implemented             | Identity + MATMUL | Not implemented | Direct host/shared bindings |
-| AMD XDNA (`virtio-accel-xdna`)              | Experimental; HRX on XDNA2                | Static BF16 TOSA + explicit FP8 storage CAST             | Accumulator outputs only          | Not implemented                        | E4M3/E5M2 → BF16 CAST       | Not implemented   | Not implemented | Direct host/shared bindings |
+| AMD XDNA (`virtio-accel-xdna`)              | Experimental; HRX on XDNA2                | Static BF16 TOSA + explicit FP8 storage CAST + INT8 tier | Accumulator outputs only          | Not implemented                        | E4M3/E5M2 → BF16 CAST       | Identity + MATMUL | Not implemented | Direct host/shared bindings |
 | Qualcomm Hexagon (`virtio-accel-hexagon`)   | Experimental; QAIRT 2.49 on Windows ARM64 | Static TOSA 1.0 FP16 + BOOL/INT32 auxiliaries; INT8 tier | Blocked by v73 precision evidence | 41/42 shared operators (`ERF` blocked) | Blocked: ambiguous encoding | Identity + MATMUL | Not implemented | Direct host/shared bindings |
 | Vulkan (planned)                            | Planned                                   | Not implemented                                          | Not implemented                   | Not implemented                        | Not implemented             | Not implemented   | Not implemented | Not implemented             |
 
@@ -77,6 +77,9 @@ See the [`virtio-accel-hexagon` support boundary](crates/virtio-accel-hexagon/RE
   FP32 and FP16 arithmetic are rejected.
 - **FP8 storage:** Explicit TOSA CAST from E4M3 or E5M2 to BF16 runs on the NPU and is bit-exact for
   every finite value. NaN payload canonicalization is permitted. FP8 arithmetic is not advertised.
+- **INT8:** Exact identity and zero-point-aware MATMUL are supported with INT32 output. The
+  capability mirrors OpenVINO's narrow integer surface, while XDNA admission adds a one-core static
+  memory envelope and explicit four-byte DMA slot padding where a logical input is not word-sized.
 - **Runtime:** Native execution requires the pinned amdxdna-native HRX runtime and compiler
   toolchain. Portable admission and offline artifact compilation remain available without a device.
 
@@ -95,7 +98,7 @@ Independently of backend execution, `virtio-accel-tosa` validates the TOSA 1.0 p
 | `virtio-accel-vaccel`      | `core`                | Adapter seam for mapping native provider contracts (including vAccel-style backends) to `virtio-accel-core`  |
 | `virtio-accel-coreml`      | `std`                 | TOSA-to-Core ML lowering, direct buffers, and asynchronous ANE-capable prediction                            |
 | `virtio-accel-openvino`    | `std`                 | TOSA-to-OpenVINO IR lowering, direct host-pointer tensors, and asynchronous NPU/GPU/CPU inference            |
-| `virtio-accel-xdna`        | `std`                 | AMD XDNA2 NPU backend over HRX with direct buffers, asynchronous dispatch, and strict BF16/FP8 TOSA tiers    |
+| `virtio-accel-xdna`        | `std`                 | AMD XDNA2 NPU backend over HRX with direct buffers, asynchronous dispatch, and strict BF16/FP8/INT8 TOSA tiers |
 | `virtio-accel-hexagon`     | `std` (Windows ARM64) | Strict FP16/INT8 TOSA-to-QNN lowering, direct buffers, and asynchronous Hexagon HTP execution                |
 | `virtio-accel`             | `core + alloc`        | Facade re-exporting the portable layers                                                                      |
 | `virtio-accel-proto`       | `core`                | Pointer-free, little-endian protocol 1.0 wire structures                                                     |

--- a/crates/virtio-accel-xdna/README.md
+++ b/crates/virtio-accel-xdna/README.md
@@ -17,14 +17,16 @@ compiling it with the bounded aiecc helper subprocess (`compiler/xdna_compile.py
 pinned toolchain venv in a cleared environment, content-addressed in a cache). The compilable TOSA
 subset today is BF16 IDENTITY (a DMA copy), BF16 → FP32 MATMUL (the spec-mandated FP32-accumulator
 shape, batch 1, at multiples of the tested compute tile), BF16 NHWC MAX_POOL2D, and explicit
-FP8E4M3/FP8E5M2 → BF16 CAST. FP8 is a storage tier, not an arithmetic tier: the guest keeps the
+FP8E4M3/FP8E5M2 → BF16 CAST, plus exact INT8 IDENTITY and zero-point-aware INT8 → INT32 MATMUL.
+FP8 is a storage tier, not an arithmetic tier: the guest keeps the
 conversion visible in its graph, the NPU expands each value exactly, and subsequent programs use
 the existing BF16 compute kernels. MAX_POOL2D is
 deliberately bounded to batch 1, zero padding, propagating NaNs, kernel and stride dimensions no
 larger than 8, and at most 8,192 input-plus-output elements so both tensors fit in the worker's
 local-memory budget. All of this is exercised by `tests/hardware.rs` (a DMA passthrough, compiled
 TOSA IDENTITY, bit-exact non-square MATMUL, the shared MAX_POOL2D oracle, and both shared
-bit-exact FP8 → BF16 CAST oracles) and by
+bit-exact FP8 → BF16 CAST oracles, plus the shared exact INT8 identity and nonzero-zero-point
+MATMUL oracles) and by
 `tests/conformance.rs` (the shared semantic suite, including the direct-binding copy-path
 diagnostics, on the device). Hosts without HRX build the portable admission surface plus a
 placeholder, compile no `unsafe`, and still unit-test admission and the artifact codec. The
@@ -57,15 +59,24 @@ pin. Builds without the runtime still compile and unit-test the portable admissi
 ## Advertised numerical tier
 
 Per the numerical-tier decision (#82), the crate defines a BF16 floating-point target (TOSA
-`EXT-BF16`), a separate FP8 storage target (`EXT-BF16 | EXT-FP8E4M3 | EXT-FP8E5M2`), and a future
+`EXT-BF16`), a separate FP8 storage target (`EXT-BF16 | EXT-FP8E4M3 | EXT-FP8E5M2`), and an exact
 integer target. It rejects FP32/FP16 compute at admission rather than silently executing it as
 BF16. Native builds expose the implemented BF16 IDENTITY, MATMUL, MAX_POOL2D, and explicit
-FP8-to-BF16 CAST surfaces through `TosaCapabilityProvider`; placeholder builds expose an empty
-capability list, and the integer target is not advertised through the provider until its execution
-tier lands. The FP8 capability advertises FP8 only for graph inputs and BF16 only for graph
+FP8-to-BF16 CAST surfaces plus INT8 IDENTITY and MATMUL through `TosaCapabilityProvider`;
+placeholder builds expose an empty capability list. The FP8 capability advertises FP8 only for
+graph inputs and BF16 only for graph
 outputs, so it cannot be mistaken for native FP8 arithmetic. MAX_POOL2D advertises the same
 propagating-NaN and zero-padding semantic constraints as the OpenVINO reference backend, while
 admission applies the narrower XDNA2 shape and local-memory envelope described above.
+
+The integer capability deliberately mirrors OpenVINO's `CONST`/`IDENTITY`/`MATMUL`, INT8, and
+restricted INT32 semantic declaration, but does not claim the complete TOSA Integer profile.
+Admission is narrower for an XDNA-specific reason: batch is one, dimensions are at most 512, and
+the padded A/B plus INT32 C footprint is at most 16 KiB so depth-two FIFOs fit one AIE2P core.
+Non-word-sized INT8 inputs are rounded up to a four-byte binding slot because AIE DMA descriptors
+cannot transfer a shorter granularity; that padding is explicit in the artifact's binding plan and
+ignored by the kernel, rather than copied into a hidden bounce buffer. Zero points remain signed
+INT8 compile-time values and are subtracted on the NPU before exact INT32 accumulation.
 
 ## Completion and fault model
 
@@ -137,6 +148,24 @@ throughput optimization rather than a correctness requirement for this storage t
 Wall-clock results are manual release evidence from the named NPU/toolchain, not a portable CI gate.
 Deterministic CI continues to enforce exact numerics, direct bindings, and zero submission-time
 transfer bytes.
+
+The INT8 MATMUL benchmark follows the same 20-warmup/200-sample structure. Shapes divisible by the
+AIE2P 4x4x8 INT16 matrix tile widen and subtract both zero points exactly on the NPU, then use the
+native matrix unit; small shapes that cannot fill one tile use a scalar on-NPU kernel. Both paths
+remain direct-bound and bit-exact. Run it with:
+
+```sh
+source ~/toolchains/amdxdna-hrx-v2026.08/env.sh
+export VIRTIO_ACCEL_AMDXDNA_TOOLCHAIN=~/toolchains/amdxdna-hrx-v2026.08
+cargo test --release -p virtio-accel-xdna --test hardware \
+  measures_exact_int8_matmul_latency -- --ignored --nocapture --test-threads=1
+```
+
+On August 26, 2026, the reference `1022:17f0` XDNA2 NPU and v2026.08 toolchain measured a
+64x64x32 specialization at 661 ns admission p50 and 334.065 microseconds submit-to-complete p50
+(343.723 microseconds p95), or 0.785 effective GOPS at this dispatch-sized workload. All 660
+bindings across 220 submissions were direct and submission performed zero explicit transfer
+bytes. This is evidence for the initial one-core tier, not a peak-throughput claim.
 
 Part of the [`virtio-accel`](https://github.com/MicroPerceptron/virtio-accel) workspace: an
 experimental native-Rust protocol and implementation stack for a transport-neutral virtual

--- a/crates/virtio-accel-xdna/compiler/xdna_compile.py
+++ b/crates/virtio-accel-xdna/compiler/xdna_compile.py
@@ -13,12 +13,15 @@ Two modes:
 
 ``spec.json`` (all fields validated integers or closed enums; no guest bytes reach this process):
 
-    {"op": "IDENTITY", "dtype": "bf16", "elements": <n>, "device": "npu2",
+    {"op": "IDENTITY", "dtype": "bf16" | "i8", "elements": <n>, "device": "npu2",
      "fold_ddr_addr_offset": false}
     {"op": "CAST", "in_dtype": "fp8e4m3" | "fp8e5m2", "out_dtype": "bf16",
      "elements": <n>, "device": "npu2", "fold_ddr_addr_offset": false}
     {"op": "MATMUL", "in_dtype": "bf16", "out_dtype": "f32", "m": <M>, "k": <K>, "n": <N>,
      "device": "npu2", "fold_ddr_addr_offset": false}
+    {"op": "MATMUL", "in_dtype": "i8", "out_dtype": "i32", "m": <M>, "k": <K>, "n": <N>,
+     "left_zero_point": <i8>, "right_zero_point": <i8>, "device": "npu2",
+     "fold_ddr_addr_offset": false}
     {"op": "MAX_POOL2D", "dtype": "bf16", "layout": "NHWC", "batch": 1,
      "input_h": <H>, "input_w": <W>, "channels": <C>, "output_h": <OH>, "output_w": <OW>,
      "kernel_h": <KH>, "kernel_w": <KW>, "stride_h": <SH>, "stride_w": <SW>,
@@ -178,18 +181,20 @@ extern "C" void cast_fp8e5m2_to_bf16(
 """
 
 
-def _build_identity(line_size: int):
-    """Return the @iron.jit IDENTITY design (a bf16 DMA copy: shim -> memtile -> shim)."""
+def _build_identity(line_size: int, dtype: str):
+    """Return the @iron.jit direct-DMA IDENTITY design (shim -> memtile -> shim)."""
     import aie.iron as iron
     import ml_dtypes
     import numpy as np
     from aie.iron import CompileTime, In, ObjectFifo, Out, Program, Runtime
     from aie.iron.device import AnyShimTile
 
+    element_type = ml_dtypes.bfloat16 if dtype == "bf16" else np.int8
+
     @iron.jit
-    def identity_bf16(x_in: In, y_out: Out, *, n: CompileTime[int]):
-        vector_ty = np.ndarray[(n,), np.dtype[ml_dtypes.bfloat16]]
-        line_ty = np.ndarray[(line_size,), np.dtype[ml_dtypes.bfloat16]]
+    def identity(x_in: In, y_out: Out, *, n: CompileTime[int]):
+        vector_ty = np.ndarray[(n,), np.dtype[element_type]]
+        line_ty = np.ndarray[(line_size,), np.dtype[element_type]]
         of_in = ObjectFifo(line_ty, name="in")
         of_out = of_in.cons().forward()
 
@@ -208,7 +213,7 @@ def _build_identity(line_size: int):
         )
         return Program(iron.get_current_device(), rt).resolve_program()
 
-    return identity_bf16
+    return identity
 
 
 def _build_fp8_to_bf16(line_size: int, in_dtype: str):
@@ -357,6 +362,173 @@ def _build_matmul(tile_m: int, tile_k: int, tile_n: int):
     return matmul_bf16_f32
 
 
+def _int8_matmul_kernel_source(
+    m: int, k: int, n: int, left_zero_point: int, right_zero_point: int
+) -> str:
+    """Generate the exact fixed-shape TOSA INT8 MATMUL device kernel.
+
+    OpenVINO expresses zero-point handling as INT32 widen/subtract nodes before MatMul. IRON has no
+    equivalent provider graph, so XDNA specializes the same arithmetic into the AIE core kernel.
+    The caller has already bounded K so every exact dot product fits INT32.
+    """
+    if m % 4 == 0 and k % 4 == 0 and n % 8 == 0:
+        # XDNA2's AIE2P INT16 MMUL is 4x4x8. Widening after zero-point subtraction is exact for
+        # every INT8 value (the adjusted range is -255..255), and avoids the overflow that would
+        # occur if adjusted values were squeezed back into INT8. Packing costs scalar loads, while
+        # the dominant multiply-accumulate work stays on the native vector unit.
+        return f"""
+#include <cstdint>
+#include <aie_api/aie.hpp>
+
+extern "C" void matmul_i8_i32_zp(
+    const int8_t *__restrict lhs,
+    const int8_t *__restrict rhs,
+    int32_t *__restrict output) {{
+    constexpr unsigned M = {m};
+    constexpr unsigned K = {k};
+    constexpr unsigned N = {n};
+    constexpr int32_t LEFT_ZERO_POINT = {left_zero_point};
+    constexpr int32_t RIGHT_ZERO_POINT = {right_zero_point};
+    using MMUL = aie::mmul<4, 4, 8, int16, int16, acc32>;
+    alignas(aie::vector_decl_align) int16 left_tile[MMUL::size_A];
+    alignas(aie::vector_decl_align) int16 right_tile[MMUL::size_B];
+    alignas(aie::vector_decl_align) int32 output_tile[MMUL::size_C];
+
+    for (unsigned row_base = 0; row_base < M; row_base += 4) {{
+        for (unsigned column_base = 0; column_base < N; column_base += 8) {{
+            MMUL accumulator;
+            for (unsigned inner_base = 0; inner_base < K; inner_base += 4) {{
+                for (unsigned row = 0; row < 4; ++row) {{
+                    for (unsigned inner = 0; inner < 4; ++inner) {{
+                        left_tile[row * 4 + inner] = static_cast<int16>(
+                            static_cast<int32_t>(lhs[(row_base + row) * K + inner_base + inner])
+                            - LEFT_ZERO_POINT);
+                    }}
+                }}
+                for (unsigned inner = 0; inner < 4; ++inner) {{
+                    for (unsigned column = 0; column < 8; ++column) {{
+                        right_tile[inner * 8 + column] = static_cast<int16>(
+                            static_cast<int32_t>(rhs[(inner_base + inner) * N + column_base + column])
+                            - RIGHT_ZERO_POINT);
+                    }}
+                }}
+                accumulator.mac(
+                    aie::load_v<MMUL::size_A>(left_tile),
+                    aie::load_v<MMUL::size_B>(right_tile));
+            }}
+            aie::store_v(output_tile, accumulator.to_vector<int32>());
+            for (unsigned row = 0; row < 4; ++row) {{
+                for (unsigned column = 0; column < 8; ++column) {{
+                    output[(row_base + row) * N + column_base + column] =
+                        output_tile[row * 8 + column];
+                }}
+            }}
+        }}
+    }}
+}}
+"""
+
+    # Arbitrary small shapes (including the shared 2x3x2 corpus case) cannot use a complete MMUL
+    # tile. Keep this fallback scalar and explicitly disable Peano's unsupported generic vector
+    # legalization; no host fallback is involved.
+    return f"""
+#include <cstdint>
+
+extern "C" void matmul_i8_i32_zp(
+    const int8_t *__restrict lhs,
+    const int8_t *__restrict rhs,
+    int32_t *__restrict output) {{
+    constexpr unsigned M = {m};
+    constexpr unsigned K = {k};
+    constexpr unsigned N = {n};
+    constexpr int32_t LEFT_ZERO_POINT = {left_zero_point};
+    constexpr int32_t RIGHT_ZERO_POINT = {right_zero_point};
+    for (unsigned row = 0; row < M; ++row) {{
+        for (unsigned column = 0; column < N; ++column) {{
+            int32_t accumulator = 0;
+#pragma clang loop vectorize(disable) interleave(disable)
+            for (unsigned inner = 0; inner < K; ++inner) {{
+                const int32_t left = static_cast<int32_t>(lhs[row * K + inner]);
+                const int32_t right = static_cast<int32_t>(rhs[inner * N + column]);
+                accumulator +=
+                    (left - LEFT_ZERO_POINT) * (right - RIGHT_ZERO_POINT);
+            }}
+            output[row * N + column] = accumulator;
+        }}
+    }}
+}}
+"""
+
+
+def _build_int8_matmul(
+    m: int, k: int, n: int, left_zero_point: int, right_zero_point: int
+):
+    """Return the exact one-core INT8 -> INT32 MATMUL design.
+
+    Complete bounded tensors are direct-DMA'd into depth-two object FIFOs. The worker invokes one
+    Peano-compiled AIE kernel; no host staging, host arithmetic, or floating-point conversion occurs.
+    """
+    import aie.iron as iron
+    import numpy as np
+    from aie.iron import In, ObjectFifo, Out, Program, Runtime, Worker
+    from aie.iron.kernel import ExternalFunction
+
+    lhs_transport_elements = (m * k + 3) & ~3
+    rhs_transport_elements = (k * n + 3) & ~3
+
+    @iron.jit
+    def matmul_int8_int32(lhs_in: In, rhs_in: In, output_out: Out):
+        # AIE DMA lengths are 32-bit granular. Padding is part of the declared direct-binding ABI,
+        # and the kernel's M/K/N loops never inspect it.
+        lhs_ty = np.ndarray[(lhs_transport_elements,), np.dtype[np.int8]]
+        rhs_ty = np.ndarray[(rhs_transport_elements,), np.dtype[np.int8]]
+        output_ty = np.ndarray[(m * n,), np.dtype[np.int32]]
+        kernel = ExternalFunction(
+            "matmul_i8_i32_zp",
+            source_string=_int8_matmul_kernel_source(
+                m, k, n, left_zero_point, right_zero_point
+            ),
+            arg_types=[lhs_ty, rhs_ty, output_ty],
+        )
+        lhs_fifo = ObjectFifo(lhs_ty, name="int8_lhs")
+        rhs_fifo = ObjectFifo(rhs_ty, name="int8_rhs")
+        output_fifo = ObjectFifo(output_ty, name="int32_output")
+
+        def core_fn(lhs_source, rhs_source, output_destination, matmul):
+            lhs = lhs_source.acquire(1)
+            rhs = rhs_source.acquire(1)
+            output = output_destination.acquire(1)
+            matmul(lhs, rhs, output)
+            lhs_source.release(1)
+            rhs_source.release(1)
+            output_destination.release(1)
+
+        worker = Worker(
+            core_fn,
+            [lhs_fifo.cons(), rhs_fifo.cons(), output_fifo.prod(), kernel],
+        )
+
+        def sequence(lhs, rhs, output, lhs_prod, rhs_prod, output_cons):
+            lhs_prod.fill(lhs)
+            rhs_prod.fill(rhs)
+            output_cons.drain(output, wait=True)
+
+        rt = Runtime(
+            sequence,
+            [
+                lhs_ty,
+                rhs_ty,
+                output_ty,
+                lhs_fifo.prod(),
+                rhs_fifo.prod(),
+                output_fifo.cons(),
+            ],
+        )
+        return Program(iron.get_current_device(), rt, workers=[worker]).resolve_program()
+
+    return matmul_int8_int32
+
+
 def _build_max_pool2d():
     """Return a batch-1 BF16 NHWC MAX_POOL2D design with propagating NaNs.
 
@@ -447,7 +619,7 @@ def _compile(workdir: Path) -> int:
         dtype = spec.get("dtype")
         elements = spec.get("elements")
         line_size = spec.get("line_size")
-        if dtype != "bf16":
+        if dtype not in ("bf16", "i8"):
             return _fail(workdir, "spec-rejected", f"unsupported dtype: {dtype}")
         if not isinstance(line_size, int) or line_size <= 0:
             return _fail(workdir, "spec-rejected", f"invalid line_size: {line_size}")
@@ -455,11 +627,15 @@ def _compile(workdir: Path) -> int:
             return _fail(
                 workdir, "spec-rejected", f"elements must be a positive multiple of {line_size}"
             )
-        # The binding plan: exact per-slot byte sizes (bf16 = 2 B/element).
-        input_bytes, output_bytes = [elements * 2], [elements * 2]
+        element_bytes = 2 if dtype == "bf16" else 1
+        if dtype == "i8":
+            max_line_size = spec.get("max_line_size")
+            if max_line_size != 1024 or line_size > max_line_size:
+                return _fail(workdir, "spec-rejected", "unsupported INT8 IDENTITY line size")
+        input_bytes, output_bytes = [elements * element_bytes], [elements * element_bytes]
 
         def build():
-            return _build_identity(line_size).specialize(n=elements)
+            return _build_identity(line_size, dtype).specialize(n=elements)
     elif op == "CAST":
         in_dtype = spec.get("in_dtype")
         out_dtype = spec.get("out_dtype")
@@ -483,26 +659,61 @@ def _compile(workdir: Path) -> int:
         in_dtype = spec.get("in_dtype")
         out_dtype = spec.get("out_dtype")
         m, k, n = spec.get("m"), spec.get("k"), spec.get("n")
-        tile_m, tile_k, tile_n = spec.get("tile_m"), spec.get("tile_k"), spec.get("tile_n")
         max_dim = spec.get("max_dim")
-        if in_dtype != "bf16" or out_dtype != "f32":
+        if (in_dtype, out_dtype) not in (("bf16", "f32"), ("i8", "i32")):
             return _fail(
                 workdir, "spec-rejected", f"unsupported dtype pair: {in_dtype}->{out_dtype}"
             )
         if not isinstance(max_dim, int) or max_dim <= 0:
             return _fail(workdir, "spec-rejected", f"invalid max_dim: {max_dim}")
-        for name, dim, tile in (("m", m, tile_m), ("k", k, tile_k), ("n", n, tile_n)):
-            if not isinstance(tile, int) or tile <= 0:
-                return _fail(workdir, "spec-rejected", f"invalid tile_{name}: {tile}")
-            if not isinstance(dim, int) or dim <= 0 or dim % tile != 0 or dim > max_dim:
+        for name, dim in (("m", m), ("k", k), ("n", n)):
+            if not isinstance(dim, int) or dim <= 0 or dim > max_dim:
                 return _fail(
-                    workdir, "spec-rejected", f"{name}={dim} must be a positive multiple of {tile} <= {max_dim}"
+                    workdir, "spec-rejected", f"{name}={dim} must be positive and <= {max_dim}"
                 )
-        # The binding plan: A[M,K] and B[K,N] are bf16 (2 B), C[M,N] is the fp32 accumulator (4 B).
-        input_bytes, output_bytes = [m * k * 2, k * n * 2], [m * n * 4]
+        if in_dtype == "bf16":
+            tile_m, tile_k, tile_n = (
+                spec.get("tile_m"),
+                spec.get("tile_k"),
+                spec.get("tile_n"),
+            )
+            for name, dim, tile in (("m", m, tile_m), ("k", k, tile_k), ("n", n, tile_n)):
+                if not isinstance(tile, int) or tile <= 0:
+                    return _fail(workdir, "spec-rejected", f"invalid tile_{name}: {tile}")
+                if dim % tile != 0:
+                    return _fail(
+                        workdir,
+                        "spec-rejected",
+                        f"{name}={dim} must be a multiple of {tile}",
+                    )
+            input_bytes, output_bytes = [m * k * 2, k * n * 2], [m * n * 4]
 
-        def build():
-            return _build_matmul(tile_m, tile_k, tile_n).specialize(M=m, K=k, N=n)
+            def build():
+                return _build_matmul(tile_m, tile_k, tile_n).specialize(M=m, K=k, N=n)
+        else:
+            left_zero_point = spec.get("left_zero_point")
+            right_zero_point = spec.get("right_zero_point")
+            max_total_bytes = spec.get("max_total_bytes")
+            if (
+                not isinstance(left_zero_point, int)
+                or not -128 <= left_zero_point <= 127
+                or not isinstance(right_zero_point, int)
+                or not -128 <= right_zero_point <= 127
+            ):
+                return _fail(workdir, "spec-rejected", "INT8 zero point is out of range")
+            if not isinstance(max_total_bytes, int) or max_total_bytes <= 0:
+                return _fail(workdir, "spec-rejected", "invalid INT8 local-memory bound")
+            lhs_bytes = (m * k + 3) & ~3
+            rhs_bytes = (k * n + 3) & ~3
+            total_bytes = lhs_bytes + rhs_bytes + m * n * 4
+            if total_bytes > max_total_bytes:
+                return _fail(workdir, "spec-rejected", "INT8 MATMUL local-memory bound exceeded")
+            input_bytes, output_bytes = [lhs_bytes, rhs_bytes], [m * n * 4]
+
+            def build():
+                return _build_int8_matmul(
+                    m, k, n, left_zero_point, right_zero_point
+                ).specialize()
     elif op == "MAX_POOL2D":
         dtype = spec.get("dtype")
         layout = spec.get("layout")

--- a/crates/virtio-accel-xdna/src/compiler.rs
+++ b/crates/virtio-accel-xdna/src/compiler.rs
@@ -23,9 +23,9 @@ use virtio_accel_core::BackendError;
 use crate::XDNA_ERROR_DOMAIN;
 use crate::artifact;
 use crate::lower::{
-    CompilerSpec, FP8_CAST_LINE_SIZE, Fp8Format, IDENTITY_LINE_SIZE, MATMUL_MAX_DIM, MATMUL_TILE_K,
-    MATMUL_TILE_M, MATMUL_TILE_N, MAX_POOL_MAX_KERNEL, MAX_POOL_MAX_STRIDE,
-    MAX_POOL_MAX_TOTAL_ELEMENTS,
+    CompilerSpec, FP8_CAST_LINE_SIZE, Fp8Format, IDENTITY_LINE_SIZE, INT8_IDENTITY_MAX_LINE_SIZE,
+    INT8_MATMUL_MAX_TOTAL_BYTES, MATMUL_MAX_DIM, MATMUL_TILE_K, MATMUL_TILE_M, MATMUL_TILE_N,
+    MAX_POOL_MAX_KERNEL, MAX_POOL_MAX_STRIDE, MAX_POOL_MAX_TOTAL_ELEMENTS,
 };
 
 /// The embedded compiler helper; written into each private workdir before invocation.
@@ -62,6 +62,13 @@ fn spec_json(spec: CompilerSpec) -> String {
                  \"line_size\":{IDENTITY_LINE_SIZE},{device}}}"
             )
         }
+        CompilerSpec::Int8Identity {
+            elements,
+            line_size,
+        } => format!(
+            "{{\"op\":\"IDENTITY\",\"dtype\":\"i8\",\"elements\":{elements},\
+             \"line_size\":{line_size},\"max_line_size\":{INT8_IDENTITY_MAX_LINE_SIZE},{device}}}"
+        ),
         CompilerSpec::Fp8ToBf16 { format, elements } => {
             let input = match format {
                 Fp8Format::E4M3 => "fp8e4m3",
@@ -77,6 +84,18 @@ fn spec_json(spec: CompilerSpec) -> String {
              \"m\":{m},\"k\":{k},\"n\":{n},\"tile_m\":{MATMUL_TILE_M},\
              \"tile_k\":{MATMUL_TILE_K},\"tile_n\":{MATMUL_TILE_N},\
              \"max_dim\":{MATMUL_MAX_DIM},{device}}}"
+        ),
+        CompilerSpec::Int8Matmul {
+            m,
+            k,
+            n,
+            left_zero_point,
+            right_zero_point,
+        } => format!(
+            "{{\"op\":\"MATMUL\",\"in_dtype\":\"i8\",\"out_dtype\":\"i32\",\
+             \"m\":{m},\"k\":{k},\"n\":{n},\"left_zero_point\":{left_zero_point},\
+             \"right_zero_point\":{right_zero_point},\"max_dim\":{MATMUL_MAX_DIM},\
+             \"max_total_bytes\":{INT8_MATMUL_MAX_TOTAL_BYTES},{device}}}"
         ),
         CompilerSpec::MaxPool2d {
             input_h,
@@ -345,6 +364,17 @@ mod tests {
     }
 
     #[test]
+    fn int8_identity_spec_carries_the_admitted_line_size() {
+        let json = spec_json(CompilerSpec::Int8Identity {
+            elements: 8,
+            line_size: 8,
+        });
+        assert!(json.contains("\"dtype\":\"i8\""));
+        assert!(json.contains("\"line_size\":8"));
+        assert!(json.contains("\"max_line_size\":1024"));
+    }
+
+    #[test]
     fn matmul_spec_carries_the_authoritative_tiling_envelope() {
         let json = spec_json(CompilerSpec::Matmul {
             m: 64,
@@ -356,6 +386,26 @@ mod tests {
             "\"tile_k\":64",
             "\"tile_n\":32",
             "\"max_dim\":512",
+        ] {
+            assert!(json.contains(field), "missing {field} in {json}");
+        }
+    }
+
+    #[test]
+    fn int8_matmul_spec_preserves_zero_points_and_memory_bound() {
+        let json = spec_json(CompilerSpec::Int8Matmul {
+            m: 2,
+            k: 3,
+            n: 2,
+            left_zero_point: -2,
+            right_zero_point: 3,
+        });
+        for field in [
+            "\"in_dtype\":\"i8\"",
+            "\"out_dtype\":\"i32\"",
+            "\"left_zero_point\":-2",
+            "\"right_zero_point\":3",
+            "\"max_total_bytes\":16384",
         ] {
             assert!(json.contains(field), "missing {field} in {json}");
         }

--- a/crates/virtio-accel-xdna/src/lib.rs
+++ b/crates/virtio-accel-xdna/src/lib.rs
@@ -19,7 +19,8 @@
 //! (execution-model spec, issue #85). `load_program` accepts the crate-local precompiled format
 //! ([`artifact`]) directly, and a TOSA artifact by admitting it and compiling it with the bounded
 //! aiecc helper subprocess (issue #84). The compilable TOSA subsets today are BF16 IDENTITY,
-//! BF16 → FP32 MATMUL, BF16 MAX_POOL2D, and explicit FP8 → BF16 storage conversion.
+//! BF16 → FP32 MATMUL, BF16 MAX_POOL2D, explicit FP8 → BF16 storage conversion, and exact INT8
+//! IDENTITY plus zero-point-aware INT8 → INT32 MATMUL.
 //! Admission (`lower`) unit-tests on every host.
 
 #![cfg_attr(not(va_xdna), forbid(unsafe_code))]
@@ -30,14 +31,18 @@ mod lower;
 pub use artifact::{PrecompiledArtifact, XDNA_PRECOMPILED_FORMAT};
 pub use lower::{
     AdmitError, CompilerSpec, Fp8Format, XDNA_TOSA_CAPABILITY, XDNA_TOSA_FP8_CAPABILITY,
-    XDNA_TOSA_FP8_TARGET, XDNA_TOSA_INTEGER_TARGET, XDNA_TOSA_TARGET, admit,
+    XDNA_TOSA_FP8_TARGET, XDNA_TOSA_INTEGER_CAPABILITY, XDNA_TOSA_INTEGER_TARGET, XDNA_TOSA_TARGET,
+    admit,
 };
 
 use virtio_accel_tosa::{CapabilityDescriptor, TosaCapabilityProvider};
 
 #[cfg(va_xdna)]
-const TOSA_CAPABILITIES: &[CapabilityDescriptor] =
-    &[XDNA_TOSA_CAPABILITY, XDNA_TOSA_FP8_CAPABILITY];
+const TOSA_CAPABILITIES: &[CapabilityDescriptor] = &[
+    XDNA_TOSA_CAPABILITY,
+    XDNA_TOSA_FP8_CAPABILITY,
+    XDNA_TOSA_INTEGER_CAPABILITY,
+];
 #[cfg(not(va_xdna))]
 const TOSA_CAPABILITIES: &[CapabilityDescriptor] = &[];
 

--- a/crates/virtio-accel-xdna/src/lower.rs
+++ b/crates/virtio-accel-xdna/src/lower.rs
@@ -6,7 +6,8 @@
 //! amdxdna artifact. Anything outside the advertised subset is rejected here, before any subprocess
 //! runs. Graph lowering for compute tiers grows on top of this; the compilable subsets today are
 //! the BF16 IDENTITY (a DMA copy), BF16 → FP32 MATMUL (issue #90), BF16 NHWC MAX_POOL2D
-//! (issue #91), and explicit FP8 → BF16 CAST storage conversion (issue #109).
+//! (issue #91), explicit FP8 → BF16 CAST storage conversion (issue #109), and exact INT8
+//! IDENTITY plus zero-point-aware INT8 → INT32 MATMUL (issue #144).
 
 use virtio_accel_tosa::{
     AnalyzedValueKind, CapabilityDescriptor, DType, DTypeCapability, ExtensionSet,
@@ -41,7 +42,7 @@ pub const XDNA_TOSA_FP8_TARGET: Target = Target::new(
 
 /// The integer tier: TOSA 1.0, integer profile, level 8K, no extensions.
 ///
-/// Native i8/i16 matmul with exact (bit-for-bit) results, kept on a separate target from the
+/// INT8 identity and zero-point-aware MATMUL with exact INT32 results, kept on a separate target from the
 /// floating-point tier exactly as the OpenVINO backend separates its FP and INTEGER targets.
 pub const XDNA_TOSA_INTEGER_TARGET: Target = Target::new(
     Version::TOSA_1_0,
@@ -99,12 +100,54 @@ pub const XDNA_TOSA_FP8_CAPABILITY: CapabilityDescriptor = CapabilityDescriptor 
     },
 };
 
+// This is deliberately the same semantic surface OpenVINO advertises for its integer target.
+// XDNA's admission functions below impose an additional, hardware-specific static-memory envelope.
+const INTEGER_DTYPES: &[DTypeCapability] = &[
+    DTypeCapability::new(DType::INT8, ValueRoles::ALL),
+    DTypeCapability::new(
+        DType::INT32,
+        ValueRoles::OUTPUT
+            .union(ValueRoles::CONSTANT)
+            .union(ValueRoles::INTERMEDIATE),
+    ),
+];
+
+const INTEGER_OPERATORS: &[OperatorCapability] = &[
+    OperatorCapability::new(Op::CONST),
+    OperatorCapability::new(Op::IDENTITY),
+    OperatorCapability::new(Op::MATMUL),
+];
+
+/// Conservative exact integer-profile capability boundary for XDNA lowering.
+///
+/// This mirrors OpenVINO's dtype and operator declaration. XDNA additionally admits only bounded,
+/// static specializations that fit the proven one-core implementation; this is a hardware
+/// envelope, not a semantic fallback.
+pub const XDNA_TOSA_INTEGER_CAPABILITY: CapabilityDescriptor = CapabilityDescriptor {
+    target: XDNA_TOSA_INTEGER_TARGET,
+    dtypes: INTEGER_DTYPES,
+    operators: INTEGER_OPERATORS,
+    graph: GraphCapabilities {
+        max_regions: 1,
+        max_blocks: 1,
+        dynamic_shapes: false,
+        runtime_conditions: RuntimeConditionSupport::None,
+    },
+};
+
 /// The DMA line size the IDENTITY template transfers in; an admitted element count must be a
 /// positive multiple of it. The Rust compiler driver carries this value into the helper spec.
 pub(crate) const IDENTITY_LINE_SIZE: usize = 1024;
 
 /// The fixed element tile converted by the FP8 → BF16 kernel.
 pub(crate) const FP8_CAST_LINE_SIZE: usize = 1024;
+
+/// Largest direct-DMA line used by the INT8 IDENTITY template.
+///
+/// Small corpus tensors use one shorter line. Every line is four-byte aligned because the AIE DMA
+/// rejects shorter granularity; larger tensors must divide into complete 1,024-byte lines so the
+/// runtime sequence never needs a hidden tail copy.
+pub(crate) const INT8_IDENTITY_MAX_LINE_SIZE: usize = 1024;
 
 /// The one tested MATMUL compute tile (`m`, `k`, `n`), proven on npu2 (AIE2P).
 ///
@@ -121,6 +164,13 @@ pub(crate) const MATMUL_TILE_N: usize = 32;
 /// Largest admitted MATMUL dimension. The tested tiling generalizes across multiples of the tile,
 /// but only within this envelope; larger shapes are a later generalization and are rejected now.
 pub(crate) const MATMUL_MAX_DIM: usize = 512;
+
+/// Largest combined input/output footprint for the exact INT8 MATMUL specialization.
+///
+/// The initial kernel keeps complete A, B, and C tensors in one AIE2P core. Limiting their
+/// undoubled footprint to 16 KiB leaves room for depth-two FIFOs, code, and bookkeeping in its
+/// roughly 64 KiB local memory. This is stricter than OpenVINO because it is an XDNA memory limit.
+pub(crate) const INT8_MATMUL_MAX_TOTAL_BYTES: usize = 16 * 1024;
 
 /// Maximum admitted pooling kernel and stride dimensions. Larger windows are unproven on the
 /// scalar AIE2P kernel and are rejected before the compiler subprocess runs.
@@ -140,6 +190,9 @@ pub enum CompilerSpec {
     /// BF16 → BF16 elementwise copy of `elements` values (a positive multiple of
     /// 1,024 values).
     Identity { elements: usize },
+    /// Exact INT8 → INT8 elementwise copy. `line_size` is the complete DMA line selected by
+    /// admission; no tail staging or dtype conversion is permitted.
+    Int8Identity { elements: usize, line_size: usize },
     /// Explicit FP8 storage conversion to BF16. Every finite source value is exactly
     /// representable, so the output is bit-exact except for permitted NaN canonicalization.
     Fp8ToBf16 { format: Fp8Format, elements: usize },
@@ -147,6 +200,17 @@ pub enum CompilerSpec {
     /// `k`, `n` is a positive multiple of the corresponding MATMUL tile dimension and at most
     /// 512. The FP32 output is the TOSA-mandated accumulator (issue #82).
     Matmul { m: usize, k: usize, n: usize },
+    /// Exact zero-point-aware INT8 × INT8 → INT32 matrix multiply (batch 1).
+    ///
+    /// The serialized TOSA zero points are part of the specialization and therefore also part of
+    /// the compiler cache key. Arithmetic is `(a - a_zp) * (b - b_zp)` accumulated in INT32.
+    Int8Matmul {
+        m: usize,
+        k: usize,
+        n: usize,
+        left_zero_point: i8,
+        right_zero_point: i8,
+    },
     /// Batch-1 BF16 NHWC MAX_POOL2D with zero padding and propagating NaNs. The complete static
     /// specialization is carried to the helper so no TOSA bytes cross the subprocess boundary.
     MaxPool2d {
@@ -197,7 +261,8 @@ impl From<AdmitError> for virtio_accel_core::BackendError {
 /// Admit a TOSA artifact for `target`, returning the specialization the helper compiles.
 ///
 /// The BF16 target admits IDENTITY (a DMA copy), BF16 → FP32 MATMUL, and BF16 NHWC MAX_POOL2D.
-/// The separate FP8 storage target admits one explicit FP8 → BF16 CAST. Everything else is rejected
+/// The separate FP8 storage target admits one explicit FP8 → BF16 CAST. The integer target admits
+/// exact INT8 IDENTITY and zero-point-aware INT8 → INT32 MATMUL. Everything else is rejected
 /// without running the compiler. Each template admits only graphs whose **dataflow** matches what
 /// the compiled kernel executes — the IDENTITY
 /// template requires every operator to be IDENTITY (no constants: with a single block input, every
@@ -209,8 +274,10 @@ impl From<AdmitError> for virtio_accel_core::BackendError {
 /// BF16 MATMUL zero-points are constant zero — is enforced by
 /// [`analyze_for`](virtio_accel_tosa::Model::analyze_for) before these structural checks.
 pub fn admit(bytes: &[u8], target: Target) -> Result<CompilerSpec, AdmitError> {
-    if target != XDNA_TOSA_TARGET && target != XDNA_TOSA_FP8_TARGET {
-        // The integer tier and other targets are later tickets.
+    if target != XDNA_TOSA_TARGET
+        && target != XDNA_TOSA_FP8_TARGET
+        && target != XDNA_TOSA_INTEGER_TARGET
+    {
         return Err(AdmitError::Unsupported);
     }
     let model = parse(bytes).map_err(|_| AdmitError::Parse)?;
@@ -257,8 +324,155 @@ pub fn admit(bytes: &[u8], target: Target) -> Result<CompilerSpec, AdmitError> {
         (XDNA_TOSA_FP8_TARGET, None, None, Some(cast), 0, 0) => {
             admit_fp8_to_bf16(&analysis, block, cast)
         }
+        (XDNA_TOSA_INTEGER_TARGET, None, None, None, _, 0) => admit_int8_identity(&analysis, block),
+        (XDNA_TOSA_INTEGER_TARGET, Some(matmul), None, None, 0, _) => {
+            admit_int8_matmul(&analysis, block, matmul)
+        }
         _ => Err(AdmitError::Unsupported),
     }
+}
+
+/// Admit exact INT8 IDENTITY, including the shared eight-byte corpus fixture.
+///
+/// Unlike BF16's established 1,024-element template, a small INT8 tensor is one complete DMA line.
+/// Larger tensors must be an exact multiple of the maximum line so no tail is staged on the host.
+fn admit_int8_identity(
+    analysis: &virtio_accel_tosa::TosaAnalysis<'_>,
+    block: virtio_accel_tosa::BlockId,
+) -> Result<CompilerSpec, AdmitError> {
+    let inputs = analysis.block_inputs(block);
+    let outputs = analysis.block_outputs(block);
+    if inputs.len() != 1 || outputs.len() != 1 {
+        return Err(AdmitError::Unsupported);
+    }
+    for value in analysis.values() {
+        if let AnalyzedValueKind::Tensor(tensor) = value.kind() {
+            if tensor.dtype() != DType::INT8 {
+                return Err(AdmitError::Unsupported);
+            }
+        }
+    }
+
+    let elements = tensor_elements(analysis, outputs[0])?;
+    let line_size = elements.min(INT8_IDENTITY_MAX_LINE_SIZE);
+    if line_size % 4 != 0 || (elements > INT8_IDENTITY_MAX_LINE_SIZE && elements % line_size != 0) {
+        return Err(AdmitError::Unsupported);
+    }
+    Ok(CompilerSpec::Int8Identity {
+        elements,
+        line_size,
+    })
+}
+
+/// Admit exact zero-point-aware INT8 MATMUL with the same graph semantics as OpenVINO.
+///
+/// XDNA specializes the two serialized rank-1 INT8 zero points into the device kernel because the
+/// AIE kernel API has no provider graph in which to insert OpenVINO's widen-and-subtract nodes.
+/// Both paths compute the same TOSA expression; XDNA never adjusts values on the host.
+fn admit_int8_matmul(
+    analysis: &virtio_accel_tosa::TosaAnalysis<'_>,
+    block: virtio_accel_tosa::BlockId,
+    matmul: virtio_accel_tosa::OperatorId,
+) -> Result<CompilerSpec, AdmitError> {
+    let inputs = analysis.operator_inputs(matmul);
+    let outputs = analysis.operator_outputs(matmul);
+    if inputs.len() != 4
+        || outputs.len() != 1
+        || analysis.block_inputs(block) != [inputs[0], inputs[1]]
+        || analysis.block_outputs(block) != [outputs[0]]
+    {
+        return Err(AdmitError::Unsupported);
+    }
+    for operator in analysis.execution_order(block) {
+        if analysis.operator(*operator).op() != Op::CONST {
+            continue;
+        }
+        for produced in analysis.operator_outputs(*operator) {
+            if *produced != inputs[2] && *produced != inputs[3] {
+                return Err(AdmitError::Unsupported);
+            }
+        }
+    }
+
+    let lhs = matmul_dims(analysis, inputs[0], DType::INT8)?;
+    let rhs = matmul_dims(analysis, inputs[1], DType::INT8)?;
+    let out = matmul_dims(analysis, outputs[0], DType::INT32)?;
+    let ([1, m, k], [1, k2, n], [1, m2, n2]) = (lhs, rhs, out) else {
+        return Err(AdmitError::Unsupported);
+    };
+    if k != k2 || m != m2 || n != n2 || [m, k, n].iter().any(|dim| *dim > MATMUL_MAX_DIM) {
+        return Err(AdmitError::Unsupported);
+    }
+
+    // AIE DMA descriptors transfer whole 32-bit words. The direct-binding ABI therefore rounds
+    // each INT8 input slot up to four bytes; the kernel ignores those explicit padding bytes.
+    let lhs_bytes = align_to_four(m.checked_mul(k).ok_or(AdmitError::Unsupported)?)?;
+    let rhs_bytes = align_to_four(k.checked_mul(n).ok_or(AdmitError::Unsupported)?)?;
+    let output_bytes = m
+        .checked_mul(n)
+        .and_then(|elements| elements.checked_mul(4))
+        .ok_or(AdmitError::Unsupported)?;
+    if lhs_bytes
+        .checked_add(rhs_bytes)
+        .and_then(|bytes| bytes.checked_add(output_bytes))
+        .is_none_or(|bytes| bytes > INT8_MATMUL_MAX_TOTAL_BYTES)
+    {
+        return Err(AdmitError::Unsupported);
+    }
+
+    Ok(CompilerSpec::Int8Matmul {
+        m,
+        k,
+        n,
+        left_zero_point: int8_zero_point(analysis, inputs[2])?,
+        right_zero_point: int8_zero_point(analysis, inputs[3])?,
+    })
+}
+
+fn align_to_four(bytes: usize) -> Result<usize, AdmitError> {
+    bytes
+        .checked_add(3)
+        .map(|bytes| bytes & !3)
+        .ok_or(AdmitError::Unsupported)
+}
+
+fn int8_zero_point(
+    analysis: &virtio_accel_tosa::TosaAnalysis<'_>,
+    value: virtio_accel_tosa::ValueId,
+) -> Result<i8, AdmitError> {
+    let AnalyzedValueKind::Tensor(tensor) = analysis.value(value).kind() else {
+        return Err(AdmitError::Unsupported);
+    };
+    if tensor.dtype() != DType::INT8 || tensor.dimensions().ne([1]) {
+        return Err(AdmitError::Unsupported);
+    }
+    let [byte] = analysis
+        .serialized_constant(value)
+        .ok_or(AdmitError::Unsupported)?
+    else {
+        return Err(AdmitError::Unsupported);
+    };
+    Ok(*byte as i8)
+}
+
+fn tensor_elements(
+    analysis: &virtio_accel_tosa::TosaAnalysis<'_>,
+    value: virtio_accel_tosa::ValueId,
+) -> Result<usize, AdmitError> {
+    let AnalyzedValueKind::Tensor(tensor) = analysis.value(value).kind() else {
+        return Err(AdmitError::Unsupported);
+    };
+    let mut elements = 1usize;
+    for dimension in tensor.dimensions() {
+        let dimension = usize::try_from(dimension).map_err(|_| AdmitError::Unsupported)?;
+        if dimension == 0 {
+            return Err(AdmitError::Unsupported);
+        }
+        elements = elements
+            .checked_mul(dimension)
+            .ok_or(AdmitError::Unsupported)?;
+    }
+    Ok(elements)
 }
 
 /// Admit one explicit FP8 → BF16 CAST directly connecting the block input and output.
@@ -594,11 +808,23 @@ mod tests {
         in_dtype: DType,
         out_dtype: DType,
     ) -> OwnedGraph<'static> {
-        // A BF16 zero (0x0000) and an FP32 zero (0x0000_0000); the zero-point dtype tracks the
-        // input dtype, so two bytes suffice for every dtype used here.
-        let zero = |dtype: DType| match dtype {
+        matmul_graph_with_zero_points(m, k, n, in_dtype, out_dtype, 0, 0)
+    }
+
+    fn matmul_graph_with_zero_points(
+        m: i32,
+        k: i32,
+        n: i32,
+        in_dtype: DType,
+        out_dtype: DType,
+        left_zero_point: i8,
+        right_zero_point: i8,
+    ) -> OwnedGraph<'static> {
+        let zero_point = |dtype: DType, value: i8| match dtype {
+            DType::INT8 => vec![value as u8],
+            DType::BF16 => vec![0u8; 2],
             DType::FP32 => vec![0u8; 4],
-            _ => vec![0u8; 2],
+            _ => Vec::new(),
         };
         let mut graph = OwnedGraph::new("main");
         graph
@@ -608,13 +834,13 @@ mod tests {
                 "lhs_zp",
                 vec![1],
                 in_dtype,
-                zero(in_dtype),
+                zero_point(in_dtype, left_zero_point),
             ))
             .push_tensor(OwnedTensor::constant(
                 "rhs_zp",
                 vec![1],
                 in_dtype,
-                zero(in_dtype),
+                zero_point(in_dtype, right_zero_point),
             ))
             .push_tensor(OwnedTensor::new("output", vec![1, m, n], out_dtype))
             .push_operator(OwnedOperator::new(
@@ -702,6 +928,81 @@ mod tests {
             .expect("build bf16 identity");
         let spec = admit(&bytes, XDNA_TOSA_TARGET).expect("admit");
         assert_eq!(spec, CompilerSpec::Identity { elements: 4 * 1024 });
+    }
+
+    #[test]
+    fn integer_capability_matches_the_openvino_precedent() {
+        assert_eq!(
+            XDNA_TOSA_INTEGER_CAPABILITY.target,
+            XDNA_TOSA_INTEGER_TARGET
+        );
+        assert_eq!(XDNA_TOSA_INTEGER_CAPABILITY.dtypes, INTEGER_DTYPES);
+        assert_eq!(XDNA_TOSA_INTEGER_CAPABILITY.operators, INTEGER_OPERATORS);
+        assert_eq!(XDNA_TOSA_INTEGER_CAPABILITY.graph.max_regions, 1);
+        assert_eq!(XDNA_TOSA_INTEGER_CAPABILITY.graph.max_blocks, 1);
+        assert_eq!(
+            XDNA_TOSA_INTEGER_CAPABILITY.graph.runtime_conditions,
+            RuntimeConditionSupport::None
+        );
+    }
+
+    #[test]
+    fn admits_shared_int8_identity_shape() {
+        let bytes = identity_graph(DType::INT8, vec![8])
+            .build(XDNA_TOSA_INTEGER_TARGET)
+            .expect("build int8 identity");
+        assert_eq!(
+            admit(&bytes, XDNA_TOSA_INTEGER_TARGET),
+            Ok(CompilerSpec::Int8Identity {
+                elements: 8,
+                line_size: 8,
+            })
+        );
+    }
+
+    #[test]
+    fn admits_zero_point_aware_int8_matmul() {
+        let bytes = matmul_graph_with_zero_points(2, 3, 2, DType::INT8, DType::INT32, -2, 3)
+            .build(XDNA_TOSA_INTEGER_TARGET)
+            .expect("build int8 matmul");
+        assert_eq!(
+            admit(&bytes, XDNA_TOSA_INTEGER_TARGET),
+            Ok(CompilerSpec::Int8Matmul {
+                m: 2,
+                k: 3,
+                n: 2,
+                left_zero_point: -2,
+                right_zero_point: 3,
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_int8_shapes_outside_the_one_core_envelope() {
+        let non_word_identity = identity_graph(DType::INT8, vec![6])
+            .build(XDNA_TOSA_INTEGER_TARGET)
+            .expect("build int8 identity");
+        assert_eq!(
+            admit(&non_word_identity, XDNA_TOSA_INTEGER_TARGET),
+            Err(AdmitError::Unsupported)
+        );
+
+        let non_divisible_identity = identity_graph(DType::INT8, vec![1025])
+            .build(XDNA_TOSA_INTEGER_TARGET)
+            .expect("build int8 identity");
+        assert_eq!(
+            admit(&non_divisible_identity, XDNA_TOSA_INTEGER_TARGET),
+            Err(AdmitError::Unsupported)
+        );
+
+        let oversized_matmul =
+            matmul_graph_with_zero_points(64, 64, 64, DType::INT8, DType::INT32, -2, 3)
+                .build(XDNA_TOSA_INTEGER_TARGET)
+                .expect("build int8 matmul");
+        assert_eq!(
+            admit(&oversized_matmul, XDNA_TOSA_INTEGER_TARGET),
+            Err(AdmitError::Unsupported)
+        );
     }
 
     #[test]
@@ -1027,13 +1328,13 @@ mod tests {
     }
 
     #[test]
-    fn rejects_wrong_target() {
+    fn rejects_bf16_artifact_under_integer_target() {
         let bytes = identity_graph(DType::BF16, vec![1, 4, 1024])
             .build(XDNA_TOSA_TARGET)
             .expect("build");
         assert_eq!(
             admit(&bytes, XDNA_TOSA_INTEGER_TARGET),
-            Err(AdmitError::Unsupported)
+            Err(AdmitError::Analysis)
         );
     }
 }

--- a/crates/virtio-accel-xdna/tests/common/mod.rs
+++ b/crates/virtio-accel-xdna/tests/common/mod.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, Instant};
 use virtio_accel_core::{Accelerator, BackendError, EventState};
 use virtio_accel_tosa::DType;
 use virtio_accel_tosa_build::{OperatorKind, OwnedGraph, OwnedOperator, OwnedTensor};
-use virtio_accel_xdna::{XDNA_TOSA_FP8_TARGET, XDNA_TOSA_TARGET};
+use virtio_accel_xdna::{XDNA_TOSA_FP8_TARGET, XDNA_TOSA_INTEGER_TARGET, XDNA_TOSA_TARGET};
 
 pub fn bf16_identity_tosa(elements: usize) -> Vec<u8> {
     let shape = vec![1, 1, elements as i32];
@@ -78,6 +78,54 @@ pub fn bf16_matmul_tosa(m: i32, k: i32, n: i32) -> Vec<u8> {
         .push_input("rhs")
         .push_output("output");
     graph.build(XDNA_TOSA_TARGET).expect("build bf16 matmul")
+}
+
+#[allow(dead_code)] // The hardware benchmark uses this; conformance.rs compiles this module too.
+pub fn int8_matmul_tosa(
+    m: i32,
+    k: i32,
+    n: i32,
+    left_zero_point: i8,
+    right_zero_point: i8,
+) -> Vec<u8> {
+    let mut graph = OwnedGraph::new("main");
+    graph
+        .push_tensor(OwnedTensor::new("lhs", vec![1, m, k], DType::INT8))
+        .push_tensor(OwnedTensor::new("rhs", vec![1, k, n], DType::INT8))
+        .push_tensor(OwnedTensor::constant(
+            "lhs_zp",
+            vec![1],
+            DType::INT8,
+            vec![left_zero_point as u8],
+        ))
+        .push_tensor(OwnedTensor::constant(
+            "rhs_zp",
+            vec![1],
+            DType::INT8,
+            vec![right_zero_point as u8],
+        ))
+        .push_tensor(OwnedTensor::new("output", vec![1, m, n], DType::INT32))
+        .push_operator(OwnedOperator::new(
+            OperatorKind::Const,
+            vec![],
+            vec!["lhs_zp".into()],
+        ))
+        .push_operator(OwnedOperator::new(
+            OperatorKind::Const,
+            vec![],
+            vec!["rhs_zp".into()],
+        ))
+        .push_operator(OwnedOperator::new(
+            OperatorKind::MatMul,
+            vec!["lhs".into(), "rhs".into(), "lhs_zp".into(), "rhs_zp".into()],
+            vec!["output".into()],
+        ))
+        .push_input("lhs")
+        .push_input("rhs")
+        .push_output("output");
+    graph
+        .build(XDNA_TOSA_INTEGER_TARGET)
+        .expect("build int8 matmul")
 }
 
 pub fn poll_to_terminal<A: Accelerator>(

--- a/crates/virtio-accel-xdna/tests/hardware.rs
+++ b/crates/virtio-accel-xdna/tests/hardware.rs
@@ -9,21 +9,27 @@
 use std::time::{Duration, Instant};
 
 mod common;
-use common::{bf16_identity_tosa, bf16_matmul_tosa, fp8e4m3_to_bf16_tosa, poll_to_terminal};
+use common::{
+    bf16_identity_tosa, bf16_matmul_tosa, fp8e4m3_to_bf16_tosa, int8_matmul_tosa, poll_to_terminal,
+};
 
 use virtio_accel_conformance::numerics::{
-    CAST_FP8E4M3_TO_BF16, CAST_FP8E5M2_TO_BF16, MAX_POOL2D_BF16, TosaFp8ToBfloat16Case,
+    CAST_FP8E4M3_TO_BF16, CAST_FP8E5M2_TO_BF16, IDENTITY_INT8, MATMUL_INT8, MAX_POOL2D_BF16,
+    TosaFp8ToBfloat16Case,
 };
 use virtio_accel_core::{
     Accelerator, AccessMode, ArtifactFormat, ArtifactRef, BackendError, BindingRef, BufferDesc,
     BufferRange, BufferUsage, ByteSink, ByteSource, ContextDesc, EventState, MemoryDomain,
     QueueDesc, ReleaseFailure, SubmitFailure, TargetIdentity, Timeout,
 };
-use virtio_accel_tosa::{ARTIFACT_FORMAT, DType, TosaCapabilityProvider, fp8e4m3_to_bf16_bits};
+use virtio_accel_tosa::{
+    ARTIFACT_FORMAT, DType, TosaCapabilityProvider, dot_i8_i32, fp8e4m3_to_bf16_bits,
+};
 use virtio_accel_tosa_build::{OperatorKind, OwnedGraph, OwnedOperator, OwnedTensor};
 use virtio_accel_xdna::{
-    InitError, XDNA_PRECOMPILED_FORMAT, XDNA_TOSA_FP8_TARGET, XDNA_TOSA_TARGET, XdnaAccelerator,
-    XdnaBuffer, XdnaContext, XdnaProgram, XdnaQueue, XdnaResourceCounts, compile_artifact,
+    InitError, XDNA_PRECOMPILED_FORMAT, XDNA_TOSA_FP8_TARGET, XDNA_TOSA_INTEGER_TARGET,
+    XDNA_TOSA_TARGET, XdnaAccelerator, XdnaBuffer, XdnaContext, XdnaProgram, XdnaQueue,
+    XdnaResourceCounts, compile_artifact,
 };
 #[cfg(feature = "test-control")]
 use virtio_accel_xdna::{XdnaTestConfig, XdnaTestFault};
@@ -228,9 +234,13 @@ fn device_info_reports_the_npu() {
     let info = backend.device_info().expect("device info");
     assert_eq!(info.identity.vendor_id, 0x1022);
     assert_eq!(info.identity.device_id, 0x17f0);
-    assert_eq!(backend.tosa_capabilities().len(), 2);
+    assert_eq!(backend.tosa_capabilities().len(), 3);
     assert_eq!(backend.tosa_capabilities()[0].target, XDNA_TOSA_TARGET);
     assert_eq!(backend.tosa_capabilities()[1].target, XDNA_TOSA_FP8_TARGET);
+    assert_eq!(
+        backend.tosa_capabilities()[2].target,
+        XDNA_TOSA_INTEGER_TARGET
+    );
 }
 
 #[test]
@@ -836,6 +846,421 @@ fn tosa_bf16_identity_runs_on_the_npu() {
     backend.free_buffer(input).expect("free input");
     backend.free_buffer(output).expect("free output");
     backend.unload_program(program).expect("unload");
+    backend.destroy_queue(queue).expect("destroy queue");
+    backend.destroy_context(context).expect("destroy context");
+}
+
+#[test]
+fn tosa_int8_corpus_compiles_to_wellformed_artifacts() {
+    if !toolchain_present() {
+        eprintln!("no XDNA toolchain configured; skipping compiler test");
+        return;
+    }
+    for (case_name, artifact, expected_slots) in [
+        (IDENTITY_INT8.name, IDENTITY_INT8.artifact, &[8, 8][..]),
+        (MATMUL_INT8.name, MATMUL_INT8.artifact, &[8, 8, 16][..]),
+    ] {
+        let container = compile_artifact(artifact, XDNA_TOSA_INTEGER_TARGET)
+            .unwrap_or_else(|error| panic!("compile {case_name}: {error:?}"));
+        let parsed = virtio_accel_xdna::PrecompiledArtifact::parse(&container)
+            .unwrap_or_else(|error| panic!("parse {case_name}: {error:?}"));
+        assert!(parsed.xclbin.starts_with(b"xclbin2"));
+        assert!(!parsed.insts.is_empty() && parsed.insts.len() % 4 == 0);
+        assert_eq!(parsed.slot_bytes, expected_slots);
+        assert_eq!(parsed.entry, "MLIR_AIE");
+    }
+}
+
+#[test]
+fn tosa_int8_identity_matches_the_shared_exact_oracle_on_the_npu() {
+    let Some(backend) = backend() else { return };
+    if !toolchain_present() {
+        eprintln!("no XDNA toolchain configured; skipping TOSA execution test");
+        return;
+    }
+    let context = backend
+        .create_context(ContextDesc::default())
+        .expect("context");
+    let queue = backend
+        .create_queue(&context, QueueDesc::default())
+        .expect("queue");
+    let program = backend
+        .load_program(
+            &context,
+            ArtifactRef {
+                format: ARTIFACT_FORMAT,
+                target: XDNA_TOSA_INTEGER_TARGET.to_identity(),
+                payload: &Slice(IDENTITY_INT8.artifact),
+                resident_bytes: u64::MAX,
+            },
+        )
+        .expect("load INT8 identity");
+    let input_bytes = IDENTITY_INT8.inputs[0].bytes;
+    let output_len = IDENTITY_INT8.outputs[0].bytes.len();
+    let (mut input, _) = backend
+        .allocate_buffer(
+            &context,
+            BufferDesc::new(
+                input_bytes.len() as u64,
+                4096,
+                MemoryDomain::Shared,
+                BufferUsage::TRANSFER_DESTINATION | BufferUsage::PROGRAM_INPUT,
+            )
+            .unwrap(),
+        )
+        .expect("input buffer")
+        .into_parts();
+    let (output, _) = backend
+        .allocate_buffer(
+            &context,
+            BufferDesc::new(
+                output_len as u64,
+                4096,
+                MemoryDomain::Shared,
+                BufferUsage::TRANSFER_SOURCE | BufferUsage::PROGRAM_OUTPUT,
+            )
+            .unwrap(),
+        )
+        .expect("output buffer")
+        .into_parts();
+    backend
+        .write_buffer(&mut input, 0, &Slice(input_bytes))
+        .expect("write INT8 input");
+
+    let direct_before = backend.direct_binding_admissions();
+    let transfer_before = backend.explicit_transfer_bytes();
+    let event = backend
+        .submit(
+            &queue,
+            &program,
+            &[
+                BindingRef {
+                    slot: 0,
+                    buffer: &input,
+                    range: BufferRange::new(0, input_bytes.len() as u64).unwrap(),
+                    access: AccessMode::Read,
+                },
+                BindingRef {
+                    slot: 1,
+                    buffer: &output,
+                    range: BufferRange::new(0, output_len as u64).unwrap(),
+                    access: AccessMode::Write,
+                },
+            ],
+            Timeout::Infinite,
+        )
+        .expect("submit INT8 identity");
+    let state = poll_to_terminal(&backend, &event, Duration::from_secs(30))
+        .expect("INT8 identity did not complete");
+    assert!(matches!(state, EventState::Complete), "got {state:?}");
+    assert_eq!(backend.direct_binding_admissions() - direct_before, 2);
+    assert_eq!(backend.explicit_transfer_bytes() - transfer_before, 0);
+
+    let mut result = vec![0u8; output_len];
+    backend
+        .read_buffer(&output, 0, &mut SliceMut(&mut result))
+        .expect("read INT8 output");
+    assert!(IDENTITY_INT8.output_matches(0, &result));
+
+    backend.destroy_event(event).expect("destroy event");
+    backend.free_buffer(input).expect("free input");
+    backend.free_buffer(output).expect("free output");
+    backend.unload_program(program).expect("unload program");
+    backend.destroy_queue(queue).expect("destroy queue");
+    backend.destroy_context(context).expect("destroy context");
+}
+
+#[test]
+fn tosa_int8_matmul_matches_the_shared_exact_oracle_on_the_npu() {
+    let Some(backend) = backend() else { return };
+    if !toolchain_present() {
+        eprintln!("no XDNA toolchain configured; skipping TOSA execution test");
+        return;
+    }
+    let context = backend
+        .create_context(ContextDesc::default())
+        .expect("context");
+    let queue = backend
+        .create_queue(&context, QueueDesc::default())
+        .expect("queue");
+    let program = backend
+        .load_program(
+            &context,
+            ArtifactRef {
+                format: ARTIFACT_FORMAT,
+                target: XDNA_TOSA_INTEGER_TARGET.to_identity(),
+                payload: &Slice(MATMUL_INT8.artifact),
+                resident_bytes: u64::MAX,
+            },
+        )
+        .expect("load INT8 matmul");
+    let input_desc = |bytes: usize| {
+        BufferDesc::new(
+            bytes as u64,
+            4096,
+            MemoryDomain::Shared,
+            BufferUsage::TRANSFER_DESTINATION | BufferUsage::PROGRAM_INPUT,
+        )
+        .unwrap()
+    };
+    let lhs_len = (MATMUL_INT8.inputs[0].bytes.len() + 3) & !3;
+    let rhs_len = (MATMUL_INT8.inputs[1].bytes.len() + 3) & !3;
+    let (mut lhs, _) = backend
+        .allocate_buffer(&context, input_desc(lhs_len))
+        .expect("lhs buffer")
+        .into_parts();
+    let (mut rhs, _) = backend
+        .allocate_buffer(&context, input_desc(rhs_len))
+        .expect("rhs buffer")
+        .into_parts();
+    let output_len = MATMUL_INT8.outputs[0].values.len() * 4;
+    let (output, _) = backend
+        .allocate_buffer(
+            &context,
+            BufferDesc::new(
+                output_len as u64,
+                4096,
+                MemoryDomain::Shared,
+                BufferUsage::TRANSFER_SOURCE | BufferUsage::PROGRAM_OUTPUT,
+            )
+            .unwrap(),
+        )
+        .expect("output buffer")
+        .into_parts();
+    let mut lhs_bytes = vec![0u8; lhs_len];
+    lhs_bytes[..MATMUL_INT8.inputs[0].bytes.len()].copy_from_slice(MATMUL_INT8.inputs[0].bytes);
+    let mut rhs_bytes = vec![0u8; rhs_len];
+    rhs_bytes[..MATMUL_INT8.inputs[1].bytes.len()].copy_from_slice(MATMUL_INT8.inputs[1].bytes);
+    backend
+        .write_buffer(&mut lhs, 0, &Slice(&lhs_bytes))
+        .expect("write lhs");
+    backend
+        .write_buffer(&mut rhs, 0, &Slice(&rhs_bytes))
+        .expect("write rhs");
+
+    let direct_before = backend.direct_binding_admissions();
+    let transfer_before = backend.explicit_transfer_bytes();
+    let event = backend
+        .submit(
+            &queue,
+            &program,
+            &[
+                BindingRef {
+                    slot: 0,
+                    buffer: &lhs,
+                    range: BufferRange::new(0, lhs_len as u64).unwrap(),
+                    access: AccessMode::Read,
+                },
+                BindingRef {
+                    slot: 1,
+                    buffer: &rhs,
+                    range: BufferRange::new(0, rhs_len as u64).unwrap(),
+                    access: AccessMode::Read,
+                },
+                BindingRef {
+                    slot: 2,
+                    buffer: &output,
+                    range: BufferRange::new(0, output_len as u64).unwrap(),
+                    access: AccessMode::Write,
+                },
+            ],
+            Timeout::Infinite,
+        )
+        .expect("submit INT8 matmul");
+    let state = poll_to_terminal(&backend, &event, Duration::from_secs(30))
+        .expect("INT8 matmul did not complete");
+    assert!(matches!(state, EventState::Complete), "got {state:?}");
+    assert_eq!(backend.direct_binding_admissions() - direct_before, 3);
+    assert_eq!(backend.explicit_transfer_bytes() - transfer_before, 0);
+
+    let mut result = vec![0u8; output_len];
+    backend
+        .read_buffer(&output, 0, &mut SliceMut(&mut result))
+        .expect("read INT32 output");
+    let values: Vec<_> = result
+        .chunks_exact(4)
+        .map(|bytes| i32::from_le_bytes(bytes.try_into().expect("four-byte chunk")))
+        .collect();
+    assert!(MATMUL_INT8.output_matches(0, &values));
+
+    backend.destroy_event(event).expect("destroy event");
+    backend.free_buffer(lhs).expect("free lhs");
+    backend.free_buffer(rhs).expect("free rhs");
+    backend.free_buffer(output).expect("free output");
+    backend.unload_program(program).expect("unload program");
+    backend.destroy_queue(queue).expect("destroy queue");
+    backend.destroy_context(context).expect("destroy context");
+}
+
+#[test]
+#[ignore = "manual native performance evidence"]
+fn measures_exact_int8_matmul_latency() {
+    let Some(backend) = backend() else { return };
+    if !toolchain_present() {
+        eprintln!("no XDNA toolchain configured; skipping INT8 benchmark");
+        return;
+    }
+    const M: usize = 64;
+    const K: usize = 64;
+    const N: usize = 32;
+    const LEFT_ZERO_POINT: i8 = -2;
+    const RIGHT_ZERO_POINT: i8 = 3;
+    const WARMUPS: usize = 20;
+    const SAMPLES: usize = 200;
+
+    let artifact = int8_matmul_tosa(
+        M as i32,
+        K as i32,
+        N as i32,
+        LEFT_ZERO_POINT,
+        RIGHT_ZERO_POINT,
+    );
+    let context = backend
+        .create_context(ContextDesc::default())
+        .expect("context");
+    let queue = backend
+        .create_queue(&context, QueueDesc::default())
+        .expect("queue");
+    let program = backend
+        .load_program(
+            &context,
+            ArtifactRef {
+                format: ARTIFACT_FORMAT,
+                target: XDNA_TOSA_INTEGER_TARGET.to_identity(),
+                payload: &Slice(&artifact),
+                resident_bytes: u64::MAX,
+            },
+        )
+        .expect("load INT8 benchmark program");
+    let lhs_bytes: Vec<u8> = (0..M * K).map(|index| (index * 17 + 3) as u8).collect();
+    let rhs_bytes: Vec<u8> = (0..K * N).map(|index| (index * 29 + 11) as u8).collect();
+    let output_len = M * N * 4;
+    let input_desc = |bytes: usize| {
+        BufferDesc::new(
+            bytes as u64,
+            4096,
+            MemoryDomain::Shared,
+            BufferUsage::TRANSFER_DESTINATION | BufferUsage::PROGRAM_INPUT,
+        )
+        .expect("input descriptor")
+    };
+    let (mut lhs, _) = backend
+        .allocate_buffer(&context, input_desc(lhs_bytes.len()))
+        .expect("lhs buffer")
+        .into_parts();
+    let (mut rhs, _) = backend
+        .allocate_buffer(&context, input_desc(rhs_bytes.len()))
+        .expect("rhs buffer")
+        .into_parts();
+    let (output, _) = backend
+        .allocate_buffer(
+            &context,
+            BufferDesc::new(
+                output_len as u64,
+                4096,
+                MemoryDomain::Shared,
+                BufferUsage::TRANSFER_SOURCE | BufferUsage::PROGRAM_OUTPUT,
+            )
+            .expect("output descriptor"),
+        )
+        .expect("output buffer")
+        .into_parts();
+    backend
+        .write_buffer(&mut lhs, 0, &Slice(&lhs_bytes))
+        .expect("initialize lhs");
+    backend
+        .write_buffer(&mut rhs, 0, &Slice(&rhs_bytes))
+        .expect("initialize rhs");
+
+    let direct_before = backend.direct_binding_admissions();
+    let transfer_before = backend.explicit_transfer_bytes();
+    let submit_once = || {
+        let bindings = [
+            BindingRef {
+                slot: 0,
+                buffer: &lhs,
+                range: BufferRange::new(0, lhs_bytes.len() as u64).expect("lhs range"),
+                access: AccessMode::Read,
+            },
+            BindingRef {
+                slot: 1,
+                buffer: &rhs,
+                range: BufferRange::new(0, rhs_bytes.len() as u64).expect("rhs range"),
+                access: AccessMode::Read,
+            },
+            BindingRef {
+                slot: 2,
+                buffer: &output,
+                range: BufferRange::new(0, output_len as u64).expect("output range"),
+                access: AccessMode::Write,
+            },
+        ];
+        let started = Instant::now();
+        let event = backend
+            .submit(&queue, &program, &bindings, Timeout::Infinite)
+            .expect("warm INT8 submission");
+        let admission = started.elapsed();
+        let state = poll_to_terminal(&backend, &event, Duration::from_secs(30))
+            .expect("INT8 benchmark completion");
+        assert!(matches!(state, EventState::Complete), "got {state:?}");
+        let completion = started.elapsed();
+        backend.destroy_event(event).expect("destroy event");
+        (admission, completion)
+    };
+    for _ in 0..WARMUPS {
+        submit_once();
+    }
+    let (mut admission, mut completion): (Vec<_>, Vec<_>) =
+        (0..SAMPLES).map(|_| submit_once()).unzip();
+    admission.sort_unstable();
+    completion.sort_unstable();
+
+    let submissions = (WARMUPS + SAMPLES) as u64;
+    let direct_bindings = backend.direct_binding_admissions() - direct_before;
+    let explicit_transfer_bytes = backend.explicit_transfer_bytes() - transfer_before;
+    assert_eq!(direct_bindings, submissions * 3);
+    assert_eq!(explicit_transfer_bytes, 0);
+
+    let mut result = vec![0u8; output_len];
+    backend
+        .read_buffer(&output, 0, &mut SliceMut(&mut result))
+        .expect("read benchmark output");
+    for row in 0..M {
+        for column in 0..N {
+            let right: Vec<_> = (0..K).map(|inner| rhs_bytes[inner * N + column]).collect();
+            let expected = dot_i8_i32(
+                &lhs_bytes[row * K..(row + 1) * K],
+                &right,
+                LEFT_ZERO_POINT,
+                RIGHT_ZERO_POINT,
+                0,
+            )
+            .expect("exact oracle");
+            let offset = (row * N + column) * 4;
+            let actual = i32::from_le_bytes(
+                result[offset..offset + 4]
+                    .try_into()
+                    .expect("four-byte output"),
+            );
+            assert_eq!(actual, expected, "C[{row},{column}] oracle mismatch");
+        }
+    }
+
+    let p50 = completion[SAMPLES / 2];
+    let operations = (2 * M * K * N) as f64;
+    let gigaops = operations / p50.as_secs_f64() / 1_000_000_000.0;
+    eprintln!(
+        "XDNA exact INT8 MATMUL: shape=1x{M}x{K} · 1x{K}x{N}; worker=1; zero_points=[{LEFT_ZERO_POINT},{RIGHT_ZERO_POINT}]; warmups={WARMUPS}; samples={SAMPLES}; admission p50={:?} p95={:?}; submit-to-complete p50={:?} p95={:?}; effective={gigaops:.3} GOPS; direct_bindings={direct_bindings}; explicit_transfer_bytes={explicit_transfer_bytes}",
+        admission[SAMPLES / 2],
+        admission[SAMPLES * 95 / 100],
+        p50,
+        completion[SAMPLES * 95 / 100],
+    );
+
+    backend.free_buffer(lhs).expect("free lhs");
+    backend.free_buffer(rhs).expect("free rhs");
+    backend.free_buffer(output).expect("free output");
+    backend.unload_program(program).expect("unload program");
     backend.destroy_queue(queue).expect("destroy queue");
     backend.destroy_context(context).expect("destroy context");
 }

--- a/crates/virtio-accel-xdna/tests/xdna.rs
+++ b/crates/virtio-accel-xdna/tests/xdna.rs
@@ -9,7 +9,7 @@ use virtio_accel_tosa::{ExtensionSet, Op, OperatorConstraints, ProfileSet, Targe
 use virtio_accel_xdna::XdnaAccelerator;
 use virtio_accel_xdna::{
     REQUIRED_RESIDENT_BYTES, XDNA_TOSA_CAPABILITY, XDNA_TOSA_FP8_CAPABILITY, XDNA_TOSA_FP8_TARGET,
-    XDNA_TOSA_INTEGER_TARGET, XDNA_TOSA_TARGET,
+    XDNA_TOSA_INTEGER_CAPABILITY, XDNA_TOSA_INTEGER_TARGET, XDNA_TOSA_TARGET,
 };
 
 #[test]
@@ -101,6 +101,22 @@ fn bf16_capability_matches_the_implemented_surface() {
             .contains(OperatorConstraints::PROPAGATING_NAN)
     );
     assert!(pool.constraints.contains(OperatorConstraints::ZERO_PADDING));
+}
+
+#[test]
+fn integer_capability_matches_the_openvino_semantic_surface() {
+    use virtio_accel_tosa::DType;
+
+    assert_eq!(
+        XDNA_TOSA_INTEGER_CAPABILITY.target,
+        XDNA_TOSA_INTEGER_TARGET
+    );
+    for op in [Op::CONST, Op::IDENTITY, Op::MATMUL] {
+        assert!(XDNA_TOSA_INTEGER_CAPABILITY.supports_operator(op));
+    }
+    assert!(XDNA_TOSA_INTEGER_CAPABILITY.supports_dtype(DType::INT8, ValueRoles::ALL));
+    assert!(XDNA_TOSA_INTEGER_CAPABILITY.supports_dtype(DType::INT32, ValueRoles::OUTPUT));
+    assert!(!XDNA_TOSA_INTEGER_CAPABILITY.supports_dtype(DType::INT32, ValueRoles::INPUT));
 }
 
 #[cfg(not(va_xdna))]

--- a/docs/portability.md
+++ b/docs/portability.md
@@ -71,7 +71,7 @@ by the reusable semantic suite. A public hardware CI lane remains unavailable, s
 publishes the exact manual replacement commands.
 
 The AMD XDNA crate compiles its portable admission surface (`lower`, including the TOSA IDENTITY,
-MATMUL, MAX_POOL2D, and explicit FP8-to-BF16 CAST admissions and its advertised `Target`
+MATMUL, MAX_POOL2D, explicit FP8-to-BF16 CAST, and exact INT8 admissions and its advertised `Target`
 constants), the portable
 precompiled-artifact codec, and a placeholder on every host; portable CI unit-tests admission. HRX
 exposes a plain C ABI, so its
@@ -88,7 +88,8 @@ the separately pinned `VIRTIO_ACCEL_AMDXDNA_TOOLCHAIN`. On the reference machine
 toolchain and an NPU, backend-local tests run a DMA passthrough, a
 compiled TOSA BF16 IDENTITY, a bit-exact BF16 → FP32 MATMUL, BF16 NHWC MAX_POOL2D against the
 shared bit-exact oracle, both FP8E4M3/E5M2 → BF16 CASTs against shared bit-exact oracles, and the
-shared semantic conformance suite end to end; compilation invokes
+shared exact INT8 identity and nonzero-zero-point MATMUL oracles, plus the shared semantic
+conformance suite end to end; compilation invokes
 the aiecc helper as a bounded subprocess (never a Cargo dependency). The conformance run includes
 provider-resource accounting and direct-binding diagnostics; a feature-gated on-metal fault suite
 proves definite device loss, the 120-second tier-2 watchdog state machine with a shortened test
@@ -97,6 +98,11 @@ discard. MAX_POOL2D mirrors OpenVINO's
 propagating-NaN and zero-padding semantics, but XDNA admission is deliberately narrower: batch 1,
 kernel and stride dimensions at most 8, and at most 8,192 input-plus-output elements so the full
 tensors fit in the AIE2P worker's local memory. A public hardware CI lane remains unavailable.
+The INT8 capability mirrors OpenVINO's exact `CONST`/`IDENTITY`/`MATMUL` semantic surface but adds
+an XDNA-specific one-core memory envelope. AIE DMA's four-byte transfer granularity is represented
+as explicit per-slot padding in the compiled artifact, never as hidden submission-time staging.
+Tile-compatible MATMUL shapes widen/subtract zero points on the NPU and use the native 4x4x8 INT16
+matrix unit; smaller shapes use an exact scalar on-NPU kernel.
 
 Concrete VMM, kernel, OS, and vendor adapters are outside the portable-v1 milestone and must not
 become default dependencies of a portable crate.

--- a/docs/research/tosa-int8-block-fp-status.md
+++ b/docs/research/tosa-int8-block-fp-status.md
@@ -2,6 +2,15 @@
 
 Status checked: **2026-08-25**
 
+Implementation update (2026-08-26): issue #144 implements the first exact XDNA integer tier:
+INT8 IDENTITY and batch-1, zero-point-aware INT8 × INT8 → INT32 MATMUL. It uses the shared
+`IDENTITY_INT8` and `MATMUL_INT8` corpus oracles on the physical NPU and does not claim complete
+`PRO-INT` support. The semantic surface mirrors OpenVINO. XDNA's documented hardware divergences
+are a bounded one-core memory envelope and explicit four-byte input-slot padding required by AIE
+DMA; neither path introduces host arithmetic or hidden staging. Tile-compatible MATMUL widens the
+zero-point-adjusted values exactly to INT16 before using AIE2P's native 4x4x8 matrix unit, while
+small incomplete tiles use an exact scalar device kernel.
+
 ## Executive conclusion
 
 INT8 inference and INT8 `MATMUL` are stable TOSA work. The latest official release is TOSA
@@ -112,11 +121,11 @@ target but publishes a separate conservative capability descriptor limited to `C
 the numerical rules under which admitted graphs are analyzed.
 [OpenVINO integer target and conservative capability](../../crates/virtio-accel-openvino/src/lower.rs)
 
-The XDNA crate already defines an unadvertised
-[`XDNA_TOSA_INTEGER_TARGET`](../../crates/virtio-accel-xdna/src/lower.rs). The implementation
-ticket should add a similarly narrow `XDNA_TOSA_INTEGER_CAPABILITY` only when its exact corpus and
-on-metal lifecycle pass. It should not add the whole Integer profile's operators merely because
-the shared TOSA validator recognizes them.
+The XDNA crate defines
+[`XDNA_TOSA_INTEGER_TARGET`](../../crates/virtio-accel-xdna/src/lower.rs) and now advertises a
+similarly narrow `XDNA_TOSA_INTEGER_CAPABILITY` because its exact corpus and on-metal lifecycle
+pass. It does not add the whole Integer profile's operators merely because the shared TOSA
+validator recognizes them.
 
 ## 2. Block floating-point and block-scaled status
 


### PR DESCRIPTION
## Summary

- add strict portable TOSA INT8 IDENTITY and INT8 to INT32 MATMUL admission
- compile exact zero-point-aware kernels for XDNA2 and advertise the integer capability
- validate the shared INT8 corpus on physical NPU hardware with direct-binding diagnostics
- add a release benchmark and document the measured latency and hardware-specific limits

## Stack

This PR is stacked on #143. Its base is codex/xdna-fp8-storage-tier.

## OpenVINO precedent

The public capability matches OpenVINO: INT8 values may be inputs, outputs, constants, or intermediates; INT32 is the MATMUL accumulator/output; and CONST, IDENTITY, and MATMUL are advertised. Zero points are subtracted before accumulation and results are exact INT32 values.

XDNA-specific divergences are documented:
- AIE DMA lengths must be four-byte granular. Six-byte corpus tensors therefore use declared eight-byte direct-binding slots with caller-visible padding. The kernel ignores the padding; there is no hidden staging.
- The first implementation uses one AIE core and admits only tensor sets fitting a 16 KiB local-memory envelope.
- Complete 4x4x8 shapes use the native AIE2P MMUL path after exact INT8 to INT16 widening. Incomplete small shapes use an exact scalar NPU kernel.
 
## Verification

- portable and native XDNA clippy with warnings denied
- workspace tests on Rust 1.85
- rustdoc with warnings denied
- release-policy check
- ordered publication dry-run for all 17 crates
- full hardware and fault suite: 25 passed, 2 manual benchmarks ignored
- shared semantic conformance suite: passed
- physical NPU exact INT8 IDENTITY and nonzero-zero-point MATMUL corpus cases: passed
- no hidden submission copies: direct bindings increased as expected; explicit transfer bytes remained zero
 
Measured on the physical XDNA2 NPU for 64x64 by 64x32 INT8 MATMUL, 20 warmups and 200 samples:
- admission p50 661 ns, p95 1.302 us
- submit-to-complete p50 334.065 us, p95 343.723 us
- effective throughput 0.785 GOPS
- 660 direct bindings, zero explicit submission-transfer bytes
 
Closes #144 .