### PR TITLE
Ticket 7: scaffold `virtio-accel-vulkan` (wayfinder map #154)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,7 @@ cargo run -p virtio-accel-coreml --example tosa_coreml
 cargo run -p virtio-accel-openvino --example tosa_openvino
 cargo run -p virtio-accel-hexagon --example tosa_hexagon
 cargo run -p virtio-accel-hexagon --example mock_classifier
+cargo run -p virtio-accel-vulkan --example tosa_vulkan
 python3 ci/publish-dry-run.py
 ```
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,6 +295,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "virtio-accel-vulkan"
+version = "0.3.4"
+dependencies = [
+ "virtio-accel-conformance",
+ "virtio-accel-core",
+ "virtio-accel-tosa",
+]
+
+[[package]]
 name = "virtio-accel-xdna"
 version = "0.3.4"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
     "crates/virtio-accel-hexagon",
     "crates/virtio-accel-mock",
     "crates/virtio-accel-vaccel",
+    "crates/virtio-accel-vulkan",
     "crates/virtio-accel-openvino",
     "crates/virtio-accel-proto",
     "crates/virtio-accel-split-queue",
@@ -79,6 +80,7 @@ virtio-accel-tosa = { path = "crates/virtio-accel-tosa", version = "0.3.4" }
 virtio-accel-tosa-build = { path = "crates/virtio-accel-tosa-build", version = "0.3.4" }
 virtio-accel-transport = { path = "crates/virtio-accel-transport", version = "0.3.4" }
 virtio-accel-vaccel = { path = "crates/virtio-accel-vaccel", version = "0.3.4" }
+virtio-accel-vulkan = { path = "crates/virtio-accel-vulkan", version = "0.3.4" }
 
 [dependencies]
 virtio-accel-core.workspace = true

--- a/README.md
+++ b/README.md
@@ -89,7 +89,11 @@ See the [`virtio-accel-hexagon` support boundary](crates/virtio-accel-hexagon/RE
 
 ### Vulkan (_planned_)
 
-The Vulkan row is a placeholder for a future Vulkan compute backend. It is not yet implemented, and no Vulkan crate or runtime build probe is currently included.
+The Vulkan row is a scaffold-in-progress for a vendor-neutral Vulkan compute backend
+(`virtio-accel-vulkan`): the crate ships admission constants and a placeholder; the `ash` FFI and
+native `Accelerator` implementation land under the
+[Vulkan wayfinder map](https://github.com/MicroPerceptron/virtio-accel/issues/154), with design
+decisions recorded in `docs/adr/`.
 
 ### TOSA 1.0
 
@@ -102,6 +106,7 @@ Independently of backend execution, `virtio-accel-tosa` validates the TOSA 1.0 p
 | `virtio-accel-vaccel`      | `core`                | Adapter seam for mapping native provider contracts (including vAccel-style backends) to `virtio-accel-core`  |
 | `virtio-accel-coreml`      | `std`                 | TOSA-to-Core ML lowering, direct buffers, and asynchronous ANE-capable prediction                            |
 | `virtio-accel-openvino`    | `std`                 | TOSA-to-OpenVINO IR lowering, direct host-pointer tensors, and asynchronous NPU/GPU/CPU inference            |
+| `virtio-accel-vulkan`      | `std`                 | Vendor-neutral Vulkan compute backend (scaffold; native backend lands under the wayfinder map)               |
 | `virtio-accel-xdna`        | `std`                 | AMD XDNA2 NPU backend over HRX with direct buffers, asynchronous dispatch, and strict BF16/FP8/INT8 TOSA tiers |
 | `virtio-accel-hexagon`     | `std` (Windows ARM64) | Strict FP16/INT8 TOSA-to-QNN lowering, direct buffers, and asynchronous Hexagon HTP execution                |
 | `virtio-accel`             | `core + alloc`        | Facade re-exporting the portable layers                                                                      |
@@ -141,6 +146,9 @@ virtio-accel-coreml ----------+--------------> virtio-accel-core
                               |
                               +--------------> virtio-accel-tosa
 virtio-accel-openvino --------+--------------> virtio-accel-core
+                              |
+                              +--------------> virtio-accel-tosa
+virtio-accel-vulkan ----------+--------------> virtio-accel-core
                               |
                               +--------------> virtio-accel-tosa
 virtio-accel-hexagon ---------+--------------> virtio-accel-core

--- a/ci/check-release-policy.py
+++ b/ci/check-release-policy.py
@@ -36,6 +36,7 @@ PUBLISHED_PACKAGES = {
     "crates/virtio-accel-openvino": "virtio-accel-openvino",
     "crates/virtio-accel-proto": "virtio-accel-proto",
     "crates/virtio-accel-vaccel": "virtio-accel-vaccel",
+    "crates/virtio-accel-vulkan": "virtio-accel-vulkan",
     "crates/virtio-accel-split-queue": "virtio-accel-split-queue",
     "crates/virtio-accel-tosa": "virtio-accel-tosa",
     "crates/virtio-accel-tosa-build": "virtio-accel-tosa-build",

--- a/ci/publication.py
+++ b/ci/publication.py
@@ -33,6 +33,7 @@ PUBLISH_ORDER = (
     "virtio-accel-coreml",
     "virtio-accel-openvino",
     "virtio-accel-hexagon",
+    "virtio-accel-vulkan",
     "virtio-accel",
 )
 

--- a/crates/virtio-accel-vulkan/Cargo.toml
+++ b/crates/virtio-accel-vulkan/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "virtio-accel-vulkan"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Vendor-neutral Vulkan compute host backend for virtio-accel"
+readme = "README.md"
+
+[dependencies]
+virtio-accel-core.workspace = true
+virtio-accel-tosa.workspace = true
+
+[dev-dependencies]
+virtio-accel-conformance.workspace = true

--- a/crates/virtio-accel-vulkan/LICENSE-APACHE
+++ b/crates/virtio-accel-vulkan/LICENSE-APACHE
@@ -1,0 +1,176 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/crates/virtio-accel-vulkan/LICENSE-MIT
+++ b/crates/virtio-accel-vulkan/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2026 MicroPerceptron contributors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/crates/virtio-accel-vulkan/README.md
+++ b/crates/virtio-accel-vulkan/README.md
@@ -1,0 +1,50 @@
+# virtio-accel-vulkan
+
+A vendor-neutral Vulkan compute host backend for `virtio-accel`, executing device-neutral TOSA
+1.0 programs on any conformant Vulkan 1.x implementation (RADV, ANV, NVIDIA, Mali, or a software
+ICD) without leaking Vulkan types into the portable crates.
+
+**Portability tier:** `host-native` — `ash` loads the platform's Vulkan loader dynamically at run
+time on the enumerated host targets (Linux, Android, Windows, macOS); a compile-only placeholder
+elsewhere. Unlike the SDK-probing backends, there is nothing to detect at build time (ADR 0002 in
+`docs/adr/`).
+
+**This crate is currently the scaffold.** It ships the always-compiled admission constants and a
+placeholder; the `ash` FFI, the native `Accelerator` implementation, and the advertised numerical
+tiers land in subsequent tickets of the
+[Vulkan wayfinder map](https://github.com/MicroPerceptron/virtio-accel/issues/154). The design
+decisions ratified with this scaffold live in `docs/adr/` (ADRs 0001–0004).
+
+## Build-time gate
+
+`VIRTIO_ACCEL_VULKAN=1` makes an unsupported target a loud build failure, `=0` forces the
+placeholder, and unset is auto. The supported set is enumerated in `build.rs`; runtime presence of
+a Vulkan loader is discovered when the native backend initializes, never at build time.
+
+## Planned numerical tier
+
+Per ADR 0004, the backend plans an FP32 base tier (`VULKAN_TOSA_TARGET`) and a provisional INT8
+tier (`VULKAN_TOSA_INTEGER_TARGET`); FP16 is deferred until per-device float-controls evidence
+exists, and FP8 is rejected at admission. Graph admission and execution wire onto these targets in
+the tickets following the scaffold.
+
+## Running
+
+```sh
+cargo run -p virtio-accel-vulkan --example tosa_vulkan
+cargo test -p virtio-accel-vulkan
+```
+
+The example reports the scaffold state and exits successfully; the tests exercise the advertised
+targets on every host.
+
+Part of the [`virtio-accel`](https://github.com/MicroPerceptron/virtio-accel) workspace: an
+experimental native-Rust protocol and implementation stack for a transport-neutral virtual
+accelerator device. Portable crates contain no host-OS or vendor APIs; host integrations live in
+separate adapter crates and never become their dependencies. The project claims no Virtio device
+ID.
+
+## License
+
+Licensed under either of [Apache License, Version 2.0](LICENSE-APACHE) or
+[MIT license](LICENSE-MIT) at your option.

--- a/crates/virtio-accel-vulkan/SAFETY.md
+++ b/crates/virtio-accel-vulkan/SAFETY.md
@@ -1,0 +1,35 @@
+# Unsafe-code audit
+
+This crate will become a host-native exception to the portable workspace's `forbid(unsafe_code)`
+rule, on the same terms as the other host backend adapters — with one structural difference from
+the hand-written FFI precedents: raw Vulkan declarations come from the pinned `ash` crate
+(ADR 0002), so the audit pins the `ash` version and the entry points actually used rather than
+re-declaring a subset in-tree.
+
+**Scaffold state.** The native modules do not exist yet. This build compiles **no `unsafe` at
+all** — only the always-compiled admission constants (`src/lower.rs`) and a placeholder — so the
+crate root still forbids unsafe outright. The full audit is authored with the FFI and lifecycle
+ticket (ticket 8 of the
+[Vulkan wayfinder map](https://github.com/MicroPerceptron/virtio-accel/issues/154)), and the
+audited exception is registered in `ci/check-release-policy.py` in the same change. Its planned
+structure:
+
+1. **Boundary statement** — safe admission constants (`lower.rs`) and safe residency accounting;
+   unsafe confined to the lifecycle/native modules built over `ash`'s generated declarations.
+2. **`ash` pin and used entry points** — the pinned `ash` version, the `Vk*` functions the crate
+   calls, and the invariants the crate owns around them (one owner plus `Drop` per handle;
+   `VkResult` checked before out-parameters are trusted).
+3. **Loader and handle lifetime** — one `ash` `Entry` per process; instance, device, queue,
+   buffer, memory, pipeline, command buffer, fence, and descriptor handles each with one Rust
+   owner and exactly-once destruction; teardown ordered events → programs → buffers → queues →
+   context → device.
+4. **Buffers and mappings** — persistent mapped access bounded by the allocation, flush and
+   invalidate discipline for non-coherent memory types, and no submission-time staging: binding at
+   an offset copies nothing by construction.
+5. **Device loss** — `VK_ERROR_DEVICE_LOST` maps to instance poisoning and whole-instance discard;
+   after poisoning, entry points are never re-entered except destruction, and destruction errors
+   are latched identically.
+6. **Concurrency** — the bounded preallocated pool member owned by the event; `vkGetFenceStatus`
+   is a read-only status query and needs no worker thread (to be proven in ticket 6, not assumed).
+7. **Audited unsafe operations** — every `unsafe` block carries a local `SAFETY:` comment; the
+   native test inventory is listed here.

--- a/crates/virtio-accel-vulkan/build.rs
+++ b/crates/virtio-accel-vulkan/build.rs
@@ -1,0 +1,35 @@
+//! Build-time gate for the optional Vulkan native path.
+//!
+//! Unlike the SDK-probing backends (`va_openvino`, `va_hexagon`, `va_xdna`), there is nothing to
+//! detect on disk: `ash` under its `loaded` feature loads the platform's Vulkan loader
+//! dynamically at run time (ADR 0002 in `docs/adr/`). The `va_vulkan` cfg therefore enumerates the
+//! host target operating systems on which a Vulkan loader could exist, and runtime absence of the
+//! loader surfaces as `InitError::RuntimeUnavailable`. The three-state `VIRTIO_ACCEL_VULKAN`
+//! control and loud force-on failure semantics survive regardless.
+
+#![forbid(unsafe_code)]
+
+/// Host target operating systems on which a Vulkan loader may be dynamically loaded.
+const SUPPORTED_TARGETS: &[&str] = &["android", "linux", "macos", "windows"];
+
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(va_vulkan)");
+    println!("cargo:rerun-if-env-changed=VIRTIO_ACCEL_VULKAN");
+
+    let forced = match std::env::var("VIRTIO_ACCEL_VULKAN") {
+        Ok(value) if value == "0" => return,
+        Ok(value) if value == "1" => true,
+        Ok(other) => panic!("VIRTIO_ACCEL_VULKAN must be \"0\" or \"1\", not {other:?}"),
+        Err(_) => false,
+    };
+
+    let os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    if SUPPORTED_TARGETS.contains(&os.as_str()) {
+        println!("cargo::rustc-cfg=va_vulkan");
+    } else {
+        assert!(
+            !forced,
+            "VIRTIO_ACCEL_VULKAN=1 but target OS {os:?} is not a Vulkan loader host target"
+        );
+    }
+}

--- a/crates/virtio-accel-vulkan/examples/tosa_vulkan.rs
+++ b/crates/virtio-accel-vulkan/examples/tosa_vulkan.rs
@@ -1,0 +1,8 @@
+fn main() {
+    match virtio_accel_vulkan::VulkanAccelerator::new() {
+        Ok(_) => unreachable!("the scaffold placeholder never initializes a backend"),
+        Err(error) => {
+            eprintln!("virtio-accel-vulkan is scaffolded but not yet executing: {error}");
+        }
+    }
+}

--- a/crates/virtio-accel-vulkan/src/lib.rs
+++ b/crates/virtio-accel-vulkan/src/lib.rs
@@ -1,0 +1,62 @@
+//! Vendor-neutral Vulkan compute host backend for `virtio-accel`.
+//!
+//! **This is the scaffold.** It ships the always-compiled admission constants (`lower`) and a
+//! placeholder; the `ash`-based FFI, the native `Accelerator` implementation, and the advertised
+//! numerical tiers land in subsequent tickets of the
+//! [Vulkan wayfinder map](https://github.com/MicroPerceptron/virtio-accel/issues/154). The design
+//! decisions ratified by this scaffold live in [`docs/adr/`](../../../../docs/adr/) (ADRs 0001–0004).
+
+#![forbid(unsafe_code)]
+
+mod lower;
+
+pub use lower::{VULKAN_TOSA_INTEGER_TARGET, VULKAN_TOSA_TARGET};
+
+/// TOSA capability list: empty until the native path's advertised tiers are ratified (ticket 5)
+/// and proven by conformance (ticket 10). Compiled for every build, native or placeholder.
+const TOSA_CAPABILITIES: &[virtio_accel_tosa::CapabilityDescriptor] = &[];
+
+/// Providers with no finite residency bound promise the maximal charge; anything less would
+/// under-report `ArtifactRef::resident_bytes`.
+pub const REQUIRED_RESIDENT_BYTES: u64 = u64::MAX;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum InitError {
+    /// The native backend or the Vulkan loader could not be initialized.
+    RuntimeUnavailable,
+}
+
+impl core::fmt::Display for InitError {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::RuntimeUnavailable => write!(formatter, "no Vulkan loader initialized"),
+        }
+    }
+}
+
+impl std::error::Error for InitError {}
+
+use virtio_accel_tosa::TosaCapabilityProvider;
+
+/// Placeholder that keeps workspace consumers portable until the native backend lands.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct VulkanAccelerator;
+
+impl VulkanAccelerator {
+    /// Report that the native backend is not available in this build.
+    pub fn new() -> Result<Self, InitError> {
+        Err(InitError::RuntimeUnavailable)
+    }
+
+    /// Enumerate nothing in the scaffold; the native path reports one entry per
+    /// `ash`-enumerated physical device.
+    pub fn available_devices() -> Result<Vec<String>, InitError> {
+        Err(InitError::RuntimeUnavailable)
+    }
+}
+
+impl TosaCapabilityProvider for VulkanAccelerator {
+    fn tosa_capabilities(&self) -> &'static [virtio_accel_tosa::CapabilityDescriptor] {
+        TOSA_CAPABILITIES
+    }
+}

--- a/crates/virtio-accel-vulkan/src/lower.rs
+++ b/crates/virtio-accel-vulkan/src/lower.rs
@@ -1,0 +1,45 @@
+//! Planned advertised TOSA tiers for the Vulkan backend.
+//!
+//! These are *candidates* declared by the scaffold (ADR 0004 in `docs/adr/`): the FP32 base tier
+//! plus the provisional INT8 tier. An FP16 tier is deliberately undeclared until per-device
+//! `VK_KHR_shader_float_controls` evidence closes wayfinder ticket 5, and FP8 is rejected at
+//! admission. The final capability descriptors and operator subset table arrive with ticket 5.
+
+use virtio_accel_tosa::{ExtensionSet, Level, ProfileSet, Target, Version};
+
+/// The FP32 base tier: TOSA 1.0, floating-point profile, level 8K, no extensions.
+pub const VULKAN_TOSA_TARGET: Target = Target::new(
+    Version::TOSA_1_0,
+    ProfileSet::FLOATING_POINT,
+    Level::Level8K,
+    ExtensionSet::NONE,
+);
+
+/// The provisional integer tier: TOSA 1.0, integer profile, level 8K, no extensions.
+pub const VULKAN_TOSA_INTEGER_TARGET: Target = Target::new(
+    Version::TOSA_1_0,
+    ProfileSet::INTEGER,
+    Level::Level8K,
+    ExtensionSet::NONE,
+);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn targets_validate() {
+        assert_eq!(VULKAN_TOSA_TARGET.validate(), Ok(VULKAN_TOSA_TARGET));
+        assert_eq!(
+            VULKAN_TOSA_INTEGER_TARGET.validate(),
+            Ok(VULKAN_TOSA_INTEGER_TARGET)
+        );
+    }
+
+    #[test]
+    fn targets_survive_an_identity_round_trip() {
+        for target in [VULKAN_TOSA_TARGET, VULKAN_TOSA_INTEGER_TARGET] {
+            assert_eq!(Target::from_identity(target.to_identity()), Ok(target));
+        }
+    }
+}

--- a/crates/virtio-accel-vulkan/tests/vulkan.rs
+++ b/crates/virtio-accel-vulkan/tests/vulkan.rs
@@ -1,0 +1,56 @@
+//! Scaffold-level tests: the advertised target constants and the placeholder.
+//!
+//! Native lifecycle tests arrive with the `ash` FFI and hardware tickets. These run on every host.
+
+use virtio_accel_tosa::{ExtensionSet, ProfileSet, Target};
+use virtio_accel_vulkan::{
+    REQUIRED_RESIDENT_BYTES, VULKAN_TOSA_INTEGER_TARGET, VULKAN_TOSA_TARGET, VulkanAccelerator,
+};
+
+#[test]
+fn required_resident_bytes_is_maximal() {
+    assert_eq!(REQUIRED_RESIDENT_BYTES, u64::MAX);
+}
+
+#[test]
+fn advertised_targets_are_coherent_and_distinct() {
+    assert_eq!(VULKAN_TOSA_TARGET.validate(), Ok(VULKAN_TOSA_TARGET));
+    assert_eq!(
+        VULKAN_TOSA_INTEGER_TARGET.validate(),
+        Ok(VULKAN_TOSA_INTEGER_TARGET)
+    );
+    assert_ne!(VULKAN_TOSA_TARGET, VULKAN_TOSA_INTEGER_TARGET);
+}
+
+#[test]
+fn fp32_target_declares_the_floating_point_profile_and_no_extensions() {
+    assert!(
+        VULKAN_TOSA_TARGET
+            .profiles
+            .contains(ProfileSet::FLOATING_POINT)
+    );
+    assert_eq!(VULKAN_TOSA_TARGET.extensions, ExtensionSet::NONE);
+}
+
+#[test]
+fn integer_target_declares_the_integer_profile_and_no_extensions() {
+    assert!(
+        VULKAN_TOSA_INTEGER_TARGET
+            .profiles
+            .contains(ProfileSet::INTEGER)
+    );
+    assert_eq!(VULKAN_TOSA_INTEGER_TARGET.extensions, ExtensionSet::NONE);
+}
+
+#[test]
+fn targets_survive_an_identity_round_trip() {
+    for target in [VULKAN_TOSA_TARGET, VULKAN_TOSA_INTEGER_TARGET] {
+        assert_eq!(Target::from_identity(target.to_identity()), Ok(target));
+    }
+}
+
+#[test]
+fn placeholder_reports_runtime_unavailable() {
+    let error = VulkanAccelerator::new().unwrap_err();
+    assert_eq!(error, virtio_accel_vulkan::InitError::RuntimeUnavailable);
+}

--- a/docs/adr/0001-graph-shaped-data-plane.md
+++ b/docs/adr/0001-graph-shaped-data-plane.md
@@ -1,0 +1,47 @@
+# 1. Data-plane posture for GPU-class hardware: the graph shape is permanent
+
+- Status: accepted (ratifies the lean seeded in wayfinder map #154)
+- Resolves: wayfinder map #154, ticket 1 (grilling: data-plane posture for GPU-class hardware)
+
+## Context
+
+Protocol 1.0's data plane is graph-shaped: one submission is one opaque program artifact plus flat
+slot-to-range buffer bindings plus a relative timeout, yielding exactly one completion event. No
+command buffers, descriptor sets, barriers, fences, dispatch geometry, or cross-submission
+dependency edges are guest-visible. The first GPU-class decision is whether that shape is an
+NPU-era provisional to be reshaped toward GPU-native concepts, or the spec's permanent shape that
+GPU backends fit through like every other provider.
+
+## Decision
+
+The graph shape is ratified as the permanent shape. GPUs operate NPU-like for this protocol's
+purposes: whole-program artifacts, flat slot bindings, and one event per submission, implemented
+in the most performant way Vulkan allows. Guest-visible command primitives are never required for
+steady-state efficiency — pre-recorded command buffers, specialization constants, pooled
+descriptors, and fence polling are all provider-internal.
+
+## Rationale
+
+- Reshaping the submission payload is a category-3 breaking wire change (new protocol major;
+  `docs/wire-abi.md` §9) — deliberately expensive, classified before any code moves.
+- The GPU-flavored primitives already have deliberately reserved, unassigned feature bits
+  (`MULTI_QUEUE`, `EVENT_QUEUE`, `EXTERNAL_MEMORY`, `TIMELINE_FENCES`). If reshaping is ever
+  warranted, the sanctioned path is a protocol-change proposal through those bits (#113 is the
+  precedent: it designed the external-memory handoff and chose completion-gating over fences,
+  leaving values unassigned).
+- Hexagon (#77, #95, #96) is the existence proof that unlike hardware operates graph-shaped with
+  zero protocol change.
+
+## Falsifier
+
+The bet stays honest through tickets 6 (execution/event model) and 8 (identity end-to-end): if
+steady-state submission provably cannot meet performance budgets without guest-visible batching
+or dependency edges, that evidence feeds a protocol-change proposal through the reserved bits —
+never a backend workaround that leaks GPU concepts into the graph-shaped contract.
+
+## Consequences
+
+- The Vulkan backend stays strictly inside #126's non-goals: no wire-ABI or portable-contract
+  change.
+- Any Protocol 1.0 document wording this resolution touches is erratum-class (category 1: no
+  accepted or emitted bytes change).

--- a/docs/adr/0002-vulkan-binding-ash.md
+++ b/docs/adr/0002-vulkan-binding-ash.md
@@ -1,0 +1,56 @@
+# 2. Vulkan binding strategy: `ash` with runtime loader discovery
+
+- Status: accepted
+- Resolves: wayfinder map #154, ticket 2 (grilling: ratify the Vulkan binding strategy) and the
+  crate layout convention question carried by ticket 7 (scaffold)
+
+## Context
+
+The workspace convention for host-native FFI is a small hand-written `ffi.rs` declaring only the
+validated subset (OpenVINO's is 171 lines; XDNA's declares only the hardware-validated HRX
+subset). Vulkan's surface is far larger than any prior target's validated subset. The map's
+scouting table (recorded 2026-08-27) evaluated `ash`, `vulkanalia`, `vulkano`, `erupt`, `wgpu`,
+`gpu-allocator`, `vk-mem`, and `rspirv`; this decision ratifies its `ash` lean and settles the
+build-time gate that the scaffold (`virtio-accel-vulkan`) is built on.
+
+## Decision
+
+- Bind Vulkan through `ash` when the FFI lands (ticket 8), pinned to an exact version. The
+  `loaded` feature only: the platform Vulkan loader is dynamically loaded at runtime via
+  `libloading` — no Vulkan-Headers, no SDK at build time, no link-time dependency.
+- The audit posture moves with the declarations: `SAFETY.md` pins the `ash` version, the entry
+  points actually used, and the invariants this crate owns around them (one owner plus `Drop` per
+  handle; status checked before out-parameters are trusted). The release-policy
+  discussion-and-evidence requirement for the new unsafe exception is discharged alongside the FFI
+  landing (tickets 2/8); the scaffold compiles no `unsafe` at all.
+- `gpu-allocator` is deferred to evidence: it is adopted only if allocation probing (tickets 3 and
+  8) shows `maxMemoryAllocationCount` pressure; `vk-mem` stays rejected; `vulkanalia` remains the
+  named fallback if `ash` vetting fails at ticket 8.
+
+## Convention question resolved
+
+With `ash` under `loaded` there is nothing to detect at build time, so the `va_vulkan` cfg cannot
+probe an SDK the way `va_openvino`, `va_hexagon`, or `va_xdna` do. The three-state env control and
+loud force-on failure semantics are preserved without a file probe:
+
+- `VIRTIO_ACCEL_VULKAN=0` forces the placeholder everywhere;
+- `VIRTIO_ACCEL_VULKAN=1` forces the native path, and the build fails loudly when the target OS is
+  outside the enumerated supported host set;
+- unset is auto: the native path compiles on enumerated host targets, the placeholder elsewhere.
+
+The supported set is enumerated in `build.rs` (Linux, Android, Windows, and macOS). Runtime
+presence is discovered by loader lookup at run time and reported as
+`InitError::RuntimeUnavailable`; it is never a compile-time property. This differs from the
+SDK-probing backends only in what "detection" means, and `docs/portability.md` carries the
+Vulkan-specific note that the `host-native` tier wording demands.
+
+## Rationale
+
+- `ash` is the ecosystem-standard raw binding (wgpu sits on it; 33M+ downloads), thin and
+  dependency-light enough to survive `deny.toml`'s `multiple-versions = "deny"` gate, and MIT OR
+  Apache-2.0 licensed. A hand-written subset would put a much larger unsafe surface under in-tree
+  audit with no validated subset worth the name; `ash` moves the raw declarations out of tree and
+  shrinks `SAFETY.md` to the entry points actually used.
+- Runtime discovery over build-time probe: the issue's own scope (see #126) requires that the
+  workspace builds and tests on hosts with no Vulkan SDK; a loader lookup at run time makes the
+  GPU-less CI lane (lavapipe) and the real-GPU lane identical code paths.

--- a/docs/adr/0003-tosa-lowering-specialized-shaders.md
+++ b/docs/adr/0003-tosa-lowering-specialized-shaders.md
@@ -1,0 +1,34 @@
+# 3. TOSA→SPIR-V lowering: checked-in shaders specialized by constants
+
+- Status: accepted (with falsification trigger)
+- Resolves: wayfinder map #154, ticket 4 (grilling: program representation and lowering mechanism)
+
+## Context
+
+XDNA requires a bounded out-of-process compiler because `aiecc` is Python; Hexagon similarly
+bridges QAIRT. Vulkan compute needs neither: per-operator SPIR-V compute shaders can be authored
+once, precompiled, and checked into the crate; shapes and tiling are then bound at compile-free
+specialization. TOSA-only artifacts stay the v1 admission format (#126 decision 2); a
+SPIR-V-direct format is a deliberate follow-on, never smuggled in.
+
+## Decision
+
+- Program compilation: per-operator SPIR-V compute shaders checked into the crate, specialized at
+  `load_program` via Vulkan specialization constants. No toolchain on the serving host, no
+  subprocess, no Python.
+- `VkShaderModule` and `VkComputePipeline` creation happens at `load_program`, never during
+  `submit`. Retained pipelines, command buffers, and descriptor pools are charged against
+  `ArtifactRef::resident_bytes`. The `VkPipelineCache` policy defaults to none unless ticket 8
+  measures a need, since pipeline creation cost is paid once per program at load.
+- Security invariant recorded: guest bytes never reach the driver's shader compiler. The driver
+  consumes only crate-authored SPIR-V parameterized by validated shapes — the threat-model's
+  transient-compile-budget clause (`docs/threat-model.md`).
+- `spirv-tools`/`naga` are dev-dependencies at most, for CI validation of the checked-in SPIR-V.
+  Runtime `rspirv` emission at load remains the documented fallback.
+
+## Falsification trigger
+
+If any advertised operator needs structure that specialization constants cannot express (for
+example data-dependent control flow), the fallback to `rspirv` load-time emission is reopened as
+a design note before operator work (ticket 9) proceeds. Until that trigger fires, the checked-in
+shader approach holds.

--- a/docs/adr/0004-first-tier-candidates.md
+++ b/docs/adr/0004-first-tier-candidates.md
@@ -1,0 +1,25 @@
+# 4. First advertised numerical tier: FP32 base, INT8 candidate, FP16 deferred
+
+- Status: provisional (declares the scaffold's `Target` constants; wayfinder map #154 ticket 5
+  closes on per-ICD float-controls evidence before operator work in ticket 9)
+- Resolves: nothing final; records the candidate set the scaffold compiles
+
+## Decision
+
+- **FP32 base tier** (`VULKAN_TOSA_TARGET`): TOSA 1.0, floating-point profile, no extensions.
+  Universal across Vulkan 1.x; the floor every advertised tier list contains.
+- **INT8 tier candidate** (`VULKAN_TOSA_INTEGER_TARGET`): TOSA 1.0, integer profile, no
+  extensions; gated per device on `shaderInt8` (plus `VK_KHR_shader_integer_dot_product` for
+  MATMUL). Declared as a scaffold candidate pending the operator subset table ticket 5 must
+  produce.
+- **FP16 deferred**: no FP16 target constant is declared. A device may offer it only when
+  `shaderFloat16` (`VK_KHR_shader_float16_int8`) and `VK_KHR_shader_float_controls` probing prove
+  the shared corpus's non-finite, subnormal, and signed-zero edges (`IDENTITY_EDGES_*`). That is
+  per-tier evidence, not an assumption, and it is checked per lane in the CI ticket.
+- **FP8**: rejected loudly at admission; no portable Vulkan path exists.
+
+## Consequences
+
+- The scaffold exports exactly the two constants above from `crates/virtio-accel-vulkan/src/lower.rs`,
+  so hardware-free golden lowering tests have a stable footing before the capability descriptors
+  and operator table arrive with ticket 5's close.

--- a/docs/portability.md
+++ b/docs/portability.md
@@ -38,7 +38,7 @@ directly, and they must keep working on any platform the portable crates support
 | `core-only` | `virtio-accel-cleanroom`, `virtio-accel-proto`, `virtio-accel-transport`, `virtio-accel-core` | `core`; the clean-room codec and transport ports have no normal/build dependencies, while proc-macros used by other crates may execute with `std` on the build host |
 | `alloc-portable` | `virtio-accel-guest`, `virtio-accel-split-queue`, `virtio-accel-device`, `virtio-accel-tosa`, `virtio-accel-tosa-build`, `virtio-accel` | `core + alloc`; no OS, filesystem, sockets, threads, or host synchronization |
 | `std-reference` | `virtio-accel-mock`, `virtio-accel-conformance` | Portable `std`; no host-OS or vendor-specific API |
-| `host-native` | `virtio-accel-coreml`, `virtio-accel-openvino`, `virtio-accel-hexagon`, `virtio-accel-xdna` | Core ML/Foundation on macOS 14+, the OpenVINO C runtime (`libopenvino_c` 2026.x), the complete QAIRT/QNN C SDK on Windows ARM64, or the amdxdna-native HRX runtime (`libhrx`) when detected at build time; a compile-only unsupported-platform or unsupported-runtime placeholder elsewhere |
+| `host-native` | `virtio-accel-coreml`, `virtio-accel-openvino`, `virtio-accel-hexagon`, `virtio-accel-xdna`, `virtio-accel-vulkan` | Core ML/Foundation on macOS 14+, the OpenVINO C runtime (`libopenvino_c` 2026.x), the complete QAIRT/QNN C SDK on Windows ARM64, the amdxdna-native HRX runtime (`libhrx`), or a dynamically loaded Vulkan loader (via `ash`) on the build.rs-enumerated host targets; a compile-only unsupported-platform or unsupported-runtime placeholder elsewhere |
 
 No host-native crate is a dependency of the facade or any portable layer. The Core ML crate's
 Objective-C bridge and TOSA-to-Core ML model compilation are built only when the Cargo target is
@@ -108,6 +108,14 @@ is represented as explicit per-slot padding in the compiled artifact, never as h
 submission-time staging. Tile-compatible MATMUL shapes widen/subtract zero points on the NPU and
 use the native 4x4x8 INT16 matrix unit; smaller shapes and exact 64-bit RESCALE arithmetic use
 scalar on-NPU kernels. RESCALE clears the at-most-three-byte padded output tail on the NPU.
+
+The Vulkan crate is a scaffold: it compiles its planned `Target` constants (`lower`) and a
+placeholder on every host. Unlike the SDK-probing backends, there is nothing to detect at build
+time — `ash` (planned for the FFI ticket) loads the platform's Vulkan loader dynamically at run
+time — so the `va_vulkan` cfg enumerates the host target operating systems (Linux, Android,
+Windows, macOS) and runtime loader absence surfaces as `InitError::RuntimeUnavailable`.
+`VIRTIO_ACCEL_VULKAN=0` forces the placeholder everywhere; `VIRTIO_ACCEL_VULKAN=1` makes an
+unsupported target a loud build failure; unset is auto (ADR 0002 in `docs/adr/`).
 
 Concrete VMM, kernel, OS, and vendor adapters are outside the portable-v1 milestone and must not
 become default dependencies of a portable crate.

--- a/docs/release-policy.md
+++ b/docs/release-policy.md
@@ -140,7 +140,7 @@ declares its own `description` and `readme`, and carries its own byte-identical 
 root license files do not reach the sub-crate tarballs; the copies exist for that reason and are
 copies rather than symlinks because CI runs `windows-latest`.
 
-`ci/check-release-policy.py` enforces all of this against an explicit seventeen-crate allowlist. A new
+`ci/check-release-policy.py` enforces all of this against an explicit eighteen-crate allowlist. A new
 package fails that check until it is added to the allowlist, which forces a decision about whether
 it is public rather than letting it default either way. The check also validates the crates.io
 keyword and category limits, which neither `cargo package` nor `cargo publish --dry-run` catches
@@ -150,7 +150,8 @@ The `fuzz/` harness is a separate workspace at version `0.0.0` and stays `publis
 
 ## Publication, yank, and rollback
 
-Seventeen packages are published to crates.io. Publication is ordered: a crate cannot be published before
+Eighteen packages are published to crates.io. Publication is ordered: a crate cannot be published
+before
 every crate it depends on, and that includes development dependencies, because a published crate's
 versioned dev-dependencies must resolve from the registry for `cargo test` to run on the packaged
 source.
@@ -173,14 +174,15 @@ source.
 | 14 | `virtio-accel-coreml` | `core`, `tosa` | `conformance` |
 | 15 | `virtio-accel-openvino` | `core`, `tosa` | `conformance` |
 | 16 | `virtio-accel-hexagon` | `core`, `tosa` | `conformance` |
-| 17 | `virtio-accel` | the six runtime crates | `conformance`, `mock`, `cleanroom` |
+| 17 | `virtio-accel-vulkan` | `core`, `tosa` | `conformance` |
+| 18 | `virtio-accel` | the six runtime crates | `conformance`, `mock`, `cleanroom` |
 
 This order is executable, not just documentary: `ci/publish-dry-run.py` walks it against an isolated
 local registry, adding each crate only after it has been built, tested, and documented from its own
 extracted tarball. A crate can therefore only ever resolve its predecessors, so a wrong order fails
 with an unresolvable dependency instead of passing quietly. The same script is a required CI job.
 
-All seventeen packages share the workspace version and are published together. A GitHub release tag
+All eighteen packages share the workspace version and are published together. A GitHub release tag
 must be exactly `v<workspace-version>` and must point at the commit being released. Publishing a
 GitHub release triggers `.github/workflows/publish.yml`, which checks out that tag, runs the release
 policy checks and publication-driver tests, repeats the full ordered local-registry dry run on the


### PR DESCRIPTION
Part of wayfinder map #154 ticket 7 (scaffold). Resolves map tickets 1, 2, and 4 as ADRs; declares ticket 5's scaffold constants as provisional candidates.

## Why

The Vulkan backend can't grow without a landing foundation: build-time gate, placeholder, admission constants, and release plumbing. ADRs 1–4 resolve the map's first four grilling tickets in one reviewable change; the scaffold proves-by-building that the foundation holds.

## What

- **ADRs** (`docs/adr/0001–0004`):
  - 0001: graph-shaped data plane ratified as the spec's permanent shape — GPUs operate NPU-like, whole-program + flat bindings + one event; falsifier: tickets 6/8 must prove this can't be met before any protocol-change proposal; any 1.0-document wording needed is erratum-class.
  - 0002: `ash` via `loaded` feature (dlopens Vulkan loader at runtime; no SDK at build time); the convention question resolved — `va_vulkan` emit-by-target-enumeration (Linux/Android/Windows/macOS) with loud force-on failure on unsupported targets; runtime loader discovery reports `InitError::RuntimeUnavailable`.
  - 0003: checked-in per-operator SPIR-V in the crate, specialized at `load_program`; `VkShaderModule`/`VkComputePipeline` at `load_program`, never `submit`; retained pipelines/CBs/descriptor pools charged against `ArtifactRef::resident_bytes`; `rspirv` fallback recorded.
  - 0004 (provisional): FP32 base + INT8 candidate; FP16 deferred per float-controls (with `rspirv`); FP8 rejected at admission.
- **Scaffold crate** `crates/virtio-accel-vulkan`: `<core,tosa>` deps, `<conformance>` dev-dep, no features; build.rs gated enumeration probe; `#![forbid(unsafe_code)]` placeholder returning `InitError::RuntimeUnavailable`; empty `TosaCapabilityProvider`; `lower.rs` two `Target` consts.
- **Plumbing**: workspace members/deps (18 crates), `PUBLISHED_PACKAGES` + `PUBLISH_ORDER` (vulkan at 17, facade 18), README/crate table/dependency graph/Vulkan section, `docs/portability.md` row + target-enumeration note (ADR 0002), `docs/release-policy.md` count bump, `CONTRIBUTING` gate list.

## Validation

- `cargo fmt --check`, `python3 ci/check-release-policy.py` (18 packages), clippy, workspace tests excluding `virtio-accel-coreml` (known environment failures, low-level), crate tests: 6 integration + 2 unit pass.
- `ci/publish-dry-run.py` validates vulkan at position 12/18 pre-reorder (then reverted); the full ordered run is blocked upstream by the pre-existing coreml failures.
