### PR TITLE
Fix the XDNA review findings: capability roles, DMA alignment, event reclaim

### DIFF
--- a/crates/virtio-accel-xdna/README.md
+++ b/crates/virtio-accel-xdna/README.md
@@ -85,7 +85,10 @@ each admitted one-core program's padded tensor footprint is at most 16 KiB so de
 one AIE2P core.
 Non-word-sized INT8 inputs are rounded up to a four-byte binding slot because AIE DMA descriptors
 cannot transfer a shorter granularity; that padding is explicit in the artifact's binding plan and
-ignored by the kernel, rather than copied into a hidden bounce buffer. RESCALE similarly rounds
+ignored by the kernel, rather than copied into a hidden bounce buffer.
+The same granularity bounds the other end of a binding: a submitted range must start on a four-byte
+boundary as well as cover its slot's exact length, and a mid-word offset is rejected as
+`Incompatible` before the device sees it. RESCALE similarly rounds
 the output slot to a DMA word and clears its at-most-three-byte tail on the NPU. Zero points remain
 compile-time values: MATMUL subtracts signed INT8 zero points before exact INT32 accumulation, and
 RESCALE applies its signed INT8 output zero point only after exact 64-bit multiply-and-round math.

--- a/crates/virtio-accel-xdna/SAFETY.md
+++ b/crates/virtio-accel-xdna/SAFETY.md
@@ -103,6 +103,12 @@ no trustworthy completion boundary. `poll_event` then reports `DeviceLost`; even
 retryably rejected as `Busy`; discarding the backend enters the quarantine described above.
 `EVENT_CANCELLATION` is not advertised.
 
+`XdnaEvent::drop` is the single reclaim path for a ring slot: `destroy_event` validates that the
+event is terminal and then drops it, so an event released either way returns its slot and its
+`resource_counts` charge exactly once. A `PENDING` slot is never reclaimed by `drop` — the dispatch
+worker still owns it and will latch it — which is what keeps a quarantined wedge's slot and charge
+outstanding rather than handing a live slot to the next submission.
+
 The per-instance resource tracker counts accepted contexts, native buffer allocations, loaded
 executables, queues, and events. Counters increment only after successful admission and decrement
 only at the matching successful release/native final `Drop`; rejected operations do not perturb

--- a/crates/virtio-accel-xdna/src/lower.rs
+++ b/crates/virtio-accel-xdna/src/lower.rs
@@ -102,13 +102,17 @@ pub const XDNA_TOSA_FP8_CAPABILITY: CapabilityDescriptor = CapabilityDescriptor 
     },
 };
 
-// This is deliberately the same semantic surface OpenVINO advertises for its integer target.
+// This is OpenVINO's semantic surface for its integer target, plus the one role its integer tier
+// does not need: OpenVINO only ever *produces* INT32, while this backend also *consumes* it as the
+// RESCALE input below. A dtype omitted from `INPUT` is unroutable through the standard
+// `INPUT || OUTPUT` capability filter, so the advertised roles have to cover every admitted tier.
 // XDNA's admission functions below impose an additional, hardware-specific static-memory envelope.
 const INTEGER_DTYPES: &[DTypeCapability] = &[
     DTypeCapability::new(DType::INT8, ValueRoles::ALL),
     DTypeCapability::new(
         DType::INT32,
-        ValueRoles::OUTPUT
+        ValueRoles::INPUT
+            .union(ValueRoles::OUTPUT)
             .union(ValueRoles::CONSTANT)
             .union(ValueRoles::INTERMEDIATE),
     ),
@@ -260,6 +264,14 @@ pub enum AdmitError {
     Unsupported,
 }
 
+impl core::fmt::Display for AdmitError {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(formatter, "{self:?}")
+    }
+}
+
+impl std::error::Error for AdmitError {}
+
 /// The one authoritative mapping to wire-level error codes, shared by `load_program` and
 /// `compile_artifact` so the two paths can never drift. The codes match the OpenVINO backend's
 /// classification of the same failure classes (its `lowering_error`): a malformed or semantically
@@ -404,6 +416,10 @@ fn admit_int8_matmul(
     let outputs = analysis.operator_outputs(matmul);
     if inputs.len() != 4
         || outputs.len() != 1
+        // The compiled kernel always declares two independent input slots, so one value feeding
+        // both operands would let a caller bind different buffers and compute `A * B` for a graph
+        // that says `X * X`.
+        || inputs[0] == inputs[1]
         || analysis.block_inputs(block) != [inputs[0], inputs[1]]
         || analysis.block_outputs(block) != [outputs[0]]
     {
@@ -719,8 +735,11 @@ fn admit_matmul(
     }
 
     // The operator's dataflow must be the block's: lhs/rhs are the block inputs in binding order,
-    // and the MATMUL result is the block output.
-    if analysis.block_inputs(block) != [inputs[0], inputs[1]]
+    // and the MATMUL result is the block output. One value feeding both operands is rejected: the
+    // compiled kernel declares two independent slots, so a caller could bind different buffers and
+    // compute `A * B` for a graph that says `X * X`.
+    if inputs[0] == inputs[1]
+        || analysis.block_inputs(block) != [inputs[0], inputs[1]]
         || analysis.block_outputs(block) != [outputs[0]]
     {
         return Err(AdmitError::Unsupported);
@@ -1513,6 +1532,62 @@ mod tests {
         assert_eq!(
             BackendError::from(AdmitError::Unsupported),
             BackendError::Unsupported
+        );
+    }
+
+    /// One value feeding both MATMUL operands is rejected. The compiled design always declares two
+    /// independent input slots, so admitting `X * X` would let a caller bind different buffers to
+    /// slots 0 and 1 and compute `A * B` — a result no reading of the graph produces.
+    #[test]
+    fn rejects_matmul_with_one_value_feeding_both_operands() {
+        fn aliased_matmul(dim: i32, in_dtype: DType, out_dtype: DType) -> Vec<u8> {
+            let zp = match in_dtype {
+                DType::INT8 => vec![0u8],
+                _ => vec![0u8; 2],
+            };
+            let mut graph = OwnedGraph::new("main");
+            graph
+                .push_tensor(OwnedTensor::new("x", vec![1, dim, dim], in_dtype))
+                .push_tensor(OwnedTensor::constant(
+                    "lhs_zp",
+                    vec![1],
+                    in_dtype,
+                    zp.clone(),
+                ))
+                .push_tensor(OwnedTensor::constant("rhs_zp", vec![1], in_dtype, zp))
+                .push_tensor(OwnedTensor::new("output", vec![1, dim, dim], out_dtype))
+                .push_operator(OwnedOperator::new(
+                    OperatorKind::Const,
+                    vec![],
+                    vec!["lhs_zp".into()],
+                ))
+                .push_operator(OwnedOperator::new(
+                    OperatorKind::Const,
+                    vec![],
+                    vec!["rhs_zp".into()],
+                ))
+                .push_operator(OwnedOperator::new(
+                    OperatorKind::MatMul,
+                    vec!["x".into(), "x".into(), "lhs_zp".into(), "rhs_zp".into()],
+                    vec!["output".into()],
+                ))
+                .push_input("x")
+                .push_input("x")
+                .push_output("output");
+            let target = if in_dtype == DType::INT8 {
+                XDNA_TOSA_INTEGER_TARGET
+            } else {
+                XDNA_TOSA_TARGET
+            };
+            graph.build(target).expect("build aliased matmul")
+        }
+
+        let bf16 = aliased_matmul(64, DType::BF16, DType::FP32);
+        assert_eq!(admit(&bf16, XDNA_TOSA_TARGET), Err(AdmitError::Unsupported));
+        let int8 = aliased_matmul(32, DType::INT8, DType::INT32);
+        assert_eq!(
+            admit(&int8, XDNA_TOSA_INTEGER_TARGET),
+            Err(AdmitError::Unsupported)
         );
     }
 

--- a/crates/virtio-accel-xdna/src/native.rs
+++ b/crates/virtio-accel-xdna/src/native.rs
@@ -44,6 +44,12 @@ const MAX_TOSA_ARTIFACT_BYTES: u64 = 256 * 1024 * 1024;
 /// Default submission-ring depth (issue #85: one admitted request, matching the Hexagon backend).
 const DEFAULT_RING_DEPTH: usize = 1;
 
+/// AIE DMA descriptors transfer whole four-byte words, so a bound range must begin on a word
+/// boundary as well as cover its slot's exact byte length. The base mapping is page-aligned, so the
+/// caller's offset alone decides alignment (the reference backend rejects the same way, against its
+/// per-slot scalar size).
+const DMA_WORD_BYTES: u64 = 4;
+
 /// The kernel's NPU TDR is 60 seconds. A longer userspace watchdog distinguishes a returned
 /// device-loss error (tier 1) from an HRX synchronize call that never returns (tier 2).
 const DEFAULT_WATCHDOG_TIMEOUT: Duration = Duration::from_secs(120);
@@ -1169,9 +1175,7 @@ impl Accelerator for XdnaAccelerator {
         context: &Self::Context,
         desc: QueueDesc,
     ) -> Result<Self::Queue, BackendError> {
-        if !desc.flags.is_empty() {
-            return Err(BackendError::Unsupported);
-        }
+        self.info.validate_queue_desc(desc)?;
         self.resources.queues.fetch_add(1, Ordering::AcqRel);
         Ok(XdnaQueue {
             context_id: context.id,
@@ -1273,6 +1277,11 @@ impl Accelerator for XdnaAccelerator {
             // length, so anything but an exact match would read or write past the caller's declared
             // range (mirrors OpenVINO's per-slot byte_len check).
             if binding.range.bytes() != program.inner.slot_bytes[slot] {
+                return reject(BackendError::Incompatible);
+            }
+            // The descriptor starts at `offset`, so an unaligned start would ask the DMA for a
+            // sub-word transfer it cannot express.
+            if binding.range.offset % DMA_WORD_BYTES != 0 {
                 return reject(BackendError::Incompatible);
             }
             // Aliasing rule: binding one buffer to several read slots is sound (the kernel only
@@ -1383,9 +1392,30 @@ impl Accelerator for XdnaAccelerator {
                 resource: event,
             });
         }
-        *event.slot.error.lock().expect("event error mutex") = None;
-        event.slot.state.store(slot_state::FREE, Ordering::Release);
-        ResourceTracker::decrement(&event.resources.events);
+        // Dropping reclaims the slot, so this is the single reclaim path: an event that is merely
+        // dropped instead of destroyed cannot strand its ring entry.
+        drop(event);
         Ok(())
+    }
+}
+
+impl Drop for XdnaEvent {
+    /// Reclaim the ring slot. `destroy_event` is the intended release path, but with a ring depth of
+    /// one a dropped-instead-of-destroyed event would strand the only slot and fail every later
+    /// submission with `Busy` for the life of the instance.
+    ///
+    /// Only a terminal slot is reclaimed. A `PENDING` slot still belongs to the dispatch worker,
+    /// which will latch it; freeing it here would hand a live slot to the next submission. Such a
+    /// slot stays charged to `resource_counts`, which is exactly where a wedged lane's event
+    /// belongs. The error detail is cleared before `FREE` is published, so a later claimer of this
+    /// slot can never observe the previous submission's failure.
+    fn drop(&mut self) {
+        let state = self.slot.state.load(Ordering::Acquire);
+        if state != slot_state::COMPLETE && state != slot_state::FAILED {
+            return;
+        }
+        *self.slot.error.lock().expect("event error mutex") = None;
+        self.slot.state.store(slot_state::FREE, Ordering::Release);
+        ResourceTracker::decrement(&self.resources.events);
     }
 }

--- a/crates/virtio-accel-xdna/tests/hardware.rs
+++ b/crates/virtio-accel-xdna/tests/hardware.rs
@@ -619,6 +619,111 @@ fn tier2_watchdog_reports_device_loss_and_discard_never_blocks() {
     assert!(started.elapsed() < Duration::from_millis(250));
 }
 
+/// An event that is dropped rather than destroyed must still release its ring slot. The ring depth
+/// is one, so stranding the slot would fail every later submission with `Busy` for the life of the
+/// instance — and leave `resource_counts` reporting an event that no longer exists.
+#[test]
+fn dropping_a_completed_event_reclaims_its_ring_slot() {
+    let Some(backend) = backend() else { return };
+    let context = backend
+        .create_context(ContextDesc::default())
+        .expect("context");
+    let queue = backend
+        .create_queue(&context, QueueDesc::default())
+        .expect("queue");
+    let program = backend
+        .load_program(
+            &context,
+            ArtifactRef {
+                format: XDNA_PRECOMPILED_FORMAT,
+                target: TargetIdentity([0; 12]),
+                payload: &Slice(PASSTHROUGH),
+                resident_bytes: u64::MAX,
+            },
+        )
+        .expect("load precompiled passthrough");
+
+    let input_desc = BufferDesc::new(
+        PASSTHROUGH_BYTES as u64,
+        4096,
+        MemoryDomain::Shared,
+        BufferUsage::TRANSFER_DESTINATION | BufferUsage::PROGRAM_INPUT,
+    )
+    .unwrap();
+    let (input, _) = backend
+        .allocate_buffer(&context, input_desc)
+        .expect("input buffer")
+        .into_parts();
+    let (unused, _) = backend
+        .allocate_buffer(&context, input_desc)
+        .expect("unused input buffer")
+        .into_parts();
+    let (output, _) = backend
+        .allocate_buffer(
+            &context,
+            BufferDesc::new(
+                PASSTHROUGH_BYTES as u64,
+                4096,
+                MemoryDomain::Shared,
+                BufferUsage::TRANSFER_SOURCE | BufferUsage::PROGRAM_OUTPUT,
+            )
+            .unwrap(),
+        )
+        .expect("output buffer")
+        .into_parts();
+
+    let range = BufferRange::new(0, PASSTHROUGH_BYTES as u64).unwrap();
+    let bindings = [
+        BindingRef {
+            slot: 0,
+            buffer: &input,
+            range,
+            access: AccessMode::Read,
+        },
+        BindingRef {
+            slot: 1,
+            buffer: &unused,
+            range,
+            access: AccessMode::Read,
+        },
+        BindingRef {
+            slot: 2,
+            buffer: &output,
+            range,
+            access: AccessMode::Write,
+        },
+    ];
+
+    // Two rounds through the single ring slot, releasing the first event by dropping it.
+    for round in 0..2 {
+        let event = match backend.submit(&queue, &program, &bindings, Timeout::Infinite) {
+            Ok(event) => event,
+            Err(failure) => panic!("submit rejected in round {round}: {failure:?}"),
+        };
+        let state = poll_to_terminal(&backend, &event, Duration::from_secs(10))
+            .expect("dispatch did not complete in 10s");
+        assert!(
+            matches!(state, EventState::Complete),
+            "round {round}: expected Complete, got {state:?}"
+        );
+        assert_eq!(backend.resource_counts().events, 1, "round {round}");
+        drop(event);
+        // The slot and the resource charge are both released by the drop.
+        assert_eq!(
+            backend.resource_counts().events,
+            0,
+            "round {round}: dropping a terminal event must release its charge"
+        );
+    }
+
+    backend.free_buffer(input).expect("free input");
+    backend.free_buffer(unused).expect("free unused");
+    backend.free_buffer(output).expect("free output");
+    backend.unload_program(program).expect("unload");
+    backend.destroy_queue(queue).expect("destroy queue");
+    backend.destroy_context(context).expect("destroy context");
+}
+
 #[test]
 fn precompiled_passthrough_runs_the_full_lifecycle() {
     let Some(backend) = backend() else { return };
@@ -733,6 +838,10 @@ fn precompiled_passthrough_runs_the_full_lifecycle() {
 fn tosa_bf16_identity_compiles_to_a_wellformed_artifact() {
     // Hardware-free: needs the compiler toolchain but never initializes a device.
     if !toolchain_present() {
+        assert!(
+            !hardware_required(),
+            "{REQUIRE_HARDWARE_ENV}=1 but VIRTIO_ACCEL_AMDXDNA_TOOLCHAIN is not configured"
+        );
         eprintln!("no XDNA toolchain configured; skipping compiler test");
         return;
     }
@@ -774,6 +883,10 @@ fn tosa_bf16_identity_compiles_to_a_wellformed_artifact() {
 fn tosa_bf16_identity_runs_on_the_npu() {
     let Some(backend) = backend() else { return };
     if !toolchain_present() {
+        assert!(
+            !hardware_required(),
+            "{REQUIRE_HARDWARE_ENV}=1 but VIRTIO_ACCEL_AMDXDNA_TOOLCHAIN is not configured"
+        );
         eprintln!("no XDNA toolchain configured; skipping TOSA execution test");
         return;
     }
@@ -869,6 +982,10 @@ fn tosa_bf16_identity_runs_on_the_npu() {
 #[test]
 fn tosa_integer_corpus_compiles_to_wellformed_artifacts() {
     if !toolchain_present() {
+        assert!(
+            !hardware_required(),
+            "{REQUIRE_HARDWARE_ENV}=1 but VIRTIO_ACCEL_AMDXDNA_TOOLCHAIN is not configured"
+        );
         eprintln!("no XDNA toolchain configured; skipping compiler test");
         return;
     }
@@ -896,6 +1013,10 @@ fn tosa_integer_corpus_compiles_to_wellformed_artifacts() {
 fn tosa_int8_identity_matches_the_shared_exact_oracle_on_the_npu() {
     let Some(backend) = backend() else { return };
     if !toolchain_present() {
+        assert!(
+            !hardware_required(),
+            "{REQUIRE_HARDWARE_ENV}=1 but VIRTIO_ACCEL_AMDXDNA_TOOLCHAIN is not configured"
+        );
         eprintln!("no XDNA toolchain configured; skipping TOSA execution test");
         return;
     }
@@ -995,6 +1116,10 @@ fn tosa_int8_identity_matches_the_shared_exact_oracle_on_the_npu() {
 fn tosa_int8_matmul_matches_the_shared_exact_oracle_on_the_npu() {
     let Some(backend) = backend() else { return };
     if !toolchain_present() {
+        assert!(
+            !hardware_required(),
+            "{REQUIRE_HARDWARE_ENV}=1 but VIRTIO_ACCEL_AMDXDNA_TOOLCHAIN is not configured"
+        );
         eprintln!("no XDNA toolchain configured; skipping TOSA execution test");
         return;
     }
@@ -1117,6 +1242,10 @@ fn tosa_int8_matmul_matches_the_shared_exact_oracle_on_the_npu() {
 fn tosa_int32_to_int8_rescale_matches_the_shared_exact_oracle_on_the_npu() {
     let Some(backend) = backend() else { return };
     if !toolchain_present() {
+        assert!(
+            !hardware_required(),
+            "{REQUIRE_HARDWARE_ENV}=1 but VIRTIO_ACCEL_AMDXDNA_TOOLCHAIN is not configured"
+        );
         eprintln!("no XDNA toolchain configured; skipping TOSA execution test");
         return;
     }
@@ -1222,6 +1351,10 @@ fn tosa_int32_to_int8_rescale_matches_the_shared_exact_oracle_on_the_npu() {
 fn measures_exact_int8_matmul_latency() {
     let Some(backend) = backend() else { return };
     if !toolchain_present() {
+        assert!(
+            !hardware_required(),
+            "{REQUIRE_HARDWARE_ENV}=1 but VIRTIO_ACCEL_AMDXDNA_TOOLCHAIN is not configured"
+        );
         eprintln!("no XDNA toolchain configured; skipping INT8 benchmark");
         return;
     }
@@ -1393,6 +1526,10 @@ fn measures_exact_int8_matmul_latency() {
 #[test]
 fn tosa_fp8_casts_compile_to_wellformed_artifacts() {
     if !toolchain_present() {
+        assert!(
+            !hardware_required(),
+            "{REQUIRE_HARDWARE_ENV}=1 but VIRTIO_ACCEL_AMDXDNA_TOOLCHAIN is not configured"
+        );
         eprintln!("no XDNA toolchain configured; skipping compiler test");
         return;
     }
@@ -1510,6 +1647,10 @@ fn run_fp8_cast_case(backend: &XdnaAccelerator, case: TosaFp8ToBfloat16Case) {
 fn tosa_fp8_casts_match_the_shared_bit_exact_oracles_on_the_npu() {
     let Some(backend) = backend() else { return };
     if !toolchain_present() {
+        assert!(
+            !hardware_required(),
+            "{REQUIRE_HARDWARE_ENV}=1 but VIRTIO_ACCEL_AMDXDNA_TOOLCHAIN is not configured"
+        );
         eprintln!("no XDNA toolchain configured; skipping TOSA execution test");
         return;
     }
@@ -1523,6 +1664,10 @@ fn tosa_fp8_casts_match_the_shared_bit_exact_oracles_on_the_npu() {
 fn measures_fp8_cast_scaling_on_one_aie_worker() {
     let Some(backend) = backend() else { return };
     if !toolchain_present() {
+        assert!(
+            !hardware_required(),
+            "{REQUIRE_HARDWARE_ENV}=1 but VIRTIO_ACCEL_AMDXDNA_TOOLCHAIN is not configured"
+        );
         eprintln!("no XDNA toolchain configured; skipping FP8 benchmark");
         return;
     }
@@ -1667,6 +1812,10 @@ fn measure_fp8_cast_size(
 #[test]
 fn tosa_bf16_max_pool2d_compiles_to_a_wellformed_artifact() {
     if !toolchain_present() {
+        assert!(
+            !hardware_required(),
+            "{REQUIRE_HARDWARE_ENV}=1 but VIRTIO_ACCEL_AMDXDNA_TOOLCHAIN is not configured"
+        );
         eprintln!("no XDNA toolchain configured; skipping compiler test");
         return;
     }
@@ -1685,6 +1834,10 @@ fn tosa_bf16_max_pool2d_compiles_to_a_wellformed_artifact() {
 fn tosa_bf16_max_pool2d_matches_the_shared_oracle_on_the_npu() {
     let Some(backend) = backend() else { return };
     if !toolchain_present() {
+        assert!(
+            !hardware_required(),
+            "{REQUIRE_HARDWARE_ENV}=1 but VIRTIO_ACCEL_AMDXDNA_TOOLCHAIN is not configured"
+        );
         eprintln!("no XDNA toolchain configured; skipping TOSA execution test");
         return;
     }
@@ -1831,6 +1984,10 @@ fn tosa_bf16_max_pool2d_matches_the_shared_oracle_on_the_npu() {
 fn tosa_bf16_matmul_compiles_to_a_wellformed_artifact() {
     // Hardware-free: needs the compiler toolchain but never initializes a device.
     if !toolchain_present() {
+        assert!(
+            !hardware_required(),
+            "{REQUIRE_HARDWARE_ENV}=1 but VIRTIO_ACCEL_AMDXDNA_TOOLCHAIN is not configured"
+        );
         eprintln!("no XDNA toolchain configured; skipping compiler test");
         return;
     }
@@ -1859,6 +2016,10 @@ fn tosa_bf16_matmul_compiles_to_a_wellformed_artifact() {
 fn tosa_bf16_matmul_runs_on_the_npu() {
     let Some(backend) = backend() else { return };
     if !toolchain_present() {
+        assert!(
+            !hardware_required(),
+            "{REQUIRE_HARDWARE_ENV}=1 but VIRTIO_ACCEL_AMDXDNA_TOOLCHAIN is not configured"
+        );
         eprintln!("no XDNA toolchain configured; skipping TOSA execution test");
         return;
     }
@@ -1998,6 +2159,10 @@ fn tosa_matmul_with_a_shared_input_buffer_runs_on_the_npu() {
     // be bit-exact.
     let Some(backend) = backend() else { return };
     if !toolchain_present() {
+        assert!(
+            !hardware_required(),
+            "{REQUIRE_HARDWARE_ENV}=1 but VIRTIO_ACCEL_AMDXDNA_TOOLCHAIN is not configured"
+        );
         eprintln!("no XDNA toolchain configured; skipping TOSA execution test");
         return;
     }
@@ -2192,6 +2357,20 @@ fn submit_enforces_the_per_slot_binding_plan_and_load_enforces_residency() {
     ];
     assert!(matches!(
         backend.submit(&queue, &program, &wrong_length, Timeout::Infinite),
+        Err(SubmitFailure::Rejected(BackendError::Incompatible))
+    ));
+
+    // Exactly the tensor length and in bounds (the buffers are twice the tensor size), but starting
+    // mid-word. An AIE DMA descriptor cannot express a sub-word start, so this is rejected before
+    // the device sees it rather than handed to the driver as a malformed transfer.
+    let misaligned = BufferRange::new(2, PASSTHROUGH_BYTES as u64).unwrap();
+    let unaligned_start = [
+        binding(0, &input, misaligned, AccessMode::Read),
+        binding(1, &unused, full, AccessMode::Read),
+        binding(2, &output, full, AccessMode::Write),
+    ];
+    assert!(matches!(
+        backend.submit(&queue, &program, &unaligned_start, Timeout::Infinite),
         Err(SubmitFailure::Rejected(BackendError::Incompatible))
     ));
 

--- a/crates/virtio-accel-xdna/tests/xdna.rs
+++ b/crates/virtio-accel-xdna/tests/xdna.rs
@@ -1,6 +1,8 @@
-//! Scaffold-level tests: the advertised targets.
+//! Host-independent tests: the advertised targets, the capability descriptors, and the offline
+//! compile path.
 //!
-//! Native lifecycle tests arrive with the HRX FFI and hardware tickets. These run on every host.
+//! Native lifecycle and on-metal numerics live in `hardware.rs`, which is gated on a detected HRX
+//! runtime. Everything here runs on every host.
 
 #[cfg(not(va_xdna))]
 use virtio_accel_tosa::TosaCapabilityProvider;
@@ -112,13 +114,42 @@ fn integer_capability_preserves_openvino_and_adds_exact_rescale() {
         XDNA_TOSA_INTEGER_TARGET
     );
     // CONST/IDENTITY/MATMUL are the OpenVINO baseline. RESCALE is the intentional issue-#147
-    // expansion; target separation and dtype roles remain unchanged.
+    // expansion, and target separation is unchanged.
     for op in [Op::CONST, Op::IDENTITY, Op::MATMUL, Op::RESCALE] {
         assert!(XDNA_TOSA_INTEGER_CAPABILITY.supports_operator(op));
     }
     assert!(XDNA_TOSA_INTEGER_CAPABILITY.supports_dtype(DType::INT8, ValueRoles::ALL));
     assert!(XDNA_TOSA_INTEGER_CAPABILITY.supports_dtype(DType::INT32, ValueRoles::OUTPUT));
-    assert!(!XDNA_TOSA_INTEGER_CAPABILITY.supports_dtype(DType::INT32, ValueRoles::INPUT));
+    // The dtype roles *do* diverge from OpenVINO here, and they have to. `ValueRoles::INPUT` means
+    // "graph-visible block input"; OpenVINO's integer tier only ever produces INT32, but the
+    // RESCALE tier consumes it as the block input, so omitting the role would advertise a surface
+    // that contradicts `admit`. `admitted_integer_block_input_dtypes_are_advertised` pins that.
+    assert!(XDNA_TOSA_INTEGER_CAPABILITY.supports_dtype(DType::INT32, ValueRoles::INPUT));
+}
+
+/// The advertised dtype roles must cover what admission actually accepts. A dtype omitted from
+/// `INPUT` is unroutable through the standard `INPUT || OUTPUT` capability filter every sibling
+/// backend builds, so an admitted tier whose block input dtype is unadvertised is invisible to a
+/// scheduler — the tier would be implemented, tested, and unreachable.
+#[test]
+fn admitted_integer_block_input_dtypes_are_advertised() {
+    use virtio_accel_conformance::numerics::RESCALE_INT32_TO_INT8;
+    use virtio_accel_tosa::DType;
+
+    // The shared corpus RESCALE fixture takes INT32 in and INT8 out, both at the block boundary.
+    assert!(
+        virtio_accel_xdna::admit(RESCALE_INT32_TO_INT8.artifact, XDNA_TOSA_INTEGER_TARGET).is_ok(),
+        "the shared RESCALE fixture must stay admissible"
+    );
+    for (dtype, role) in [
+        (DType::INT32, ValueRoles::INPUT),
+        (DType::INT8, ValueRoles::OUTPUT),
+    ] {
+        assert!(
+            XDNA_TOSA_INTEGER_CAPABILITY.supports_dtype(dtype, role),
+            "admission accepts {dtype:?} at the block boundary but the capability hides it"
+        );
+    }
 }
 
 #[cfg(not(va_xdna))]


### PR DESCRIPTION
# Why

Review findings from the XDNA map-closeout stack (#134-#153), which merged to `main` while this review was in flight; this targets `main` directly. Four defects, plus the mechanical adherence gaps
that let the first one reach `main`-adjacent review unnoticed. Each fix is paired with a test that
fails without it.

**The integer capability hid its own newest tier.** `INTEGER_DTYPES` advertised INT32 as
`OUTPUT | CONSTANT | INTERMEDIATE`, copied verbatim from OpenVINO with the comment that dtype roles
"remain unchanged". That was correct for OpenVINO, whose integer tier only ever *produces* INT32,
and became wrong the moment `RESCALE` joined the operator list: `admit_int32_to_int8_rescale`
requires the INT32 tensor to *be* the block input, which is precisely what `ValueRoles::INPUT`
denotes ("graph-visible block input"). Because every sibling backend derives an `INPUT || OUTPUT`
filter from this descriptor, the tier was implemented, proven on metal, and unroutable by any
scheduler. Precedent was followed exactly where it needed to be extended.

`tests/xdna.rs` asserted the omission, so that assertion is corrected rather than deleted, and a new
test pins the advertised roles to what `admit` actually accepts — the cross-check whose absence is
the root cause. Adding `INPUT` widens advertisement only; admission stays authoritative and still
rejects an unsupported INT32 graph with `Unsupported`, exactly as the coarse dtype/role matrix does
in every other backend.

**`submit` checked a binding's length but not its start.** The crate already rounds slot *lengths*
up to a four-byte DMA word because AIE descriptors cannot express a shorter granularity. A mid-word
*offset* is unrepresentable for the same reason, and the base mapping is page-aligned, so the
caller's offset alone decides alignment. The reference rejects this as `Incompatible` before the
device sees it; this backend passed the raw offset into `hrx_buffer_ref_t.offset`.

**Dropping an event bricked the accelerator.** `XdnaEvent` had no `Drop`, and `DEFAULT_RING_DEPTH`
is 1, so one event released by drop instead of `destroy_event` stranded the only slot: every later
`submit` returned `Busy` for the life of the instance, and `resource_counts` reported an event that
no longer existed. `Drop` is now the single reclaim path — `destroy_event` validates the event is
terminal and then drops it — so either route reclaims exactly once. This ordering matters: because
`destroy_event` takes the event by value, a `Drop` that also reclaimed would have double-decremented
the counter and could have reset a slot another submission had already claimed. A `PENDING` slot is
deliberately left alone; the dispatch worker still owns it, which is what keeps a quarantined wedge's
slot and charge outstanding rather than handing a live slot to the next submission.

**The documented hardware lane could report green having run nothing.**
`VIRTIO_ACCEL_XDNA_REQUIRE_HARDWARE=1` made a native-runtime initialization failure fatal but not a
missing toolchain, so all fifteen `toolchain_present()` skips in `hardware.rs` returned silently —
the exact false pass the switch was introduced to eliminate. They now assert the same way
`tests/conformance.rs` already did.

**Also fixed**

- MATMUL admitted one value feeding both operands. The compiled design always declares two
  independent input slots, so a caller could bind different buffers and compute `A * B` for a graph
  that says `X * X` — the dataflow guarantee the module doc claims. Both the BF16 and INT8 paths now
  reject it.
- `AdmitError` gains `Display` and `std::error::Error`, matching the reference's `LoweringError` and
  this crate's own `InitError`.
- `create_queue` routes through `DeviceInfo::validate_queue_desc` instead of hand-rolling
  `flags.is_empty()`; it was the only backend not using the shared helper.
- The stale "Scaffold" header on `tests/xdna.rs`, which claimed native lifecycle tests were still
  pending.

## Out of scope

Deliberately left for their own tickets: the single-worker throughput gap (#149, #151), collapsing
the triplicated FP8 decoder and the three-way duplication inside `lower.rs`, a `QueueScratch`
equivalent for the per-submit allocations, a BF16 MATMUL corpus fixture, and exporting
`supports_tosa_operator`/`supports_tosa_dtype` so XDNA can join the cross-backend surface test.

Two findings raised in review were checked and **rejected**, recorded here so they are not "fixed"
later: the INT8 `MMUL accumulator` is not uninitialized (`C_block() : zero(true)`, and `mac()`
forwards that flag to the `_conf` intrinsic as its accumulator-zeroing bit), and accepting an opaque
precompiled artifact without inspecting its transaction stream is an explicit Protocol 1.0 exclusion
(`docs/threat-model.md`), not a defect.

## Compatibility

- [x] **No wire effect.** This changes no accepted or emitted protocol bytes.

Two guest-visible behaviors tighten, both toward the reference: a submission whose binding offset is
not four-byte aligned is now rejected with `Incompatible`, and a MATMUL graph aliasing one value
across both operands is now rejected with `Unsupported`. Both were previously accepted and neither
could execute as the graph described. The advertised integer dtype roles widen by one flag.

## Checklist

- [x] Does not alter payload lengths, ownership, reset, error, timeout, or feature-negotiation
      behavior — or does, and says so above.
- [x] `layout.json`, `vectors.json`, `scenarios.json`, `requirements.json`, and performance budgets
      are still authoritative inputs, not regenerated by accident.
- [x] Public Rust API changes affecting backend, guest, device, or transport authors are called out:
      `AdmitError` gains `Display`/`Error`, and `XDNA_TOSA_INTEGER_CAPABILITY` advertises
      `ValueRoles::INPUT` for INT32.
- [x] No dependency, Cargo feature, or target moves platform behavior into a portable crate. No
      dependency changes at all.
- [x] No `unsafe` code was added or modified.
- [x] Deferred optional features remain unadvertised and documented as out of scope.

## Verification

All green. 308 passed, 0 failed, 23 ignored across the workspace.

```sh
cargo fmt --all -- --check
git diff --check
python3 ci/check-release-policy.py
cargo clippy -p virtio-accel-xdna --all-targets --all-features --no-deps -- -D warnings
cargo test --workspace --all-targets --all-features
RUSTDOCFLAGS=-D warnings cargo doc -p virtio-accel-xdna --all-features --no-deps
python3 ci/check-performance-budgets.py --check
python3 ci/publish-dry-run.py
cargo run --example backend_conformance
cargo run --example reference_execution
```

`native.rs` and `hardware.rs` are behind `cfg(va_xdna)`, which CI never enables, so they were also
type-checked and linted with the cfg forced on via `VIRTIO_ACCEL_HRX_LIB_DIR` (the build script's
bare-lib-directory escape hatch; `cargo check`/`clippy` need no link):

```sh
VIRTIO_ACCEL_HRX_LIB_DIR=/tmp/fakelib cargo clippy -p virtio-accel-xdna \
  --all-targets --all-features --no-deps -- -D warnings
```

I confirmed that path is not vacuous by planting a deliberate type error in `hardware.rs` and
watching the check fail, then removing it.

**Not run:** the on-metal suite — this host has no NPU and no HRX. Two of the new tests
(`dropping_a_completed_event_reclaims_its_ring_slot`, and the misaligned-binding case added to
`submit_enforces_the_per_slot_binding_plan_and_load_enforces_residency`) are `cfg(va_xdna)` and are
type-checked but unexecuted here; they need a run on the reference `1022:17f0` part before this
merges. The two tests that do run in CI were each verified to fail with the fix reverted.
