### PR TITLE
Close out the AMD XDNA backend map

### DIFF
--- a/crates/virtio-accel-xdna/README.md
+++ b/crates/virtio-accel-xdna/README.md
@@ -1,14 +1,14 @@
 # virtio-accel-xdna
 
 An AMD XDNA (Ryzen AI NPU) host backend for `virtio-accel`, targeting XDNA2/Strix-class parts
-through the HRX runtime (`libhrx`) with no XRT userspace dependency. It will execute device-neutral
+through the HRX runtime (`libhrx`) with no XRT userspace dependency. It executes device-neutral
 TOSA 1.0 programs on the NPU, compiling admitted graphs with the pinned aiecc toolchain as a
 bounded subprocess (never a Cargo dependency, never in-process Python).
 
 **Portability tier:** `host-native` — the amdxdna-native HRX runtime (`libhrx`) when detected at
 build time; a compile-only unsupported-runtime placeholder elsewhere.
 
-**This crate is under construction.** In a `va_xdna` build it runs the full `Accelerator`
+In a `va_xdna` build it runs the full `Accelerator`
 lifecycle — device/stream owner, `hrx_buffer` primitives (persistent mapping, range
 flush/invalidate, release), and a serialized dispatch worker bridging
 `hrx_stream_dispatch`/`synchronize` to a latched nonblocking `poll_event`. `load_program` accepts
@@ -31,10 +31,11 @@ MATMUL, and INT32 → INT8 RESCALE oracles) and by
 `tests/conformance.rs` (the shared semantic suite, including the direct-binding copy-path
 diagnostics, on the device). Hosts without HRX build the portable admission surface plus a
 placeholder, compile no `unsafe`, and still unit-test admission and the artifact codec. The
-remaining executing numerical tiers land in subsequent tickets of the
-[AMD XDNA wayfinder map](https://github.com/MicroPerceptron/virtio-accel/issues/78); the design
-decisions live on their ticket branches: crate layout (#83), FFI/buffers (#87), execution model
-(#85), compiler helper (#84), and the advertised numerical tier (#82).
+[AMD XDNA wayfinder map](https://github.com/MicroPerceptron/virtio-accel/issues/78) records the
+implementation lineage; its design decisions cover crate layout (#83), FFI/buffers (#87),
+execution model (#85), compiler helper (#84), and the advertised numerical tier (#82). Optional
+throughput, parallelism, broader integer, and experimental block-scaled work remains in separately
+scoped follow-up issues and does not expand this support claim.
 
 The compiler is never a Cargo dependency and never runs in-process. `compile_artifact` exposes the
 admit-then-compile path without a device (the offline / catalog-population use), so a build host can
@@ -106,6 +107,28 @@ produces no `SubmitFailure::Indeterminate` or `ReleaseFailure::Indeterminate` pa
 states remain reserved for a future runtime operation whose ownership outcome is genuinely
 unknown.
 
+## Validated baseline
+
+The hardware claim is pinned to the configuration proven on August 26, 2026:
+
+- Fedora 44 with Linux `7.1.8-200.fc44.x86_64` and the in-tree `amdxdna` driver;
+- PCI `1022:17f0` revision `0x20` (Strix/Krackan/Strix Halo XDNA2), exposed as
+  `/dev/accel/accel0`;
+- firmware `1.1.2.64` from `amdnpu/17f0_20/npu.sbin`;
+- toolchain prefix `amdxdna-hrx-v2026.08`: Python 3.12.14, `amd-npu-compiler` commit
+  `c9554426`, `mlir_aie==1.4.1`, Peano/`llvm-aie==21.0.0.2026080301+c9c5ecb7`, and
+  `hrx-xclbinutil` commit `3940dd23`;
+- HRX tag `flm-hrx-amdxdna-v2026.07.30`, source commit `eb0b39f4`, C ABI/library version
+  `0.1.0`, release SHA-256 `661ed94051cc6ad04f53739b2df7a791aecb658bc435bd5a6ff3c46716696345`;
+  and
+- unfolded DDR addressing (`NPU_RUNTIME=hrx`, `fold_ddr_addr_offset=false`).
+
+This is an evidence boundary, not a claim that every XDNA generation or runtime revision works.
+The compiler/Python toolchain runs only while populating the content-addressed artifact catalog or
+on a load path configured to compile; a serving host loading precompiled XDNP artifacts does not
+need Python or the compiler. The currently validated native runtime still uses the Linux `amdxdna`
+driver; a future kore-native runtime adapter is outside this support claim.
+
 ## Running
 
 ```sh
@@ -121,12 +144,19 @@ The exact manual replacement for the unavailable public hardware CI lane is:
 
 ```sh
 source ~/toolchains/amdxdna-hrx-v2026.08/env.sh
+export VIRTIO_ACCEL_XDNA=1
+export VIRTIO_ACCEL_XDNA_REQUIRE_HARDWARE=1
+export VIRTIO_ACCEL_AMDXDNA_TOOLCHAIN=~/toolchains/amdxdna-hrx-v2026.08
 cargo test -p virtio-accel-xdna --test conformance -- --test-threads=1
 cargo test -p virtio-accel-xdna --features test-control --test hardware -- --test-threads=1
 ```
 
 `test-control` only adds the hidden one-shot tier-1/tier-2 constructors used by the hardware test;
 ordinary `XdnaAccelerator::new` retains production behavior even in an all-features build.
+`VIRTIO_ACCEL_XDNA=1` makes an incomplete HRX install fail at build time, while the test-only
+`VIRTIO_ACCEL_XDNA_REQUIRE_HARDWARE=1` turns an inaccessible NPU into a test failure instead of the
+ordinary developer-machine skip. Together they prevent the manual hardware lane from passing
+without exercising the native backend.
 
 ## Performance evidence
 

--- a/crates/virtio-accel-xdna/tests/conformance.rs
+++ b/crates/virtio-accel-xdna/tests/conformance.rs
@@ -18,24 +18,39 @@ use virtio_accel_conformance::{
 };
 use virtio_accel_core::{AccessMode, BackendError, EventState, MemoryDomain};
 use virtio_accel_tosa::ARTIFACT_FORMAT;
-use virtio_accel_xdna::{
-    InitError, REQUIRED_RESIDENT_BYTES, XDNA_TOSA_TARGET, XdnaAccelerator, XdnaEvent,
-};
+use virtio_accel_xdna::{REQUIRED_RESIDENT_BYTES, XDNA_TOSA_TARGET, XdnaAccelerator, XdnaEvent};
 
 const BUFFER_ALIGNMENT: u64 = 4096;
 /// One IDENTITY DMA line (the smallest admitted count).
 const ELEMENTS: usize = 1024;
+const REQUIRE_HARDWARE_ENV: &str = "VIRTIO_ACCEL_XDNA_REQUIRE_HARDWARE";
+
+fn hardware_required() -> bool {
+    match std::env::var(REQUIRE_HARDWARE_ENV) {
+        Ok(value) if value == "1" => true,
+        Ok(value) if value == "0" => false,
+        Ok(value) => panic!("{REQUIRE_HARDWARE_ENV} must be \"0\" or \"1\", not {value:?}"),
+        Err(std::env::VarError::NotPresent) => false,
+        Err(error) => panic!("invalid {REQUIRE_HARDWARE_ENV}: {error}"),
+    }
+}
 
 fn toolchain_present() -> bool {
     std::env::var_os("VIRTIO_ACCEL_AMDXDNA_TOOLCHAIN").is_some()
 }
 
-/// Whether an NPU is accessible (a fresh backend constructs), so the suite can be skipped honestly.
-fn device_present() -> bool {
+/// Whether the complete native runtime is usable, so an ordinary portable run can skip honestly.
+fn runtime_present() -> bool {
     match XdnaAccelerator::new() {
         Ok(_) => true,
-        Err(InitError::DeviceUnavailable) => false,
-        Err(error) => panic!("unexpected initialization failure: {error}"),
+        Err(error) => {
+            assert!(
+                !hardware_required(),
+                "{REQUIRE_HARDWARE_ENV}=1 but the XDNA runtime is unusable: {error}"
+            );
+            eprintln!("XDNA runtime unavailable ({error}); skipping conformance suite");
+            false
+        }
     }
 }
 
@@ -113,11 +128,14 @@ fn conformance_target() -> TargetDescription {
 
 #[test]
 fn xdna_backend_passes_the_standard_semantic_suite() {
-    if !device_present() {
-        eprintln!("no XDNA NPU device accessible; skipping conformance suite");
+    if !runtime_present() {
         return;
     }
     if !toolchain_present() {
+        assert!(
+            !hardware_required(),
+            "{REQUIRE_HARDWARE_ENV}=1 but VIRTIO_ACCEL_AMDXDNA_TOOLCHAIN is not configured"
+        );
         eprintln!("no XDNA toolchain configured; skipping conformance suite");
         return;
     }

--- a/crates/virtio-accel-xdna/tests/hardware.rs
+++ b/crates/virtio-accel-xdna/tests/hardware.rs
@@ -27,12 +27,25 @@ use virtio_accel_tosa::{
 };
 use virtio_accel_tosa_build::{OperatorKind, OwnedGraph, OwnedOperator, OwnedTensor};
 use virtio_accel_xdna::{
-    InitError, XDNA_PRECOMPILED_FORMAT, XDNA_TOSA_FP8_TARGET, XDNA_TOSA_INTEGER_TARGET,
-    XDNA_TOSA_TARGET, XdnaAccelerator, XdnaBuffer, XdnaContext, XdnaProgram, XdnaQueue,
-    XdnaResourceCounts, compile_artifact,
+    XDNA_PRECOMPILED_FORMAT, XDNA_TOSA_FP8_TARGET, XDNA_TOSA_INTEGER_TARGET, XDNA_TOSA_TARGET,
+    XdnaAccelerator, XdnaBuffer, XdnaContext, XdnaProgram, XdnaQueue, XdnaResourceCounts,
+    compile_artifact,
 };
 #[cfg(feature = "test-control")]
 use virtio_accel_xdna::{XdnaTestConfig, XdnaTestFault};
+
+const REQUIRE_HARDWARE_ENV: &str = "VIRTIO_ACCEL_XDNA_REQUIRE_HARDWARE";
+
+/// Whether this run is the documented manual hardware gate, where skipping would be a false pass.
+fn hardware_required() -> bool {
+    match std::env::var(REQUIRE_HARDWARE_ENV) {
+        Ok(value) if value == "1" => true,
+        Ok(value) if value == "0" => false,
+        Ok(value) => panic!("{REQUIRE_HARDWARE_ENV} must be \"0\" or \"1\", not {value:?}"),
+        Err(std::env::VarError::NotPresent) => false,
+        Err(error) => panic!("invalid {REQUIRE_HARDWARE_ENV}: {error}"),
+    }
+}
 
 /// Whether the pinned compiler toolchain is configured (the compiler tests need it, not a device).
 fn toolchain_present() -> bool {
@@ -158,15 +171,18 @@ impl PassthroughResources {
     }
 }
 
-/// Construct a backend, or skip the test when no NPU is accessible on this host.
+/// Construct a backend, or skip when the complete native runtime is unavailable on this host.
 fn backend() -> Option<XdnaAccelerator> {
     match XdnaAccelerator::new() {
         Ok(backend) => Some(backend),
-        Err(InitError::DeviceUnavailable) => {
-            eprintln!("no XDNA NPU device accessible; skipping hardware test");
+        Err(error) => {
+            assert!(
+                !hardware_required(),
+                "{REQUIRE_HARDWARE_ENV}=1 but the XDNA runtime is unusable: {error}"
+            );
+            eprintln!("XDNA runtime unavailable ({error}); skipping hardware test");
             None
         }
-        Err(error) => panic!("unexpected initialization failure: {error}"),
     }
 }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -316,16 +316,19 @@ trait obligations and separates semantic evidence from the quantitative allocati
 in [performance.md](performance.md).
 
 Its `numerics` module complements lifecycle conformance with checked-in TOSA graphs and shared
-FP32, FP16, FP8E4M3, FP8E5M2, INT8, and packed INT4 oracles. Identity edge values, non-square
-batched matrix multiplication, and NHWC max pooling are the first shared cases. A backend runs every
-case it advertises and rejects unsupported profiles, extensions, and dtypes at program admission;
-provider-specific graphs cannot stand in for the shared bytes.
+FP32, FP16, BF16, FP8E4M3, FP8E5M2, INT8, INT32-accumulator, and packed INT4 oracles. Identity edge
+values, non-square batched matrix multiplication, NHWC max pooling, explicit FP8-to-BF16 CAST, and
+signed INT32-to-INT8 RESCALE are shared cases. A backend runs every case it advertises and rejects
+unsupported profiles, extensions, and dtypes at program admission; provider-specific graphs cannot
+stand in for the shared bytes.
 
 The exact integer oracle is implemented in portable Rust from the TOSA scaling and accumulation
-rules. The first production integer tier uses direct INT8 boundaries for identity and widens INT8
-MATMUL operands to INT32 before explicit zero-point subtraction and INT32 accumulation. Core ML
-encodes this as an ML Program on macOS 26+; OpenVINO encodes the same semantics as IR Convert,
-Subtract, and MatMul nodes. Neither path converts through floating point.
+rules. The first production integer tiers use direct INT8 boundaries for identity and widen INT8
+MATMUL operands to INT32 before explicit zero-point subtraction and INT32 accumulation. XDNA also
+implements the released per-tensor scale32/single-round RESCALE back to signed INT8. Core ML
+encodes MATMUL as an ML Program on macOS 26+; OpenVINO encodes the same MATMUL semantics as IR
+Convert, Subtract, and MatMul nodes; XDNA specializes the exact expressions into AIE kernels.
+None of these paths converts through floating point.
 
 ## Production lowering boundaries
 
@@ -357,6 +360,25 @@ validation runs the backend conformance suite and the shared numerical TOSA corp
 enumerated device and reports the direct-binding and explicit-transfer counters through the
 conformance diagnostics hook. This keeps the Core ML and Intel paths on one bounded TOSA contract
 without requiring either provider to adopt the other's native graph representation.
+
+The AMD XDNA provider follows that OpenVINO boundary with one ecosystem-forced compiler
+divergence. Safe Rust verifies and analyzes one static TOSA graph, matches only the advertised BF16,
+explicit FP8-to-BF16 storage-conversion, or exact integer templates, and invokes the pinned
+MLIR-AIE/IRON compiler as a bounded subprocess during program load or offline catalog population.
+Guest TOSA bytes never enter Python: the subprocess receives a small validated specialization, and
+its measured toolchain identity participates in the content-addressed cache key. A serving host may
+load the resulting crate-local XDNP artifact without Python or a compiler. Each artifact carries an
+exact per-slot byte/access plan so fixed DMA extents are checked again at submission.
+
+Native execution uses the amdxdna HRX C ABI rather than XRT. One process-wide device owner creates
+per-backend streams; each backend serializes accepted work through a bounded ring and worker that
+bridges blocking HRX synchronization to latched, nonblocking event polling. Persistent HRX mappings
+are the exact allocations bound to dispatch, and diagnostics prove that submission introduces no
+bounce allocation or transfer. HRX exposes no bounded cancellation, so finite deadlines are
+rejected before acceptance and a two-tier poison/watchdog model handles device loss. These choices
+preserve OpenVINO's static admission, direct-binding, capability, and conformance seams; the helper
+process, serialized stream, and XDNA-specific local-memory envelopes are documented hardware/runtime
+constraints rather than portable API changes or silent fallback paths.
 
 The Qualcomm adapter uses the same seam. Its safe planner admits 41 of the 42 floating-point
 operators shared by Core ML and OpenVINO, including owned constants/data movement, FP16 unary and

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -187,6 +187,24 @@ throughput configuration. Multi-worker striping is an optional optimization; det
 continues to gate exact numerics, direct binding, and zero submission-time transfer bytes instead
 of wall-clock latency.
 
+The exact INT8 MATMUL benchmark uses the same 20 warmups and 200 measured submissions. Shapes that
+fill the AIE2P 4x4x8 tile subtract both zero points exactly, widen to INT16, and use the native
+matrix unit; incomplete shapes retain a scalar exact kernel. Run it with:
+
+```sh
+source ~/toolchains/amdxdna-hrx-v2026.08/env.sh
+export VIRTIO_ACCEL_AMDXDNA_TOOLCHAIN=~/toolchains/amdxdna-hrx-v2026.08
+cargo test --release -p virtio-accel-xdna --test hardware \
+  measures_exact_int8_matmul_latency -- --ignored --nocapture --test-threads=1
+```
+
+On August 26, 2026, the same `1022:17f0` XDNA2 NPU and v2026.08 toolchain measured the 64x64x32
+specialization at 0.661 microseconds admission median, 0.334065 milliseconds submit-to-complete
+median, and 0.343723 milliseconds p95, or 0.785 effective GOPS. All 660 bindings across 220
+submissions were direct and submission reported zero explicit-transfer bytes. This is a first-tier
+dispatch-sized baseline, not peak NPU throughput; issue #151 tracks matrix-unit/dataflow
+optimization without weakening exactness or direct binding.
+
 ## Qualcomm Hexagon evidence status
 
 `virtio-accel-hexagon` includes an ignored release-mode measurement for fixed submission overhead:

--- a/docs/release-policy.md
+++ b/docs/release-policy.md
@@ -140,7 +140,7 @@ declares its own `description` and `readme`, and carries its own byte-identical 
 root license files do not reach the sub-crate tarballs; the copies exist for that reason and are
 copies rather than symlinks because CI runs `windows-latest`.
 
-`ci/check-release-policy.py` enforces all of this against an explicit sixteen-crate allowlist. A new
+`ci/check-release-policy.py` enforces all of this against an explicit seventeen-crate allowlist. A new
 package fails that check until it is added to the allowlist, which forces a decision about whether
 it is public rather than letting it default either way. The check also validates the crates.io
 keyword and category limits, which neither `cargo package` nor `cargo publish --dry-run` catches
@@ -150,7 +150,7 @@ The `fuzz/` harness is a separate workspace at version `0.0.0` and stays `publis
 
 ## Publication, yank, and rollback
 
-Sixteen packages are published to crates.io. Publication is ordered: a crate cannot be published before
+Seventeen packages are published to crates.io. Publication is ordered: a crate cannot be published before
 every crate it depends on, and that includes development dependencies, because a published crate's
 versioned dev-dependencies must resolve from the registry for `cargo test` to run on the packaged
 source.
@@ -180,7 +180,7 @@ local registry, adding each crate only after it has been built, tested, and docu
 extracted tarball. A crate can therefore only ever resolve its predecessors, so a wrong order fails
 with an unresolvable dependency instead of passing quietly. The same script is a required CI job.
 
-All sixteen packages share the workspace version and are published together. A GitHub release tag
+All seventeen packages share the workspace version and are published together. A GitHub release tag
 must be exactly `v<workspace-version>` and must point at the commit being released. Publishing a
 GitHub release triggers `.github/workflows/publish.yml`, which checks out that tag, runs the release
 policy checks and publication-driver tests, repeats the full ordered local-registry dry run on the


### PR DESCRIPTION
# Why

This is the final implementation ticket in the AMD XDNA wayfinder map. The backend already executes the advertised BF16, explicit FP8-storage conversion, and exact integer tiers on the NPU; this change turns that evidence into an honest support boundary and a reproducible, fail-loud hardware release gate.

The manual commands previously allowed a false green result when HRX or the NPU was unavailable because hardware tests deliberately skip on ordinary developer machines. The new test-only `VIRTIO_ACCEL_XDNA_REQUIRE_HARDWARE=1` switch makes every native-runtime initialization failure and missing compiler toolchain fatal in the documented hardware lane. Ordinary portable builds and crates.io package verification retain their clean skip behavior.

The documentation now records the exact validated driver, firmware, HRX, compiler, addressing, numerical, direct-binding, fault, and performance baseline. It also records the one ecosystem-forced departure from the OpenVINO shape: XDNA compilation is a bounded out-of-process MLIR-AIE/IRON helper, while safe Rust still owns TOSA verification, strict admission, slot planning, capability reporting, direct-binding diagnostics, and lifecycle semantics. Precompiled XDNP serving requires neither Python nor the compiler.

This PR is stacked on #152 (`codex/xdna-int8-rescale`). It completes the acceptance work for #75 and the implementation sequence in #78; those parent issues should be closed only after the complete stack reaches `main`.

Closes #93.

## Compatibility

- [x] **No wire effect.** This changes no accepted or emitted protocol bytes.

## Checklist

- [x] Does not alter payload lengths, ownership, reset, error, timeout, or feature-negotiation behavior — or does, and says so above.
- [x] `layout.json`, `vectors.json`, `scenarios.json`, `requirements.json`, and performance budgets are still authoritative inputs, not regenerated by accident.
- [x] Public Rust API changes affecting backend, guest, device, or transport authors are called out. There are none.
- [x] No dependency, Cargo feature, or target moves platform behavior into a portable crate.
- [x] No unaudited `unsafe` code was added; any confined exception has a local safety argument, tests, and release-policy entry.
- [x] Deferred optional features remain unadvertised and documented as out of scope.

## Hardware evidence

Validated on August 26, 2026 on PCI `1022:17f0` revision `0x20`, firmware `1.1.2.64`, Linux `7.1.8-200.fc44.x86_64`, the v2026.08 pinned toolchain, and HRX `flm-hrx-amdxdna-v2026.07.30`:

- shared conformance suite: 1 passed, 0 skipped;
- native hardware suite: 26 passed, 2 intentionally ignored manual benchmarks, 0 failed;
- BF16 IDENTITY, BF16 MATMUL, BF16 MAX_POOL2D, both explicit FP8-to-BF16 CAST encodings, INT8 IDENTITY, exact zero-point-aware INT8 MATMUL, and exact INT32-to-INT8 RESCALE passed their bit-exact oracles;
- lifecycle, direct-binding diagnostics, context isolation, tier-1 device loss, and tier-2 watchdog paths passed;
- 64x64x32 INT8 MATMUL measured 0.334065 ms median and 0.343723 ms p95 over 200 measured submissions, with 660 direct bindings and zero submission transfer bytes.

## Verification

```sh
cargo fmt --all -- --check
git diff --check
python3 ci/check-release-policy.py
cargo clippy -p virtio-accel-xdna --all-targets --all-features --no-deps -- -D warnings
cargo test --workspace --all-targets --all-features
RUSTDOCFLAGS=-D warnings cargo doc --workspace --all-features --no-deps
cargo run --example backend_conformance
cargo run --example reference_execution
cargo run -p virtio-accel-coreml --example tosa_coreml
cargo run -p virtio-accel-openvino --example tosa_openvino
cargo run -p virtio-accel-hexagon --example tosa_hexagon
cargo run -p virtio-accel-hexagon --example mock_classifier
python3 ci/check-performance-budgets.py --check
python3 ci/publish-dry-run.py
```

The two documented fail-loud hardware commands also passed with `VIRTIO_ACCEL_XDNA=1` and `VIRTIO_ACCEL_XDNA_REQUIRE_HARDWARE=1`.
