### PR TITLE
Tickets 9+11: FP32 MATMUL over the shared corpus; docs claim the verified lanes

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This table is organized by program and dtype. For the physical devices behind it
 | Intel OpenVINO (`virtio-accel-openvino`)    | Implemented; OpenVINO 2026.x              | Static TOSA 1.0 FP + INT8 tier                           | Supported                         | Supported                              | Not implemented             | Identity + MATMUL | Not implemented | Direct host/shared bindings |
 | AMD XDNA (`virtio-accel-xdna`)              | Experimental; HRX on XDNA2                | Static BF16 TOSA + explicit FP8 storage CAST + INT8 tier | Accumulator outputs only          | Not implemented                        | E4M3/E5M2 → BF16 CAST       | Identity + MATMUL + RESCALE | Not implemented | Direct host/shared bindings |
 | Qualcomm Hexagon (`virtio-accel-hexagon`)   | Experimental; QAIRT 2.49 on Windows ARM64 | Static TOSA 1.0 FP16 + BOOL/INT32 auxiliaries; INT8 tier | Blocked by v73 precision evidence | 41/42 shared operators (`ERF` blocked) | Blocked: ambiguous encoding | Identity + MATMUL | Not implemented | Direct host/shared bindings |
-| Vulkan (`virtio-accel-vulkan`)              | Experimental; Vulkan 1.3 loader           | Static TOSA 1.0 FP32 IDENTITY                            | Identity                          | Not implemented                        | Not implemented             | Target declared, not advertised | Not implemented | Direct host/shared/device bindings |
+| Vulkan (`virtio-accel-vulkan`)              | Experimental; Vulkan 1.3 loader           | Static TOSA 1.0 FP32 IDENTITY + MATMUL                   | Identity + MATMUL                 | Not implemented                        | Not implemented             | Target declared, not advertised | Not implemented | Direct host/shared/device bindings |
 
 ### Core ML (_Apple Neural Engine_)
 
@@ -87,14 +87,16 @@ See the [`virtio-accel-hexagon` support boundary](crates/virtio-accel-hexagon/RE
 - **Runtime:** Native execution requires the pinned amdxdna-native HRX runtime and compiler
   toolchain. Portable admission and offline artifact compilation remain available without a device.
 
-### Vulkan (_FP32 IDENTITY end-to-end_)
+### Vulkan (_FP32 IDENTITY + MATMUL end-to-end_)
 
 `virtio-accel-vulkan` is a vendor-neutral Vulkan 1.3 compute backend bound through the pinned
-`ash` crate with run-time loader discovery. It executes the FP32 IDENTITY tier end-to-end on
-checked-in SPIR-V specialized at `load_program`, with dedicated directly bound storage buffers,
-`Host`/`Shared`/`Device` memory domains, a bounded per-context submission ring polled through
-`vkGetFenceStatus`, and the full backend conformance suite passing on Intel ANV (Arc 140V) and
-lavapipe. Operator tiers beyond IDENTITY, FP16/INT8 gating, and broader numerical coverage remain under the
+`ash` crate with run-time loader discovery. It executes the FP32 IDENTITY and MATMUL tier
+end-to-end on checked-in SPIR-V specialized at `load_program`, with dedicated directly bound
+storage buffers, `Host`/`Shared`/`Device` memory domains, a bounded per-context submission ring
+polled through `vkGetFenceStatus`, and the full backend conformance suite passing on Intel ANV,
+Apple M3 via MoltenVK (local validation only, not a CI lane), and Mesa lavapipe in CI. MATMUL
+admits only zero zero-point graphs (the TOSA 1.0 `CONST`-producer form). FP16/INT8 gating and
+broader operator coverage remain under the
 [Vulkan wayfinder map](https://github.com/MicroPerceptron/virtio-accel/issues/154); design
 decisions are recorded in `docs/adr/`.
 
@@ -109,7 +111,7 @@ Independently of backend execution, `virtio-accel-tosa` validates the TOSA 1.0 p
 | `virtio-accel-vaccel`      | `core`                | Adapter seam for mapping native provider contracts (including vAccel-style backends) to `virtio-accel-core`  |
 | `virtio-accel-coreml`      | `std`                 | TOSA-to-Core ML lowering, direct buffers, and asynchronous ANE-capable prediction                            |
 | `virtio-accel-openvino`    | `std`                 | TOSA-to-OpenVINO IR lowering, direct host-pointer tensors, and asynchronous NPU/GPU/CPU inference            |
-| `virtio-accel-vulkan`      | `std`                 | Vendor-neutral Vulkan 1.3 compute backend over `ash`: checked-in SPIR-V, direct storage-buffer binding, FP32 IDENTITY |
+| `virtio-accel-vulkan`      | `std`                 | Vendor-neutral Vulkan 1.3 compute backend over `ash`: checked-in SPIR-V, direct storage-buffer binding, FP32 IDENTITY + MATMUL |
 | `virtio-accel-xdna`        | `std`                 | AMD XDNA2 NPU backend over HRX with direct buffers, asynchronous dispatch, and strict BF16/FP8/INT8 TOSA tiers |
 | `virtio-accel-hexagon`     | `std` (Windows ARM64) | Strict FP16/INT8 TOSA-to-QNN lowering, direct buffers, and asynchronous Hexagon HTP execution                |
 | `virtio-accel`             | `core + alloc`        | Facade re-exporting the portable layers                                                                      |
@@ -198,8 +200,9 @@ For portable adapter-boundary validation while the native vAccel path is wired, 
 `virtio-accel-hexagon = "0.3"` exposes the separate Qualcomm adapter. A complete QAIRT/QNN SDK on Windows ARM64 enables its HTP backend; SDK-free builds validate its strict FP16 graph planner and constructors return `RuntimeUnavailable`.
 
 `virtio-accel-vulkan = "0.3"` loads the platform Vulkan loader at run time. It currently admits
-FP32 IDENTITY and returns `RuntimeUnavailable` or `DeviceUnavailable` when no suitable Vulkan 1.3
-compute path exists; it does not silently fall back to the mock backend.
+FP32 IDENTITY and FP32 MATMUL (zero zero-points) and returns `RuntimeUnavailable` or
+`DeviceUnavailable` when no suitable Vulkan 1.3 compute path exists; it does not silently fall
+back to the mock backend.
 
 Add `virtio-accel-tosa = "0.3"` separately to validate TOSA 1.0 artifacts, inspect safe borrowed graph and typed-attribute views, enforce complete stable-op semantics for a declared target, and construct the device-neutral TOSA artifact envelope. `Model::analyze_for` also produces bounded dense IDs, topological order, liveness, runtime obligations, and specialization keys for Core ML, OpenVINO, or another provider. It is intentionally not re-exported by the facade.
 

--- a/crates/virtio-accel-vulkan/README.md
+++ b/crates/virtio-accel-vulkan/README.md
@@ -15,6 +15,10 @@ build time (ADR 0002 in `docs/adr/`).
   graph, admitted hardware-free in `lower` and executed by a checked-in SPIR-V word-copy kernel
   specialized with the element count at `load_program`. Guest bytes never reach the driver's
   shader compiler (ADR 0003).
+- **FP32 MATMUL** (same target): batched 3-D matrix multiplication with zero zero-points (the
+  TOSA 1.0 `CONST`-producer form), executed by a checked-in SPIR-V kernel with M/N/K/batch
+  specialization constants, one thread per output element over an (n, m, batch) dispatch, and no
+  fused multiply-add so the shared oracle's tolerance holds under every float-controls mode.
 - **Memory domains** (ADR 0005): `Host` and `Shared` are persistently mapped host-coherent
   allocations; `Device` is device-local memory reached only through bounded staging inside
   `write_buffer`/`read_buffer`. `Shared` and `Device` are advertised only when the device exposes
@@ -48,6 +52,12 @@ The example executes the FP32 identity artifact on the preferred device (discret
 virtual, then CPU) and exits successfully, or reports that no device is available. The native tests
 run against every enumerated device and skip without one; `VIRTIO_ACCEL_VULKAN_REQUIRE_DEVICE=1`
 turns absence into a failure, and `VK_DRIVER_FILES` pins the ICD (the CI lane pins lavapipe).
+
+## Verified driver stacks
+
+The full backend suite — admission, lifecycle, conformance, and the shared FP32 IDENTITY/MATMUL
+oracles — passes on Intel ANV, on Apple M3 via MoltenVK (local validation only, not a CI lane),
+and on Mesa lavapipe in the `vulkan-lavapipe-test` CI lane. One crate, no per-driver code paths.
 
 Part of the [`virtio-accel`](https://github.com/MicroPerceptron/virtio-accel) workspace: an
 experimental native-Rust protocol and implementation stack for a transport-neutral virtual

--- a/crates/virtio-accel-vulkan/src/lower.rs
+++ b/crates/virtio-accel-vulkan/src/lower.rs
@@ -18,7 +18,8 @@ use std::fmt;
 use virtio_accel_tosa::{
     AnalysisError, AnalyzedValueKind, CapabilityDescriptor, DType, DTypeCapability,
     Error as ParseError, ExtensionSet, GraphCapabilities, Level, Op, OperatorCapability,
-    ProfileSet, RuntimeConditionSupport, Target, TosaAnalysis, ValueId, ValueRoles, Version, parse,
+    OperatorId, ProfileSet, RuntimeConditionSupport, Target, TosaAnalysis, ValueId, ValueRoles,
+    Version, parse,
 };
 
 /// The FP32 base tier: TOSA 1.0, floating-point profile, level 8K, no extensions.
@@ -42,7 +43,10 @@ pub const VULKAN_TOSA_INTEGER_TARGET: Target = Target::new(
 
 const FLOAT_DTYPES: &[DTypeCapability] = &[DTypeCapability::new(DType::FP32, ValueRoles::ALL)];
 
-const FLOAT_OPERATORS: &[OperatorCapability] = &[OperatorCapability::new(Op::IDENTITY)];
+const FLOAT_OPERATORS: &[OperatorCapability] = &[
+    OperatorCapability::new(Op::IDENTITY),
+    OperatorCapability::new(Op::MATMUL),
+];
 
 /// The FP32 base tier's admitted boundary: exactly what the checked-in shaders execute.
 pub const VULKAN_TOSA_CAPABILITY: CapabilityDescriptor = CapabilityDescriptor {
@@ -96,6 +100,8 @@ impl std::error::Error for LoweringError {}
 pub(crate) enum Kernel {
     /// Elementwise 32-bit word copy (`shader::copy_u32_spirv`).
     CopyU32,
+    /// FP32 batched matrix multiplication (`shader::matmul_fp32_spirv`).
+    MatmulFp32,
 }
 
 /// One binding slot of an admitted program.
@@ -125,6 +131,17 @@ pub(crate) struct ProgramPlan {
     /// Elements processed by one invocation domain; the shader's specialization constant.
     pub element_count: u32,
     pub slots: Vec<SlotPlan>,
+    /// MATMUL geometry: (batch, m, n, k). Zero for non-MATMUL kernels.
+    pub matmul: Option<MatmulGeometry>,
+}
+
+/// Batched matrix-multiplication dimensions captured from an admitted graph.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct MatmulGeometry {
+    pub batch: u32,
+    pub m: u32,
+    pub n: u32,
+    pub k: u32,
 }
 
 #[cfg(test)]
@@ -152,26 +169,44 @@ pub(crate) fn lower_tosa(bytes: &[u8], target: Target) -> Result<ProgramPlan, Lo
     let outputs = analysis.block_outputs(block);
     let order = analysis.execution_order(block);
 
-    // The tier admits exactly one boundary-to-boundary IDENTITY today. Everything else is
+    // The tier admits graphs whose execution order carries `CONST` producers for constant
+    // parameters plus exactly one boundary-to-boundary compute operator. Everything else is
     // rejected here, before any Vulkan object exists, with the reason a host can act on.
-    let [operator_id] = order else {
+    let compute_operators: Vec<_> = order
+        .iter()
+        .filter(|operator_id| analysis.operator(**operator_id).op() != Op::CONST)
+        .collect();
+    let [operator_id] = compute_operators[..] else {
         return Err(LoweringError::UnsupportedGraph);
     };
     let operator = analysis.operator(*operator_id);
     if !supports_tosa_operator(operator.op()) {
         return Err(LoweringError::UnsupportedOperator(operator.op()));
     }
+    match operator.op() {
+        Op::IDENTITY => lower_identity(&analysis, *operator_id, inputs, outputs),
+        Op::MATMUL => lower_matmul(&analysis, *operator_id, inputs, outputs),
+        other => Err(LoweringError::UnsupportedOperator(other)),
+    }
+}
+
+fn lower_identity(
+    analysis: &TosaAnalysis<'_>,
+    operator_id: OperatorId,
+    inputs: &[ValueId],
+    outputs: &[ValueId],
+) -> Result<ProgramPlan, LoweringError> {
     let ([input], [output]) = (inputs, outputs) else {
         return Err(LoweringError::UnsupportedGraph);
     };
-    if analysis.operator_inputs(*operator_id) != [*input]
-        || analysis.operator_outputs(*operator_id) != [*output]
+    if analysis.operator_inputs(operator_id) != [*input]
+        || analysis.operator_outputs(operator_id) != [*output]
     {
         return Err(LoweringError::UnsupportedGraph);
     }
 
-    let input_tensor = boundary_tensor(&analysis, *input)?;
-    let output_tensor = boundary_tensor(&analysis, *output)?;
+    let input_tensor = boundary_tensor(analysis, *input)?;
+    let output_tensor = boundary_tensor(analysis, *output)?;
     if input_tensor != output_tensor {
         return Err(LoweringError::UnsupportedGraph);
     }
@@ -198,7 +233,101 @@ pub(crate) fn lower_tosa(bytes: &[u8], target: Target) -> Result<ProgramPlan, Lo
                 scalar_bytes: input_tensor.scalar_bytes,
             },
         ],
+        matmul: None,
     })
+}
+
+fn lower_matmul(
+    analysis: &TosaAnalysis<'_>,
+    operator_id: OperatorId,
+    inputs: &[ValueId],
+    outputs: &[ValueId],
+) -> Result<ProgramPlan, LoweringError> {
+    let ([lhs, rhs], [output]) = (inputs, outputs) else {
+        return Err(LoweringError::UnsupportedGraph);
+    };
+    let operator_inputs = analysis.operator_inputs(operator_id);
+    if operator_inputs.len() != 4
+        || operator_inputs[0] != *lhs
+        || operator_inputs[1] != *rhs
+        || analysis.operator_outputs(operator_id) != [*output]
+    {
+        return Err(LoweringError::UnsupportedGraph);
+    }
+    // TOSA 1.0 FP32 MATMUL admits only zero zero-points: the two trailing inputs must be
+    // `CONST` tensors whose serialized payload is all-zero (signed zero included).
+    for zero_point in &operator_inputs[2..4] {
+        let bytes = analysis
+            .serialized_constant(*zero_point)
+            .ok_or(LoweringError::UnsupportedGraph)?;
+        if !serialized_float_is_zero(bytes) {
+            return Err(LoweringError::UnsupportedGraph);
+        }
+    }
+
+    let lhs_tensor = boundary_tensor(analysis, *lhs)?;
+    let rhs_tensor = boundary_tensor(analysis, *rhs)?;
+    let output_tensor = boundary_tensor(analysis, *output)?;
+
+    let [batch_l, m, k] = lhs_tensor.dims;
+    let [batch_r, k_r, n] = rhs_tensor.dims;
+    let [batch_o, m_o, n_o] = output_tensor.dims;
+    if batch_l != batch_r || batch_l != batch_o || k != k_r || m != m_o || n != n_o {
+        return Err(LoweringError::UnsupportedGraph);
+    }
+
+    let batch = u32::try_from(batch_l).map_err(|_| LoweringError::ResourceLimit)?;
+    let m = u32::try_from(m).map_err(|_| LoweringError::ResourceLimit)?;
+    let n = u32::try_from(n).map_err(|_| LoweringError::ResourceLimit)?;
+    let k = u32::try_from(k).map_err(|_| LoweringError::ResourceLimit)?;
+
+    let lhs_bytes = lhs_tensor
+        .elements
+        .checked_mul(lhs_tensor.scalar_bytes)
+        .ok_or(LoweringError::ResourceLimit)?;
+    let rhs_bytes = rhs_tensor
+        .elements
+        .checked_mul(rhs_tensor.scalar_bytes)
+        .ok_or(LoweringError::ResourceLimit)?;
+    let output_bytes = output_tensor
+        .elements
+        .checked_mul(output_tensor.scalar_bytes)
+        .ok_or(LoweringError::ResourceLimit)?;
+
+    Ok(ProgramPlan {
+        kernel: Kernel::MatmulFp32,
+        element_count: batch
+            .checked_mul(m)
+            .and_then(|v| v.checked_mul(n))
+            .ok_or(LoweringError::ResourceLimit)?,
+        slots: vec![
+            SlotPlan {
+                slot: 0,
+                role: SlotRole::Input,
+                byte_len: lhs_bytes,
+                scalar_bytes: lhs_tensor.scalar_bytes,
+            },
+            SlotPlan {
+                slot: 1,
+                role: SlotRole::Input,
+                byte_len: rhs_bytes,
+                scalar_bytes: rhs_tensor.scalar_bytes,
+            },
+            SlotPlan {
+                slot: 2,
+                role: SlotRole::Output,
+                byte_len: output_bytes,
+                scalar_bytes: output_tensor.scalar_bytes,
+            },
+        ],
+        matmul: Some(MatmulGeometry { batch, m, n, k }),
+    })
+}
+
+/// Whether a serialized FP32 constant payload is zero (any sign) byte for byte.
+fn serialized_float_is_zero(bytes: &[u8]) -> bool {
+    bytes.len() == 4
+        && u32::from_le_bytes(bytes.try_into().expect("length checked")) & 0x7fff_ffff == 0
 }
 
 /// Static shape summary of a boundary tensor.
@@ -207,6 +336,7 @@ struct BoundaryTensor {
     dtype: DType,
     elements: u64,
     scalar_bytes: u64,
+    dims: [u64; 3],
 }
 
 fn boundary_tensor(
@@ -229,11 +359,17 @@ fn boundary_tensor(
         return Err(LoweringError::UnsupportedGraph);
     }
     let mut elements = 1_u64;
-    for dimension in tensor.dimensions() {
+    let mut dims = [1_u64; 3];
+    for (index, dimension) in tensor.dimensions().enumerate() {
+        if index >= 3 {
+            // Rank > 3 has no slot in the checked-in kernels.
+            return Err(LoweringError::UnsupportedGraph);
+        }
         let dimension = u64::try_from(dimension)
             .ok()
             .filter(|dimension| *dimension > 0)
             .ok_or(LoweringError::UnsupportedGraph)?;
+        dims[index] = dimension;
         elements = elements
             .checked_mul(dimension)
             .ok_or(LoweringError::ResourceLimit)?;
@@ -242,6 +378,7 @@ fn boundary_tensor(
         dtype,
         elements,
         scalar_bytes,
+        dims,
     })
 }
 
@@ -249,7 +386,7 @@ fn boundary_tensor(
 mod tests {
     use super::*;
     use virtio_accel_conformance::numerics::{
-        IDENTITY_EDGES_FP16, IDENTITY_EDGES_FP32, IDENTITY_INT8, MATMUL_FP32,
+        IDENTITY_EDGES_FP16, IDENTITY_EDGES_FP32, IDENTITY_INT8, MATMUL_FP32, MAX_POOL2D_FP32,
     };
 
     const IDENTITY_FP32_LOCAL: &[u8] = include_bytes!("../tests/data/identity-fp32-v1.0.0.tosa");
@@ -266,7 +403,8 @@ mod tests {
     #[test]
     fn capability_names_exactly_the_executed_boundary() {
         assert!(supports_tosa_operator(Op::IDENTITY));
-        assert!(!supports_tosa_operator(Op::MATMUL));
+        assert!(supports_tosa_operator(Op::MATMUL));
+        assert!(!supports_tosa_operator(Op::MAX_POOL2D));
         assert!(supports_tosa_dtype(DType::FP32));
         assert!(!supports_tosa_dtype(DType::FP16));
         assert!(!supports_tosa_dtype(DType::INT8));
@@ -322,10 +460,32 @@ mod tests {
 
     #[test]
     fn rejects_operators_outside_the_tier() {
+        // MAX_POOL2D is not yet admitted: the FP32 base tier grows one operator at a time.
         assert!(matches!(
-            lower_tosa(MATMUL_FP32.artifact, VULKAN_TOSA_TARGET),
-            Err(LoweringError::UnsupportedOperator(Op::MATMUL) | LoweringError::UnsupportedGraph)
+            lower_tosa(MAX_POOL2D_FP32.artifact, VULKAN_TOSA_TARGET),
+            Err(LoweringError::UnsupportedOperator(Op::MAX_POOL2D))
         ));
+    }
+
+    #[test]
+    fn lowers_the_shared_fp32_matmul_artifact() {
+        let plan = lower_tosa(MATMUL_FP32.artifact, VULKAN_TOSA_TARGET).unwrap();
+        assert_eq!(plan.kernel, Kernel::MatmulFp32);
+        let geometry = plan.matmul.expect("MATMUL plan carries geometry");
+        assert_eq!(geometry.batch, 1);
+        assert_eq!(geometry.m, 2);
+        assert_eq!(geometry.n, 2);
+        assert_eq!(geometry.k, 3);
+        assert_eq!(plan.element_count, 4);
+        assert_eq!(plan.slots.len(), 3);
+        assert_eq!(plan.slot(0).unwrap().role, SlotRole::Input);
+        assert_eq!(plan.slot(0).unwrap().byte_len, 6 * 4);
+        assert_eq!(plan.slot(1).unwrap().role, SlotRole::Input);
+        assert_eq!(plan.slot(1).unwrap().byte_len, 6 * 4);
+        assert_eq!(plan.slot(2).unwrap().role, SlotRole::Output);
+        assert_eq!(plan.slot(2).unwrap().byte_len, 4 * 4);
+        assert_eq!(plan.slot(2).unwrap().scalar_bytes, 4);
+        assert!(plan.slot(3).is_none());
     }
 
     #[test]

--- a/crates/virtio-accel-vulkan/src/native.rs
+++ b/crates/virtio-accel-vulkan/src/native.rs
@@ -108,9 +108,15 @@ impl Instance {
         let application = vk::ApplicationInfo::default()
             .application_name(c"virtio-accel-vulkan")
             .api_version(vk::API_VERSION_1_3);
-        let info = vk::InstanceCreateInfo::default().application_info(&application);
-        // SAFETY: `info` and the structures it points to outlive the call; no layers or
-        // extensions are requested, so the loader validates nothing beyond the API version.
+        // MoltenVK and other portability drivers refuse enumeration unless the instance opts
+        // into the portability extension; requesting it is a no-op on conformant native drivers.
+        let extension_names = [c"VK_KHR_portability_enumeration".as_ptr()];
+        let info = vk::InstanceCreateInfo::default()
+            .application_info(&application)
+            .flags(vk::InstanceCreateFlags::ENUMERATE_PORTABILITY_KHR)
+            .enabled_extension_names(&extension_names);
+        // SAFETY: `info` and the structures it points to outlive the call; no layers are
+        // requested, and the extension name is a static literal whose pointer outlives the call.
         let instance = match unsafe { entry.create_instance(&info, None) } {
             Ok(instance) => instance,
             Err(vk::Result::ERROR_INCOMPATIBLE_DRIVER) => {
@@ -404,6 +410,9 @@ impl Shared {
             return Err(InitError::DeviceUnavailable);
         };
 
+        // The shared set layout declares the widest kernel's binding count: slots 0..2 so both
+        // the two-slot elementwise kernels and the three-slot MATMUL kernel update a contiguous
+        // prefix of one descriptor set.
         let bindings = [
             vk::DescriptorSetLayoutBinding::default()
                 .binding(shader::INPUT_BINDING)
@@ -412,6 +421,11 @@ impl Shared {
                 .stage_flags(vk::ShaderStageFlags::COMPUTE),
             vk::DescriptorSetLayoutBinding::default()
                 .binding(shader::OUTPUT_BINDING)
+                .descriptor_type(vk::DescriptorType::STORAGE_BUFFER)
+                .descriptor_count(1)
+                .stage_flags(vk::ShaderStageFlags::COMPUTE),
+            vk::DescriptorSetLayoutBinding::default()
+                .binding(shader::MATMUL_OUTPUT_BINDING)
                 .descriptor_type(vk::DescriptorType::STORAGE_BUFFER)
                 .descriptor_count(1)
                 .stage_flags(vk::ShaderStageFlags::COMPUTE),
@@ -577,9 +591,11 @@ impl ContextInner {
         let command_buffers = unsafe { device.allocate_command_buffers(&allocate_info) }
             .map_err(|result| shared.fail(result))?;
 
+        // The shared set layout declares three storage-buffer bindings (the widest kernel), so
+        // each allocated set charges three descriptors against the pool.
         let pool_sizes = [vk::DescriptorPoolSize {
             ty: vk::DescriptorType::STORAGE_BUFFER,
-            descriptor_count: RING_DEPTH * 2,
+            descriptor_count: RING_DEPTH * 3,
         }];
         let descriptor_pool_info = vk::DescriptorPoolCreateInfo::default()
             .max_sets(RING_DEPTH)
@@ -1010,7 +1026,7 @@ pub struct VulkanProgram {
     context: Rc<ContextInner>,
     pipeline: vk::Pipeline,
     plan: ProgramPlan,
-    workgroups: u32,
+    workgroups: [u32; 3],
     state: Rc<ProgramState>,
 }
 
@@ -1379,18 +1395,18 @@ impl VulkanAccelerator {
     ) -> Result<(), vk::Result> {
         let shared = &self.shared;
         let device = &shared.device;
-        let writes = [
-            vk::WriteDescriptorSet::default()
-                .dst_set(slot.descriptor_set)
-                .dst_binding(shader::INPUT_BINDING)
-                .descriptor_type(vk::DescriptorType::STORAGE_BUFFER)
-                .buffer_info(&descriptors[..1]),
-            vk::WriteDescriptorSet::default()
-                .dst_set(slot.descriptor_set)
-                .dst_binding(shader::OUTPUT_BINDING)
-                .descriptor_type(vk::DescriptorType::STORAGE_BUFFER)
-                .buffer_info(&descriptors[1..2]),
-        ];
+        // Descriptor bindings match the slot index of the plan: slot `i` writes binding `i`
+        // against the shared set layout's declared binding range.
+        let mut writes = Vec::with_capacity(descriptors.len());
+        for (index, info) in descriptors.iter().enumerate() {
+            writes.push(
+                vk::WriteDescriptorSet::default()
+                    .dst_set(slot.descriptor_set)
+                    .dst_binding(index as u32)
+                    .descriptor_type(vk::DescriptorType::STORAGE_BUFFER)
+                    .buffer_info(std::slice::from_ref(info)),
+            );
+        }
         let begin = vk::CommandBufferBeginInfo::default()
             .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT);
         // Make the shader's storage writes visible to host reads after the fence signals.
@@ -1426,7 +1442,12 @@ impl VulkanAccelerator {
                 &[slot.descriptor_set],
                 &[],
             );
-            device.cmd_dispatch(slot.command_buffer, program.workgroups, 1, 1);
+            device.cmd_dispatch(
+                slot.command_buffer,
+                program.workgroups[0],
+                program.workgroups[1],
+                program.workgroups[2],
+            );
             device.cmd_pipeline_barrier2(slot.command_buffer, &dependency);
             device.end_command_buffer(slot.command_buffer)?;
             device.queue_submit2(shared.queue, &submits, slot.fence)
@@ -1638,12 +1659,23 @@ impl Accelerator for VulkanAccelerator {
             }
         };
         let plan = lower_tosa(bytes, target).map_err(Self::lowering_error)?;
-        let workgroups = shader::elementwise_workgroups(plan.element_count);
-        if workgroups > shared.physical.limits.max_compute_work_group_count[0] {
+        let workgroups = match plan.kernel {
+            Kernel::CopyU32 => [shader::elementwise_workgroups(plan.element_count), 1, 1],
+            Kernel::MatmulFp32 => {
+                let geometry = plan.matmul.expect("MATMUL plan carries geometry");
+                shader::matmul_workgroups(geometry.m, geometry.n, geometry.batch)
+            }
+        };
+        let limits = &shared.physical.limits;
+        if workgroups[0] > limits.max_compute_work_group_count[0]
+            || workgroups[1] > limits.max_compute_work_group_count[1]
+            || workgroups[2] > limits.max_compute_work_group_count[2]
+        {
             return Err(BackendError::ResourceLimit);
         }
         let code = match plan.kernel {
             Kernel::CopyU32 => shader::copy_u32_spirv(),
+            Kernel::MatmulFp32 => shader::matmul_fp32_spirv(),
         };
 
         let device = &shared.device;
@@ -1651,15 +1683,54 @@ impl Accelerator for VulkanAccelerator {
         // SAFETY: `code` is the crate-authored SPIR-V module, live for the call.
         let module = unsafe { device.create_shader_module(&module_info, None) }
             .map_err(|result| shared.fail(result))?;
-        let element_count = plan.element_count.to_ne_bytes();
-        let entries = [vk::SpecializationMapEntry {
-            constant_id: shader::ELEMENT_COUNT_SPEC_ID,
-            offset: 0,
-            size: std::mem::size_of::<u32>(),
-        }];
+        // Specialization data is laid out in one buffer whose layout matches the entries: a
+        // single u32 for the elementwise kernel, or m/n/k/batch in that order for MATMUL.
+        let (entries, spec_data) = match plan.kernel {
+            Kernel::CopyU32 => (
+                vec![vk::SpecializationMapEntry {
+                    constant_id: shader::ELEMENT_COUNT_SPEC_ID,
+                    offset: 0,
+                    size: std::mem::size_of::<u32>(),
+                }],
+                plan.element_count.to_ne_bytes().to_vec(),
+            ),
+            Kernel::MatmulFp32 => {
+                let geometry = plan.matmul.expect("MATMUL plan carries geometry");
+                let mut data = Vec::with_capacity(16);
+                data.extend_from_slice(&geometry.m.to_ne_bytes());
+                data.extend_from_slice(&geometry.n.to_ne_bytes());
+                data.extend_from_slice(&geometry.k.to_ne_bytes());
+                data.extend_from_slice(&geometry.batch.to_ne_bytes());
+                (
+                    vec![
+                        vk::SpecializationMapEntry {
+                            constant_id: shader::MATMUL_SPEC_ID_M,
+                            offset: 0,
+                            size: 4,
+                        },
+                        vk::SpecializationMapEntry {
+                            constant_id: shader::MATMUL_SPEC_ID_N,
+                            offset: 4,
+                            size: 4,
+                        },
+                        vk::SpecializationMapEntry {
+                            constant_id: shader::MATMUL_SPEC_ID_K,
+                            offset: 8,
+                            size: 4,
+                        },
+                        vk::SpecializationMapEntry {
+                            constant_id: shader::MATMUL_SPEC_ID_BATCH,
+                            offset: 12,
+                            size: 4,
+                        },
+                    ],
+                    data,
+                )
+            }
+        };
         let specialization = vk::SpecializationInfo::default()
             .map_entries(&entries)
-            .data(&element_count);
+            .data(&spec_data);
         let stage = vk::PipelineShaderStageCreateInfo::default()
             .stage(vk::ShaderStageFlags::COMPUTE)
             .module(module)

--- a/crates/virtio-accel-vulkan/src/shader.rs
+++ b/crates/virtio-accel-vulkan/src/shader.rs
@@ -31,6 +31,7 @@ const OP_CAPABILITY: u16 = 17;
 const OP_TYPE_VOID: u16 = 19;
 const OP_TYPE_BOOL: u16 = 20;
 const OP_TYPE_INT: u16 = 21;
+const OP_TYPE_FLOAT: u16 = 22;
 const OP_TYPE_VECTOR: u16 = 23;
 const OP_TYPE_RUNTIME_ARRAY: u16 = 29;
 const OP_TYPE_STRUCT: u16 = 30;
@@ -46,7 +47,13 @@ const OP_STORE: u16 = 62;
 const OP_ACCESS_CHAIN: u16 = 65;
 const OP_DECORATE: u16 = 71;
 const OP_MEMBER_DECORATE: u16 = 72;
+const OP_I_ADD: u16 = 128;
+const OP_I_MUL: u16 = 132;
+const OP_F_ADD: u16 = 129;
+const OP_F_MUL: u16 = 133;
 const OP_U_LESS_THAN: u16 = 176;
+const OP_LOGICAL_AND: u16 = 167;
+const OP_LOOP_MERGE: u16 = 246;
 const OP_SELECTION_MERGE: u16 = 247;
 const OP_LABEL: u16 = 248;
 const OP_BRANCH: u16 = 249;
@@ -72,6 +79,7 @@ const DECORATION_OFFSET: u32 = 35;
 const BUILT_IN_GLOBAL_INVOCATION_ID: u32 = 28;
 const FUNCTION_CONTROL_NONE: u32 = 0;
 const SELECTION_CONTROL_NONE: u32 = 0;
+const LOOP_CONTROL_NONE: u32 = 0;
 
 /// SPIR-V 1.3: the version every Vulkan 1.1+ implementation must consume, and the first with the
 /// `StorageBuffer` storage class in core (no `SPV_KHR_storage_buffer_storage_class` extension).
@@ -297,6 +305,299 @@ pub const fn elementwise_workgroups(element_count: u32) -> u32 {
     element_count.div_ceil(ELEMENTWISE_WORKGROUP_SIZE)
 }
 
+/// Workgroup size of the MATMUL shader along X and Y (`OpExecutionMode LocalSize x y 1`).
+pub const MATMUL_WORKGROUP_SIZE_X: u32 = 8;
+/// Workgroup size of the MATMUL shader along Y.
+pub const MATMUL_WORKGROUP_SIZE_Y: u32 = 8;
+
+/// MATMUL specialization constants (ids 0..5): output rows `m`, output columns `n`, shared
+/// reduction dimension `k`, and batch. `load_program` overrides every one.
+pub const MATMUL_SPEC_ID_M: u32 = 0;
+pub const MATMUL_SPEC_ID_N: u32 = 1;
+pub const MATMUL_SPEC_ID_K: u32 = 2;
+pub const MATMUL_SPEC_ID_BATCH: u32 = 3;
+
+/// Descriptor binding of the left-hand side matrix (set 0).
+pub const MATMUL_LHS_BINDING: u32 = 0;
+/// Descriptor binding of the right-hand side matrix (set 0).
+pub const MATMUL_RHS_BINDING: u32 = 1;
+/// Descriptor binding of the output matrix (set 0).
+pub const MATMUL_OUTPUT_BINDING: u32 = 2;
+
+/// FP32 batched matrix multiplication: `out[b, m, n] = sum_k(lhs[b, m, k] * rhs[b, k, n])` for
+/// every `(b, m, n)` below the specialization constants. One thread per output element, dispatched
+/// over X = columns, Y = rows, Z = batches; out-of-range threads return without a write.
+///
+/// Row-major 3-D tensors exactly as TOSA lays them out: the per-batch strides are `m*k` (lhs),
+/// `k*n` (rhs), and `m*n` (output) elements. Reduction order is the ascending-`k` summation the
+/// shared FP32 oracle tolerates; every product and every accumulation is an IEEE FP32 operation
+/// with no fused-multiply-add, so the oracle's tolerance is never stretched by contraction.
+///
+/// Layout: set 0, bindings 0/1 are the read-only operands `{ float data[]; }`, binding 2 the
+/// output with the same layout. `m`, `n`, `k`, and `batch` are specialization constants 0..3.
+pub fn matmul_fp32_spirv() -> &'static [u32] {
+    static MODULE: OnceLock<Vec<u32>> = OnceLock::new();
+    MODULE.get_or_init(assemble_matmul_fp32)
+}
+
+fn assemble_matmul_fp32() -> Vec<u32> {
+    let mut a = Assembler::new();
+    let main = a.id();
+    let gid = a.id();
+    let void = a.id();
+    let fn_type = a.id();
+    let uint = a.id();
+    let float = a.id();
+    let uvec3 = a.id();
+    let bool_type = a.id();
+    let ptr_in_uvec3 = a.id();
+    let ptr_in_uint = a.id();
+    let words_f = a.id();
+    let block_f = a.id();
+    let ptr_sb_block_f = a.id();
+    let lhs = a.id();
+    let rhs = a.id();
+    let out = a.id();
+    let ptr_sb_float = a.id();
+    let zero = a.id();
+    let one = a.id();
+    let m = a.id();
+    let n = a.id();
+    let k = a.id();
+    let batch = a.id();
+    let fzero = a.id();
+    let ptr_func_float = a.id();
+    let ptr_func_uint = a.id();
+    let acc = a.id();
+    let i = a.id();
+    let entry = a.id();
+    let x_ptr = a.id();
+    let y_ptr = a.id();
+    let z_ptr = a.id();
+    let x = a.id();
+    let y = a.id();
+    let z = a.id();
+    let in_m = a.id();
+    let in_n = a.id();
+    let in_b = a.id();
+    let in_mn = a.id();
+    let in_all = a.id();
+    let out_of_bounds = a.id();
+    let copy = a.id();
+    let merge = a.id();
+    let header = a.id();
+    let i_val = a.id();
+    let in_k = a.id();
+    let body = a.id();
+    let cont = a.id();
+    let done = a.id();
+    let lhs_base = a.id();
+    let lhs_row = a.id();
+    let lhs_idx = a.id();
+    let lhs_ptr = a.id();
+    let lhs_val = a.id();
+    let rhs_base = a.id();
+    let rhs_row = a.id();
+    let rhs_idx = a.id();
+    let rhs_ptr = a.id();
+    let rhs_val = a.id();
+    let product = a.id();
+    let acc_val = a.id();
+    let acc_next = a.id();
+    let i_next = a.id();
+    let out_base = a.id();
+    let out_row = a.id();
+    let out_idx = a.id();
+    let out_ptr = a.id();
+    let acc_final = a.id();
+    let two = a.id();
+
+    a.emit(OP_CAPABILITY, &[CAPABILITY_SHADER]);
+    a.emit(
+        OP_MEMORY_MODEL,
+        &[ADDRESSING_MODEL_LOGICAL, MEMORY_MODEL_GLSL450],
+    );
+    let mut entry_point = vec![EXECUTION_MODEL_GL_COMPUTE, main];
+    entry_point.extend(literal_string("main"));
+    entry_point.push(gid);
+    a.emit(OP_ENTRY_POINT, &entry_point);
+    a.emit(
+        OP_EXECUTION_MODE,
+        &[
+            main,
+            EXECUTION_MODE_LOCAL_SIZE,
+            MATMUL_WORKGROUP_SIZE_X,
+            MATMUL_WORKGROUP_SIZE_Y,
+            1,
+        ],
+    );
+
+    a.emit(
+        OP_DECORATE,
+        &[gid, DECORATION_BUILT_IN, BUILT_IN_GLOBAL_INVOCATION_ID],
+    );
+    a.emit(OP_DECORATE, &[words_f, DECORATION_ARRAY_STRIDE, 4]);
+    a.emit(OP_DECORATE, &[block_f, DECORATION_BLOCK]);
+    a.emit(OP_MEMBER_DECORATE, &[block_f, 0, DECORATION_OFFSET, 0]);
+    a.emit(OP_DECORATE, &[lhs, DECORATION_DESCRIPTOR_SET, 0]);
+    a.emit(OP_DECORATE, &[lhs, DECORATION_BINDING, MATMUL_LHS_BINDING]);
+    a.emit(OP_DECORATE, &[lhs, DECORATION_NON_WRITABLE]);
+    a.emit(OP_DECORATE, &[rhs, DECORATION_DESCRIPTOR_SET, 0]);
+    a.emit(OP_DECORATE, &[rhs, DECORATION_BINDING, MATMUL_RHS_BINDING]);
+    a.emit(OP_DECORATE, &[rhs, DECORATION_NON_WRITABLE]);
+    a.emit(OP_DECORATE, &[out, DECORATION_DESCRIPTOR_SET, 0]);
+    a.emit(
+        OP_DECORATE,
+        &[out, DECORATION_BINDING, MATMUL_OUTPUT_BINDING],
+    );
+    a.emit(OP_DECORATE, &[m, DECORATION_SPEC_ID, MATMUL_SPEC_ID_M]);
+    a.emit(OP_DECORATE, &[n, DECORATION_SPEC_ID, MATMUL_SPEC_ID_N]);
+    a.emit(OP_DECORATE, &[k, DECORATION_SPEC_ID, MATMUL_SPEC_ID_K]);
+    a.emit(
+        OP_DECORATE,
+        &[batch, DECORATION_SPEC_ID, MATMUL_SPEC_ID_BATCH],
+    );
+
+    a.emit(OP_TYPE_VOID, &[void]);
+    a.emit(OP_TYPE_FUNCTION, &[fn_type, void]);
+    a.emit(OP_TYPE_INT, &[uint, 32, 0]);
+    a.emit(OP_TYPE_FLOAT, &[float, 32]);
+    a.emit(OP_TYPE_VECTOR, &[uvec3, uint, 3]);
+    a.emit(OP_TYPE_BOOL, &[bool_type]);
+    a.emit(OP_TYPE_POINTER, &[ptr_in_uvec3, STORAGE_CLASS_INPUT, uvec3]);
+    a.emit(OP_VARIABLE, &[ptr_in_uvec3, gid, STORAGE_CLASS_INPUT]);
+    a.emit(OP_TYPE_POINTER, &[ptr_in_uint, STORAGE_CLASS_INPUT, uint]);
+    a.emit(OP_TYPE_RUNTIME_ARRAY, &[words_f, float]);
+    a.emit(OP_TYPE_STRUCT, &[block_f, words_f]);
+    a.emit(
+        OP_TYPE_POINTER,
+        &[ptr_sb_block_f, STORAGE_CLASS_STORAGE_BUFFER, block_f],
+    );
+    a.emit(
+        OP_VARIABLE,
+        &[ptr_sb_block_f, lhs, STORAGE_CLASS_STORAGE_BUFFER],
+    );
+    a.emit(
+        OP_VARIABLE,
+        &[ptr_sb_block_f, rhs, STORAGE_CLASS_STORAGE_BUFFER],
+    );
+    a.emit(
+        OP_VARIABLE,
+        &[ptr_sb_block_f, out, STORAGE_CLASS_STORAGE_BUFFER],
+    );
+    a.emit(
+        OP_TYPE_POINTER,
+        &[ptr_sb_float, STORAGE_CLASS_STORAGE_BUFFER, float],
+    );
+    a.emit(
+        OP_TYPE_POINTER,
+        &[ptr_func_float, STORAGE_CLASS_FUNCTION, float],
+    );
+    a.emit(
+        OP_TYPE_POINTER,
+        &[ptr_func_uint, STORAGE_CLASS_FUNCTION, uint],
+    );
+    a.emit(OP_CONSTANT, &[uint, zero, 0]);
+    a.emit(OP_CONSTANT, &[uint, one, 1]);
+    a.emit(OP_CONSTANT, &[uint, two, 2]);
+    a.emit(OP_CONSTANT, &[float, fzero, 0]);
+    a.emit(OP_SPEC_CONSTANT, &[uint, m, 1]);
+    a.emit(OP_SPEC_CONSTANT, &[uint, n, 1]);
+    a.emit(OP_SPEC_CONSTANT, &[uint, k, 1]);
+    a.emit(OP_SPEC_CONSTANT, &[uint, batch, 1]);
+
+    a.emit(OP_FUNCTION, &[void, main, FUNCTION_CONTROL_NONE, fn_type]);
+    a.emit(OP_LABEL, &[entry]);
+    a.emit(OP_VARIABLE, &[ptr_func_float, acc, STORAGE_CLASS_FUNCTION]);
+    a.emit(OP_VARIABLE, &[ptr_func_uint, i, STORAGE_CLASS_FUNCTION]);
+    a.emit(OP_ACCESS_CHAIN, &[ptr_in_uint, x_ptr, gid, zero]);
+    a.emit(OP_LOAD, &[uint, x, x_ptr]);
+    a.emit(OP_ACCESS_CHAIN, &[ptr_in_uint, y_ptr, gid, one]);
+    a.emit(OP_LOAD, &[uint, y, y_ptr]);
+    a.emit(OP_ACCESS_CHAIN, &[ptr_in_uint, z_ptr, gid, two]);
+    a.emit(OP_LOAD, &[uint, z, z_ptr]);
+    a.emit(OP_U_LESS_THAN, &[bool_type, in_m, y, m]);
+    a.emit(OP_U_LESS_THAN, &[bool_type, in_n, x, n]);
+    a.emit(OP_U_LESS_THAN, &[bool_type, in_b, z, batch]);
+    a.emit(OP_LOGICAL_AND, &[bool_type, in_mn, in_m, in_n]);
+    a.emit(OP_LOGICAL_AND, &[bool_type, in_all, in_mn, in_b]);
+    // Out-of-bounds threads skip the copy: branch to the merge when any coordinate misses.
+    a.emit(OP_LOGICAL_NOT, &[bool_type, out_of_bounds, in_all]);
+    a.emit(OP_SELECTION_MERGE, &[merge, SELECTION_CONTROL_NONE]);
+    a.emit(OP_BRANCH_CONDITIONAL, &[out_of_bounds, merge, copy]);
+    a.emit(OP_LABEL, &[copy]);
+    a.emit(OP_STORE, &[acc, fzero]);
+    a.emit(OP_STORE, &[i, zero]);
+    a.emit(OP_BRANCH, &[header]);
+    a.emit(OP_LABEL, &[header]);
+    a.emit(OP_LOAD, &[uint, i_val, i]);
+    a.emit(OP_U_LESS_THAN, &[bool_type, in_k, i_val, k]);
+    a.emit(OP_LOOP_MERGE, &[done, cont, LOOP_CONTROL_NONE]);
+    a.emit(OP_BRANCH_CONDITIONAL, &[in_k, body, done]);
+    a.emit(OP_LABEL, &[body]);
+    // lhs index: (z * m + y) * k + i
+    a.emit(OP_I_MUL, &[uint, lhs_base, z, m]);
+    a.emit(OP_I_ADD, &[uint, lhs_row, lhs_base, y]);
+    a.emit(OP_I_MUL, &[uint, lhs_idx, lhs_row, k]);
+    let lhs_index = a.id();
+    a.emit(OP_I_ADD, &[uint, lhs_index, lhs_idx, i_val]);
+    a.emit(
+        OP_ACCESS_CHAIN,
+        &[ptr_sb_float, lhs_ptr, lhs, zero, lhs_index],
+    );
+    a.emit(OP_LOAD, &[float, lhs_val, lhs_ptr]);
+    // rhs index: (z * k + i) * n + x
+    a.emit(OP_I_MUL, &[uint, rhs_base, z, k]);
+    a.emit(OP_I_ADD, &[uint, rhs_row, rhs_base, i_val]);
+    a.emit(OP_I_MUL, &[uint, rhs_idx, rhs_row, n]);
+    let rhs_index = a.id();
+    a.emit(OP_I_ADD, &[uint, rhs_index, rhs_idx, x]);
+    a.emit(
+        OP_ACCESS_CHAIN,
+        &[ptr_sb_float, rhs_ptr, rhs, zero, rhs_index],
+    );
+    a.emit(OP_LOAD, &[float, rhs_val, rhs_ptr]);
+    a.emit(OP_F_MUL, &[float, product, lhs_val, rhs_val]);
+    a.emit(OP_LOAD, &[float, acc_val, acc]);
+    a.emit(OP_F_ADD, &[float, acc_next, acc_val, product]);
+    a.emit(OP_STORE, &[acc, acc_next]);
+    a.emit(OP_BRANCH, &[cont]);
+    a.emit(OP_LABEL, &[cont]);
+    a.emit(OP_I_ADD, &[uint, i_next, i_val, one]);
+    a.emit(OP_STORE, &[i, i_next]);
+    a.emit(OP_BRANCH, &[header]);
+    a.emit(OP_LABEL, &[done]);
+    // out index: (z * m + y) * n + x
+    a.emit(OP_I_MUL, &[uint, out_base, z, m]);
+    a.emit(OP_I_ADD, &[uint, out_row, out_base, y]);
+    a.emit(OP_I_MUL, &[uint, out_idx, out_row, n]);
+    let out_index = a.id();
+    a.emit(OP_I_ADD, &[uint, out_index, out_idx, x]);
+    a.emit(OP_LOAD, &[float, acc_final, acc]);
+    a.emit(
+        OP_ACCESS_CHAIN,
+        &[ptr_sb_float, out_ptr, out, zero, out_index],
+    );
+    a.emit(OP_STORE, &[out_ptr, acc_final]);
+    a.emit(OP_BRANCH, &[merge]);
+    a.emit(OP_LABEL, &[merge]);
+    a.emit(OP_RETURN, &[]);
+    a.emit(OP_FUNCTION_END, &[]);
+    a.finish()
+}
+
+const OP_LOGICAL_NOT: u16 = 168;
+const STORAGE_CLASS_FUNCTION: u32 = 7;
+
+/// Workgroup counts of a MATMUL dispatch over `m` rows, `n` columns, and `batch` batches.
+pub const fn matmul_workgroups(m: u32, n: u32, batch: u32) -> [u32; 3] {
+    [
+        n.div_ceil(MATMUL_WORKGROUP_SIZE_X),
+        m.div_ceil(MATMUL_WORKGROUP_SIZE_Y),
+        batch,
+    ]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -329,6 +630,28 @@ mod tests {
     }
 
     #[test]
+    fn matmul_module_is_well_formed() {
+        let words = matmul_fp32_spirv();
+        assert_eq!(words[0], SPIRV_MAGIC);
+        assert_eq!(words[1], SPIRV_VERSION_1_3);
+        let mut cursor = 5;
+        let mut opcodes = Vec::new();
+        while cursor < words.len() {
+            let word_count = (words[cursor] >> 16) as usize;
+            assert!(word_count >= 1, "zero-length instruction at {cursor}");
+            assert!(cursor + word_count <= words.len(), "instruction overruns");
+            opcodes.push((words[cursor] & 0xffff) as u16);
+            cursor += word_count;
+        }
+        assert_eq!(cursor, words.len());
+        assert_eq!(opcodes[0], OP_CAPABILITY);
+        assert_eq!(opcodes[1], OP_MEMORY_MODEL);
+        assert_eq!(opcodes[2], OP_ENTRY_POINT);
+        assert_eq!(*opcodes.last().unwrap(), OP_FUNCTION_END);
+        assert_eq!(opcodes.iter().filter(|op| **op == OP_FUNCTION).count(), 1);
+    }
+
+    #[test]
     fn literal_strings_are_nul_terminated_and_word_padded() {
         assert_eq!(literal_string("main"), vec![0x6e69_616d, 0]);
         assert_eq!(literal_string("abc"), vec![0x0063_6261]);
@@ -340,5 +663,14 @@ mod tests {
         assert_eq!(elementwise_workgroups(64), 1);
         assert_eq!(elementwise_workgroups(65), 2);
         assert_eq!(elementwise_workgroups(u32::MAX), 67_108_864);
+    }
+
+    #[test]
+    fn matmul_workgroups_cover_all_dimensions() {
+        assert_eq!(matmul_workgroups(1, 1, 1), [1, 1, 1]);
+        assert_eq!(matmul_workgroups(8, 8, 1), [1, 1, 1]);
+        assert_eq!(matmul_workgroups(9, 8, 1), [1, 2, 1]);
+        assert_eq!(matmul_workgroups(8, 9, 1), [2, 1, 1]);
+        assert_eq!(matmul_workgroups(8, 8, 3), [1, 1, 3]);
     }
 }

--- a/crates/virtio-accel-vulkan/tests/targets.rs
+++ b/crates/virtio-accel-vulkan/tests/targets.rs
@@ -50,11 +50,12 @@ fn targets_survive_an_identity_round_trip() {
 }
 
 #[test]
-fn capability_advertises_only_the_fp32_identity_boundary() {
+fn capability_advertises_exactly_the_executed_fp32_boundary() {
     assert_eq!(VULKAN_TOSA_CAPABILITY.target, VULKAN_TOSA_TARGET);
     assert!(VULKAN_TOSA_CAPABILITY.supports_dtype(DType::FP32, ValueRoles::ALL));
     assert!(supports_tosa_operator(Op::IDENTITY));
-    assert!(!supports_tosa_operator(Op::MATMUL));
+    assert!(supports_tosa_operator(Op::MATMUL));
+    assert!(!supports_tosa_operator(Op::MAX_POOL2D));
     assert!(supports_tosa_dtype(DType::FP32));
     for rejected in [
         DType::FP16,
@@ -76,5 +77,12 @@ fn checked_in_shader_module_is_stable() {
     assert!(std::ptr::eq(
         words,
         virtio_accel_vulkan::shader::copy_u32_spirv()
+    ));
+    let matmul = virtio_accel_vulkan::shader::matmul_fp32_spirv();
+    assert_eq!(matmul[0], 0x0723_0203, "SPIR-V magic");
+    assert_eq!(matmul[1], 0x0001_0300, "SPIR-V 1.3");
+    assert!(std::ptr::eq(
+        matmul,
+        virtio_accel_vulkan::shader::matmul_fp32_spirv()
     ));
 }

--- a/crates/virtio-accel-vulkan/tests/vulkan.rs
+++ b/crates/virtio-accel-vulkan/tests/vulkan.rs
@@ -9,7 +9,9 @@
 
 use std::time::{Duration, Instant};
 
-use virtio_accel_conformance::numerics::{IDENTITY_EDGES_FP32, IDENTITY_INT8, MATMUL_FP32};
+use virtio_accel_conformance::numerics::{
+    IDENTITY_EDGES_FP32, IDENTITY_INT8, MATMUL_FP32, MAX_POOL2D_FP32,
+};
 use virtio_accel_conformance::{
     BindingFixture, ConformanceHooks, ProgramFixture, ResourceCounts, SubmissionPathDiagnostics,
     TargetDescription, run,
@@ -244,6 +246,99 @@ fn run_identity(
     bytes.0
 }
 
+/// Full lifecycle for the shared FP32 MATMUL case: allocate two inputs plus an output in
+/// `domain`, execute, and read the product back.
+fn run_matmul(
+    backend: &VulkanAccelerator,
+    lhs: &[u8],
+    rhs: &[u8],
+    output_len: usize,
+    domain: MemoryDomain,
+) -> Vec<u8> {
+    let device = backend.device_name();
+    let context = backend.create_context(ContextDesc::default()).unwrap();
+    let program = load(backend, &context, MATMUL_FP32.artifact, VULKAN_TOSA_TARGET)
+        .unwrap_or_else(|error| panic!("{device}: matmul load failed: {error:?}"));
+    let input_usage = BufferUsage::TRANSFER_DESTINATION | BufferUsage::PROGRAM_INPUT;
+    let lhs_desc =
+        BufferDesc::new(lhs.len() as u64, BUFFER_ALIGNMENT, domain, input_usage).unwrap();
+    let (mut lhs_buffer, _) = backend
+        .allocate_buffer(&context, lhs_desc)
+        .unwrap()
+        .into_parts();
+    backend
+        .write_buffer(&mut lhs_buffer, 0, &SliceSource(lhs))
+        .unwrap();
+    let rhs_desc =
+        BufferDesc::new(rhs.len() as u64, BUFFER_ALIGNMENT, domain, input_usage).unwrap();
+    let (mut rhs_buffer, _) = backend
+        .allocate_buffer(&context, rhs_desc)
+        .unwrap()
+        .into_parts();
+    backend
+        .write_buffer(&mut rhs_buffer, 0, &SliceSource(rhs))
+        .unwrap();
+    let output_desc = BufferDesc::new(
+        output_len as u64,
+        BUFFER_ALIGNMENT,
+        domain,
+        BufferUsage::TRANSFER_SOURCE | BufferUsage::PROGRAM_OUTPUT,
+    )
+    .unwrap();
+    let (output, _) = backend
+        .allocate_buffer(&context, output_desc)
+        .unwrap()
+        .into_parts();
+    let queue = backend
+        .create_queue(&context, QueueDesc::default())
+        .unwrap();
+    let bindings = [
+        BindingRef {
+            slot: 0,
+            buffer: &lhs_buffer,
+            range: BufferRange::new(0, lhs.len() as u64).unwrap(),
+            access: AccessMode::Read,
+        },
+        BindingRef {
+            slot: 1,
+            buffer: &rhs_buffer,
+            range: BufferRange::new(0, rhs.len() as u64).unwrap(),
+            access: AccessMode::Read,
+        },
+        BindingRef {
+            slot: 2,
+            buffer: &output,
+            range: BufferRange::new(0, output_len as u64).unwrap(),
+            access: AccessMode::Write,
+        },
+    ];
+    let event = backend
+        .submit(&queue, &program, &bindings, Timeout::Infinite)
+        .unwrap_or_else(|failure| match failure {
+            SubmitFailure::Rejected(error) => panic!("{device}: submission rejected: {error:?}"),
+            SubmitFailure::Indeterminate { error, .. } => {
+                panic!("{device}: submission indeterminate: {error:?}")
+            }
+        });
+    assert_eq!(
+        wait_for_terminal(backend, &event),
+        EventState::Complete,
+        "{device}"
+    );
+    release(backend.destroy_event(event));
+
+    let mut bytes = VecSink(vec![0; output_len]);
+    backend.read_buffer(&output, 0, &mut bytes).unwrap();
+    release(backend.destroy_queue(queue));
+    release(backend.unload_program(program));
+    release(backend.free_buffer(output));
+    release(backend.free_buffer(rhs_buffer));
+    release(backend.free_buffer(lhs_buffer));
+    release(backend.destroy_context(context));
+    assert_eq!(backend.live_resources(), Default::default(), "{device}");
+    bytes.0
+}
+
 fn advertised_domains(backend: &VulkanAccelerator) -> Vec<MemoryDomain> {
     let capabilities = backend.device_info().unwrap().capabilities;
     [
@@ -254,6 +349,26 @@ fn advertised_domains(backend: &VulkanAccelerator) -> Vec<MemoryDomain> {
     .into_iter()
     .filter(|domain| capabilities.supports_memory_domain(*domain))
     .collect()
+}
+
+#[test]
+fn executes_the_shared_fp32_matmul_in_every_advertised_domain() {
+    let case = &MATMUL_FP32;
+    let lhs = float_bytes(case.inputs[0].values.iter().copied());
+    let rhs = float_bytes(case.inputs[1].values.iter().copied());
+    let output_len = case.outputs[0].values.len() * 4;
+    for device in devices() {
+        let backend = open(&device);
+        for domain in advertised_domains(&backend) {
+            let bytes = run_matmul(&backend, &lhs, &rhs, output_len, domain);
+            let actual = floats(&bytes);
+            assert!(
+                case.output_matches(0, &actual),
+                "{device}: {domain:?}: {actual:?} does not match {:?}",
+                case.outputs[0].values
+            );
+        }
+    }
 }
 
 #[test]
@@ -446,8 +561,14 @@ fn rejects_out_of_tier_artifacts_before_any_pipeline_exists() {
     for device in devices() {
         let backend = open(&device);
         let context = backend.create_context(ContextDesc::default()).unwrap();
+        // MAX_POOL2D is not yet admitted: the FP32 base tier grows one operator at a time.
         assert!(matches!(
-            load(&backend, &context, MATMUL_FP32.artifact, VULKAN_TOSA_TARGET),
+            load(
+                &backend,
+                &context,
+                MAX_POOL2D_FP32.artifact,
+                VULKAN_TOSA_TARGET
+            ),
             Err(BackendError::Unsupported)
         ));
         assert!(matches!(

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -389,7 +389,7 @@ only through bounded staging inside the explicit transfer calls. Each context ow
 of command buffers, fences, and descriptor sets; `vkQueueSubmit2` success is the admission
 boundary and `vkGetFenceStatus` is the whole completion path, so no worker thread bridges the
 runtime. Device loss poisons the instance. The backend runs the conformance suite and the shared
-FP32 identity corpus on every enumerated device, a real GPU and a software ICD alike.
+FP32 identity and matmul corpus on every enumerated device, a real GPU and a software ICD alike.
 
 The Qualcomm adapter uses the same seam. Its safe planner admits 41 of the 42 floating-point
 operators shared by Core ML and OpenVINO, including owned constants/data movement, FP16 unary and

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -227,6 +227,38 @@ hardware contexts (issue #121), not further submission-path restructuring. The r
 still pays for itself in semantics: submissions overlap with host-side polling and readback, and
 completion waits no longer serialize against `allocate_buffer`.
 
+## Vulkan provider evidence status
+
+`virtio-accel-vulkan`'s warm path is a descriptor update plus `vkQueueSubmit` on a preallocated
+bounded ring of (command buffer, fence, descriptor set) slots — no worker thread, no
+submission-time staging; completion is a nonblocking `vkGetFenceStatus` poll (ADR 0006). Programs
+compile once at `load_program` (checked-in SPIR-V + specialization constants) and are charged
+against `ArtifactRef::resident_bytes`.
+
+Manual hardware commands (per the #75 precedent — no self-hosted runner on a public repo):
+
+```sh
+# Real GPU (any Vulkan 1.3 compute device; pin the ICD explicitly):
+VIRTIO_ACCEL_VULKAN_REQUIRE_DEVICE=1 \
+  cargo test -p virtio-accel-vulkan --test vulkan -- --nocapture
+
+# Software ICD rehearsal (the CI lane's shape):
+VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/lvp_icd.x86_64.json \
+VIRTIO_ACCEL_VULKAN_REQUIRE_DEVICE=1 \
+  cargo test -p virtio-accel-vulkan --test vulkan -- --nocapture
+```
+
+Verified driver stacks: Intel ANV (full suite, `VIRTIO_ACCEL_VULKAN_REQUIRE_DEVICE=1`), Apple M3
+via MoltenVK (local validation only, not a CI lane), and Mesa lavapipe in the `vulkan-lavapipe-test`
+CI lane. Copy-path diagnostics across all three: every submission is a direct binding;
+`explicit_transfer_bytes` stays zero for `Host` and `Shared` domains, and `Device` staging is
+confined to `write_buffer`/`read_buffer` as the memory-domain contract requires.
+
+Warm-latency numbers for the IDENTITY and MATMUL kernels are not yet published: the first
+measurement should follow the XDNA structure (load once, warm 20, measure 200) on the Intel ANV
+reference box before this section claims any timing. What is claimed today is correctness and
+copy-path shape, not wall-clock values.
+
 ## Qualcomm Hexagon evidence status
 
 `virtio-accel-hexagon` includes an ignored release-mode measurement for fixed submission overhead:

--- a/docs/portability.md
+++ b/docs/portability.md
@@ -13,7 +13,7 @@ Rust 2024 edition selected by the workspace. Every package inherits the same `ru
 | `style-and-api` | Current stable on Ubuntu | Formatting, complete normative-requirement ledger, release-policy invariants, Clippy with warnings denied, and warning-free public docs |
 | `native-test` | Current stable on Ubuntu, macOS, and Windows | All workspace unit, integration, target, feature, and documentation tests, runnable examples, and release-profile checking |
 | `openvino-host-test` | Current stable on Ubuntu with a pinned Intel OpenVINO runtime | The real (probed) OpenVINO backend: lint, unit, integration, semantic-conformance, and example runs against the CPU plugin |
-| `vulkan-lavapipe-test` | Current stable on Ubuntu with the Mesa lavapipe ICD pinned | The native Vulkan 1.3 backend: lint, unit, integration, semantic-conformance, and FP32 IDENTITY example runs without allowing a placeholder skip |
+| `vulkan-lavapipe-test` | Current stable on Ubuntu with the Mesa lavapipe ICD pinned | The native Vulkan 1.3 backend: lint, unit, integration, semantic-conformance, and FP32 IDENTITY/MATMUL example runs without allowing a placeholder skip |
 | `msrv` | Rust 1.85.0 on Ubuntu | Every workspace target and test continues to compile at the declared MSRV |
 | `portable-target` | Stable `aarch64-unknown-none`, `riscv64gc-unknown-none-elf`, and `wasm32-unknown-unknown` | `cleanroom`, `proto`, `transport`, and `core` remain `no_std`; guest, split-queue, device, and facade layers require at most `alloc`; Wasm also checks the std reference crates |
 | `feature-sets-and-dependencies` | Stable on Ubuntu | Every Cargo feature combination plus dependency and `std`/`alloc` leakage guards for the portable codecs, queue ports, and core |
@@ -112,7 +112,7 @@ scalar on-NPU kernels. RESCALE clears the at-most-three-byte padded output tail 
 
 The Vulkan crate binds Vulkan 1.3 through the pinned `ash` crate and executes admitted TOSA graphs
 on checked-in SPIR-V compute shaders specialized at `load_program`; today that is the FP32 IDENTITY
-tier. Unlike the SDK-probing backends, there is nothing to detect at build time — `ash` loads the
+and zero-zero-point FP32 MATMUL tier. Unlike the SDK-probing backends, there is nothing to detect at build time — `ash` loads the
 platform's Vulkan loader dynamically at run time — so the `va_vulkan` cfg enumerates the host
 target operating systems (Linux, Android, Windows, macOS) and runtime loader or device absence
 surfaces as `InitError`. `VIRTIO_ACCEL_VULKAN=0` forces the placeholder everywhere;


### PR DESCRIPTION
Part of wayfinder map #154 tickets 9 and 11; closes #186, resolves ticket 11's docs/plumbing half.

## Code (ticket 9)
- **Kernel**: checked-in SPIR-V `matmul_fp32_spirv` — three storage buffers (lhs/rhs/out), specialization constants M/N/K/batch, one thread per output element over (n, m, batch). Separate `OpFMul`/`OpFAdd` (no contraction) so the shared oracle's tolerance holds under every float-controls mode. `spirv-val` clean.
- **Admission** (`lower.rs`): graphs with `CONST` zero-point producers admitted; MATMUL requires both trailing CONST inputs to serialize to zero (`ZERO_ZERO_POINTS`, matching OpenVINO/Hexagon/XDNA). Golden lowering tests.
- **Native**: shared set layout widened to three bindings (slot index = binding index); descriptor pool sized for the widest kernel; per-kernel dispatch geometry and specialization at `load_program`; `submit` stays one fence + one descriptor update.
- **Portability fix**: instance creation requests `VK_KHR_portability_enumeration` with `ENUMERATE_PORTABILITY_KHR` — MoltenVK refuses enumeration otherwise (no-op on conformant drivers).

## Docs (ticket 11)
- README Vulkan row flipped to what tests demonstrate: **Static TOSA 1.0 FP32 IDENTITY + MATMUL**, `Identity + MATMUL` under FP32, direct host/shared/device bindings.
- `docs/performance.md`: Vulkan section with the warm-path shape (descriptor update + `vkQueueSubmit`, fence-poll completion, no worker thread), manual hardware commands per the #75 precedent, the three verified driver stacks, and a deliberate no-timing-claims note until the XDNA-structured warm-latency measurement lands.
- `docs/portability.md` + `docs/architecture.md` claim MATMUL; crate README documents the tier and the verified stacks. Release-policy unsafe-exception entry was registered with ticket 8's FFI.

## Evidence (three driver stacks, one crate, zero per-driver code paths)
- **Intel ANV** (Arc 140V): full backend suite green under `VIRTIO_ACCEL_VULKAN_REQUIRE_DEVICE=1`.
- **Apple M3 via MoltenVK**: full suite green; the shared MATMUL_FP32 oracle matches in every advertised memory domain. Local validation only, never a CI lane.
- **Mesa lavapipe** (`vulkan-lavapipe-test` CI lane): green on this branch (run 33839537450) — the GPU-less lane the map requires.

Debugging trail: the first kernel draft emitted `OpLogicalOr` where the spec table says `OpLogicalAnd` (167) plus an inverted out-of-bounds branch — caught on-device by a focused repro, verified against `spirv-dis`, fixed with And+Not.