### PR TITLE
v0.3.5 release prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ barriers between dependent dispatches. Buffers are dedicated directly bound stor
   tests pass on Mesa lavapipe in CI; on 2026-09-06 on Intel Arc 140V (Lunar Lake, Mesa 26.0.8 ANV,
   Vulkan 1.4.335) and the same host's llvmpipe (LLVM 21.1.8); and on 2026-09-08 on AMD Radeon 860M
   (Krackan Point, RADV Mesa 26.1.8, Vulkan 1.4.354), which also runs clean under Khronos
-  synchronization validation. sin/cos/tanh land within 1 ulp and erf within 2 ulp of binary64 on
+  synchronization validation in every advertised memory domain. sin/cos/tanh land within 1 ulp and
+  erf within 2 ulp of binary64 on
   every one. Apple M3 via MoltenVK has verified only the earlier IDENTITY + MATMUL tier. FP16/INT8
   gating remains under the
   [Vulkan wayfinder map](https://github.com/MicroPerceptron/virtio-accel/issues/154); design

--- a/website/content/index.html
+++ b/website/content/index.html
@@ -637,7 +637,9 @@ footer { padding-block: 44px 52px; }
           device-local memory. Fence status provides nonblocking completion without a worker
           thread.</p>
         <p class="bk-device"><b>Vulkan 1.3 compute devices</b>FP32 operator tier validated on
-          Intel Arc 140V with Mesa ANV and continuously verified on Mesa lavapipe</p>
+          Intel Arc 140V (Mesa ANV), AMD Radeon 860M (RADV), and continuously verified on Mesa
+          lavapipe; Apple M3 via MoltenVK has local-only validation for the earlier IDENTITY + MATMUL
+          tier</p>
         <p class="bk-label">Program dtypes</p>
         <ul class="bk-dtypes">
           <li class="dt on">FP32<span class="sr-only"> supported</span></li>


### PR DESCRIPTION
This pull request updates documentation to clarify and expand details about Vulkan compute device validation and synchronization. The main changes improve the accuracy of tested hardware and validation domains.

**Documentation improvements:**

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L112-R113): Clarifies that synchronization validation now occurs in every advertised memory domain, not just generally, improving the specificity of test coverage.
* [`website/content/index.html`](diffhunk://#diff-b3bae55b4705fc9f846807a1bcb917ef0df1b585f0c786cf93979f849ea45bfdL640-R642): Expands the list of validated Vulkan 1.3 compute devices to include AMD Radeon 860M (RADV) and specifies that Apple M3 via MoltenVK has only local validation for the earlier IDENTITY + MATMUL tier.